### PR TITLE
feat(carte): carte en troisième colonne + un saut ressort par la passerelle d'en face

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# Consignes de travail sur ce dépôt
+
+Le dépôt est en **français** : commentaires, messages de commit, titres de PR, libellés d'interface.
+Une phrase de code doit se lire comme le code autour d'elle.
+
+## Jamais de commit direct sur `main`
+
+Toute modification passe par une **branche** puis une **PR**. `main` est la branche de déploiement :
+un push y déclenche un rebuild complet et un déploiement Pages (`FORCE=1`).
+
+Nommage des branches, comme l'historique : `feat/<sujet-kebab>`, `fix/<sujet-kebab>`,
+`chore/<sujet-kebab>`, `docs/<sujet-kebab>`.
+
+## Commits
+
+Conventional Commits **avec portée**, à l'impératif, en français :
+
+```
+fix(soute): « où écouler » affiche et classe ce que ça RAPPORTE, prix d'achat déduit
+feat(carte): router les sauts par les passerelles, et donner un sens aux jambes
+```
+
+Portées en usage : `carte`, `soute`, `uex`, `manifeste`, `voyage`, `autoload`, `ci`, `data`, `doc`.
+Le sujet dit **ce que ça change pour l'utilisateur**, pas quel fichier a bougé.
+
+## Pull requests
+
+Une PR n'est prête que si **tout** ce qui suit est fait.
+
+### Titre
+Même convention que les commits : `fix(carte): ...`. Pas de « WIP », pas de titre générique.
+
+### Corps
+Quatre sections, dans cet ordre :
+
+1. **Ce que ça change** — en une ou deux phrases, du point de vue de l'utilisateur.
+2. **Pourquoi** — le symptôme observé, ou la décision de conception. Pour un bug : la **cause
+   racine** (`fichier:ligne`), pas seulement le symptôme.
+3. **Vérification** — les commandes lancées **et leur sortie** : `node --test` (compteur de tests),
+   `npx playwright test` (ou le sous-ensemble `-g` pertinent). Jamais « les tests passent » sans le
+   chiffre. Si un test échouait avant le correctif, le dire.
+4. **Ce qui n'est pas couvert** — limites connues, cas laissés de côté.
+
+Terminer par le pied de page maison :
+
+```
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+### Liens vers les issues — obligatoire
+- Un correctif de bug **doit** fermer son issue par un mot-clé GitHub dans le corps de la PR :
+  `Closes #12` (ou `Fixes #12`). Un simple `#12` ne ferme rien.
+- **Vérifier les issues épinglées avant d'ouvrir la PR** (`gh issue list --state open`, les épinglées
+  d'abord) : si le travail touche un bug déjà suivi, on lie l'existante au lieu d'en créer une.
+- Si le bug n'a pas d'issue, en **créer une d'abord** (`gh issue create --label bug`) puis la fermer
+  par la PR. C'est ce qui garde une trace du symptôme, que le message de commit ne porte pas.
+- Une PR qui corrige un bug **sans** issue liée est incomplète.
+
+### Étiquettes — obligatoire
+Poser au moins une étiquette à l'ouverture (`gh pr create --label ...`), sur la PR **et** sur
+l'issue liée. Étiquettes du dépôt : `bug`, `enhancement`, `documentation`, `question`, `duplicate`,
+`invalid`, `wontfix`, `help wanted`, `good first issue`, `ci-failure` (réservée au robot de
+`update-data.yml`). Correspondance : correctif → `bug` ; nouveauté ou reprise d'ergonomie →
+`enhancement` ; README / ADR seuls → `documentation`. Ne pas inventer d'étiquette sans la créer
+explicitement (`gh label create`).
+
+### Avant d'ouvrir
+- `node --test` **et** `npx playwright test` au vert.
+- Un correctif de bug arrive avec un **test qui échouait avant** (TDD : rouge, puis vert).
+- `README.md` mis à jour si le comportement visible change ; un ADR dans `docs/superpowers/specs/`
+  si c'est une décision de conception.
+- Pas de `data/*.json` régénéré dans une PR de code : l'amorce se régénère dans son propre commit
+  `chore(data): ...`.
+
+## Vérification avant toute affirmation
+
+Ne jamais annoncer « corrigé », « ça marche » ou « les tests passent » sans avoir lancé la commande
+et lu sa sortie dans le même tour. Un compteur de tests ou un extrait de sortie accompagne toute
+affirmation de complétude.

--- a/README.md
+++ b/README.md
@@ -192,10 +192,16 @@ n'as pas touché n'est **pas** persisté — la jambe reste branchée sur le mar
 
 ### La carte du parcours
 
-Sous le compagnon, un bandeau pose les arrêts **dans l'espace** : un disque par système traversé,
-le vaisseau sur l'escale courante, et un corridor violet `⚡` quand le parcours change de système.
+À côté du compagnon, une **troisième colonne** pose les arrêts **dans l'espace** : un disque par
+système traversé, le vaisseau sur l'escale courante, et un corridor violet `⚡` quand le parcours
+change de système. Elle ne reste à côté que si elle y garde une largeur lisible (≈ 460 px) —
+en dessous, elle repasse en **bandeau pleine largeur** sur sa propre ligne, ce qui vaut mieux qu'une
+colonne où les libellés d'escale tomberaient sous 5 px.
 Un saut est **routé par les deux passerelles** — on ne change pas de système n'importe où : le
 trajet part de l'escale, rejoint la passerelle d'ici, traverse, puis repart de celle de là-bas.
+Chaque bout se décide **séparément** : partir d'une passerelle ne dispense pas de **ressortir par
+celle d'en face**, parce qu'un saut débouche toujours de l'autre côté du tunnel (`Stanton Gateway
+(Pyro)` → New Babbage passe donc par `Pyro Gateway (Stanton)`).
 Chaque jambe est un **arc orienté** : le chevron dit le sens, et la courbure suit le trajet, si
 bien qu'un aller-retour bombe des deux côtés au lieu de se superposer.
 **Cliquer une escale déplace « je suis ici »**, exactement comme le fil d'étapes textuel — la carte

--- a/app.js
+++ b/app.js
@@ -1936,6 +1936,7 @@ function renderJourney() {
   renderJourneyRecap({ n, totalProfit, totalScu, totalFees, systems: new Set(stations.map((s) => s.system)).size });
   renderJourneyMap();
   renderSoute();
+  ajusterRangeeVoyage(); // après la carte ET la soute : les deux pèsent sur l'équilibre des colonnes
 }
 
 // Récap du voyage (colonne de gauche, sous le vaisseau) : remplit l'espace avec des KPIs utiles.
@@ -1954,14 +1955,22 @@ function renderJourneyRecap({ n, totalProfit, totalScu, totalFees, systems }) {
        ${kpi(systems, "système" + (systems > 1 ? "s" : ""))}
        ${kpi(MARKET ? materials : "…", "matériau" + (materials > 1 ? "x" : ""))}
      </div>`;
-  // Bascule intelligente : si la carte Voyage est bien plus haute que la colonne de gauche
-  // (voyage long / jambe dépliée), on empile en pleine largeur pour supprimer le grand vide.
-  // Mesure synchrone (getBoundingClientRect force le reflow) -> fiable même onglet non peint.
-  const row = $("shipJourneyRow"), jc = $("journeyCard"), vl = $("voyageLeft");
-  if (row && jc && vl && !jc.hidden) {
-    row.classList.remove("stacked"); // mesure toujours dans la disposition côte-à-côte de base
-    if (jc.getBoundingClientRect().height > vl.getBoundingClientRect().height + 140) row.classList.add("stacked");
-  }
+}
+
+// Bascule intelligente : si la carte Voyage est bien plus haute que TOUT ce qui l'accompagne
+// (voyage long / jambe dépliée), on empile en pleine largeur pour supprimer le grand vide.
+// On mesure la plus haute des AUTRES colonnes, pas seulement celle de gauche : depuis que la carte
+// du parcours est la troisième colonne, c'est souvent ELLE qui remplit le vide, et ne regarder
+// qu'à gauche empilait la rangée dès que la colonne du vaisseau était vide.
+// À appeler APRÈS le rendu de la carte : mesurée avant, elle est encore masquée (ou à sa taille du
+// rendu précédent) et la rangée s'empilait sur une hauteur qui n'existait plus.
+// Mesure synchrone (getBoundingClientRect force le reflow) -> fiable même onglet non peint.
+function ajusterRangeeVoyage() {
+  const row = $("shipJourneyRow"), jc = $("journeyCard"), vl = $("voyageLeft"), jm = $("journeyMap");
+  if (!row || !jc || !vl || jc.hidden) return;
+  row.classList.remove("stacked"); // mesure toujours dans la disposition côte-à-côte de base
+  const h = (el) => (el && !el.hidden ? el.getBoundingClientRect().height : 0);
+  if (h(jc) > Math.max(h(vl), h(jm)) + 140) row.classList.add("stacked");
 }
 
 // Bascule entre les vues et rafraîchit la bonne.

--- a/index.html
+++ b/index.html
@@ -153,12 +153,15 @@
           </div>
 
           <aside id="journeyCard" class="journey-card" hidden></aside>
-        </div>
 
-        <!-- Carte 2D du parcours : bandeau pleine largeur sous le compagnon (ADR-001). Purement
-             décorative — absente tant qu'il n'y a pas de voyage, et son échec de chargement ne
-             doit rien casser d'autre. La géométrie vient de data/starmap.json. -->
-        <aside id="journeyMap" class="journey-map" hidden></aside>
+          <!-- Carte 2D du parcours : TROISIÈME COLONNE, à côté du voyage en cours (ADR-001).
+               Elle vivait en bandeau pleine largeur, où le dessin plafonné à 760 px laissait deux
+               bandes vides sur un grand écran. Purement décorative — absente tant qu'il n'y a pas
+               de voyage, et son échec de chargement ne doit rien casser d'autre. La géométrie
+               vient de data/starmap.json. Sous ~1100 px, `flex-wrap` la renvoie sur sa
+               propre ligne : c'est le repli, et il redonne exactement l'ancien bandeau. -->
+          <aside id="journeyMap" class="journey-map" hidden></aside>
+        </div>
 
         <section id="enrouteControls" class="enroute-controls" hidden>
           <div class="field">

--- a/logic.mjs
+++ b/logic.mjs
@@ -1597,15 +1597,19 @@ export function journeyMap(stations, current, starmap, infoTerminal, enVol = fal
   const passerelles = (a, b) => {
     if (a.systeme === b.systeme) return [];
     const nomA = nomPasserelle(a.systeme, b.systeme), nomB = nomPasserelle(b.systeme, a.systeme);
-    // Un parcours qui inclut DÉJÀ les passerelles comme escales ne doit pas être routé deux fois.
-    if (a.nom === nomA || b.nom === nomB) return [];
     const sysA = parSysteme.get(a.systeme), sysB = parSysteme.get(b.systeme);
     const ancreA = (starmap[a.systeme] || {}).ancres || {}, ancreB = (starmap[b.systeme] || {}).ancres || {};
-    if (!sysA || !sysB || !ancreA[nomA] || !ancreB[nomB]) return []; // géométrie absente : ligne droite
-    return [
-      { ...posAncre(sysA, ancreA[nomA]), nom: nomA, systeme: a.systeme, passerelle: true },
-      { ...posAncre(sysB, ancreB[nomB]), nom: nomB, systeme: b.systeme, passerelle: true },
-    ];
+    // Une extrémité qui EST déjà la passerelle de son côté ne se réinsère pas — mais chaque côté se
+    // décide SÉPARÉMENT : partir de la passerelle ne dispense pas de ressortir par celle d'en face,
+    // parce qu'un saut débouche toujours de l'autre côté du tunnel. Les traiter d'un bloc coupait
+    // « Stanton Gateway (Pyro) -> New Babbage » en ligne droite, sans Pyro Gateway (Stanton).
+    const points = [];
+    for (const [ici, sys, ancres, nom] of [[a, sysA, ancreA, nomA], [b, sysB, ancreB, nomB]]) {
+      if (ici.nom === nom) continue;
+      if (!sys || !ancres[nom]) return []; // géométrie absente : ligne droite
+      points.push({ ...posAncre(sys, ancres[nom]), nom, systeme: ici.systeme, passerelle: true });
+    }
+    return points;
   };
 
   // Chaque segment est un ARC, et sa courbure suit le SENS du trajet : l'aller et le retour d'un

--- a/logic.test.mjs
+++ b/logic.test.mjs
@@ -2227,6 +2227,38 @@ test("journeyMap : un parcours qui inclut DÉJÀ les passerelles n'est pas rout�
   assert.deepEqual(c.jambes.map((j) => j.saut), [false, true, false]);
 });
 
+test("journeyMap : partir DE la passerelle route quand même par celle d'EN FACE", () => {
+  // On prend le tunnel là où on est déjà, mais on en ressort forcément de l'autre côté : le trajet
+  // Stanton Gateway (Pyro) -> New Babbage passe par Pyro Gateway (Stanton), il ne coupe pas droit.
+  const c = journeyMap(st("Stanton Gateway (Pyro)", "New Babbage"), 0, STARMAP, infoT);
+  assert.equal(c.jambes.length, 2);
+  assert.deepEqual(c.jambes.map((j) => j.saut), [true, false]); // corridor, puis vol dans Stanton
+  // Le corridor part de l'escale elle-même et débouche dans le disque de Stanton…
+  const stanton = c.systemes.find((s) => s.nom === "Stanton");
+  assert.deepEqual([c.jambes[0].x1, c.jambes[0].y1], [c.arrets[0].x, c.arrets[0].y]);
+  assert.ok(Math.hypot(c.jambes[0].x2 - stanton.cx, c.jambes[0].y2 - stanton.cy) < stanton.r * 1.1);
+  // …exactement là où la seconde jambe reprend, pour finir sur l'arrivée.
+  assert.deepEqual([c.jambes[1].x1, c.jambes[1].y1], [c.jambes[0].x2, c.jambes[0].y2]);
+  assert.deepEqual([c.jambes[1].x2, c.jambes[1].y2], [c.arrets[1].x, c.arrets[1].y]);
+  // La reprise est bien SUR la passerelle d'arrivée, pas au hasard dans le disque.
+  const pg = journeyMap(st("Megumi", "New Babbage"), 0, STARMAP, infoT).jambes[1];
+  assert.deepEqual([c.jambes[1].x1, c.jambes[1].y1], [pg.x2, pg.y2]);
+});
+
+test("journeyMap : arriver À la passerelle route quand même par celle de départ", () => {
+  // Symétrique : New Babbage -> Stanton Gateway (Pyro) traverse d'abord Pyro Gateway (Stanton).
+  const c = journeyMap(st("New Babbage", "Stanton Gateway (Pyro)"), 0, STARMAP, infoT);
+  assert.equal(c.jambes.length, 2);
+  assert.deepEqual(c.jambes.map((j) => j.saut), [false, true]); // vol dans Stanton, puis corridor
+  assert.deepEqual([c.jambes[1].x2, c.jambes[1].y2], [c.arrets[1].x, c.arrets[1].y]);
+});
+
+test("journeyMap : gateway à gateway du même lien reste un seul corridor", () => {
+  const c = journeyMap(st("Stanton Gateway (Pyro)", "Pyro Gateway (Stanton)"), 0, STARMAP, infoT);
+  assert.equal(c.jambes.length, 1);
+  assert.equal(c.jambes[0].saut, true);
+});
+
 test("journeyMap : sans géométrie de passerelle, le saut retombe sur une ligne directe", () => {
   const sansPasserelle = { Pyro: { ancres: { Terminus: STARMAP.Pyro.ancres.Terminus } }, Stanton: STARMAP.Stanton };
   const c = journeyMap(st("Megumi", "New Babbage"), 0, sansPasserelle, infoT);

--- a/style.css
+++ b/style.css
@@ -279,7 +279,11 @@ input::placeholder { color: var(--muted); }
 /* Vaisseau + Voyage côte à côte : colonne de gauche (vaisseau + récap) | carte Voyage à droite.
    align-items: flex-start -> le vaisseau garde sa hauteur naturelle (image jamais étirée). */
 .ship-journey-row { display: flex; flex-wrap: wrap; gap: 14px; align-items: flex-start; margin: 16px 0 0; }
-.voyage-left { display: flex; flex-direction: column; gap: 14px; flex: 0 1 auto; min-width: 240px; max-width: 520px; }
+/* Trois colonnes : vaisseau/récap/soute, le voyage, puis la carte. Seule celle-ci est bornée plus
+   serré qu'avant (520 -> 440), pour laisser de la place à la carte. La carte « Voyage en cours »
+   garde ses 640 px : la rétrécir à 460 empilait son en-tête de jambe sur deux lignes, et le centre
+   de la zone cliquable tombait alors sur le bouton « ✓ chargé » au lieu du dépliement. */
+.voyage-left { display: flex; flex-direction: column; gap: 14px; flex: 0 1 auto; min-width: 240px; max-width: 440px; }
 .voyage-left .ship-card { margin: 0; max-width: none; }
 .journey-card {
   position: relative; margin: 0; flex: 1 1 320px; min-width: 0; max-width: 640px; padding: 12px 16px;
@@ -447,10 +451,17 @@ input.jman-qty { width: 56px; min-width: 0; padding: 3px 5px; text-align: right;
 /* ---------- Carte 2D du parcours (ADR-001) ---------- */
 /* Bandeau pleine largeur sous le compagnon. Tout est dessiné par app.js : aucun asset, aucune
    image. Les couleurs viennent des mêmes variables que le reste — la carte suit donc le thème. */
+/* Troisième colonne de la rangée « voyage ». `flex-basis: 460px` est le seuil : au-dessous, la
+   rangée renvoie la carte à la ligne, où elle retrouve toute la largeur — l'ancien bandeau. C'est
+   voulu. Une colonne de 300 px réduirait le dessin (viewBox 680×296) à 0,44 et ses libellés à ~3,7
+   px : mieux vaut un bandeau lisible qu'une troisième colonne illisible. En pratique la carte tient
+   à côté à partir de ~1700 px de fenêtre, et repasse en bandeau en dessous. */
 .journey-map {
-  position: relative; display: block; margin: 18px 0 0; padding: 14px 16px 10px;
+  position: relative; display: block; margin: 0; padding: 14px 16px 10px;
+  flex: 1 1 460px; min-width: 380px;
   background: var(--panel); border: 1px solid var(--line); border-left: 2px solid var(--acc-2);
 }
+.ship-journey-row.stacked .journey-map { width: 100%; max-width: none; }
 .jm-label {
   display: block; margin-bottom: 8px;
   font-family: var(--mono); font-size: 10px; letter-spacing: 2px; text-transform: uppercase; color: var(--muted);


### PR DESCRIPTION
Trois commits atomiques : un correctif de carte, une reprise d'ergonomie, la documentation.

## Ce que ça change

- **Un saut ressort par la passerelle d'en face.** `Stanton Gateway (Pyro)` → `TDD New Babbage` passe désormais par `Pyro Gateway (Stanton)` au lieu d'être tiré en ligne droite.
- **La carte du parcours devient la troisième colonne**, à côté de « Voyage en cours », au lieu d'un bandeau pleine largeur où le dessin laissait deux bandes vides.
- **`CLAUDE.md`** fixe les conventions de PR du dépôt : issues liées et étiquettes obligatoires.

## Pourquoi

**Le correctif** — cause racine dans `logic.mjs:1601` : le garde-fou « ce parcours contient déjà les passerelles » testait les deux extrémités **d'un bloc** (`a.nom === nomA || b.nom === nomB`). Une seule extrémité qui était déjà sa passerelle suffisait à annuler l'insertion des **deux**. Or on ne se réinsère pas là où on est déjà, mais on ressort toujours de l'autre côté du tunnel : chaque bout se décide donc séparément. Le cas symétrique (arriver **à** une passerelle) avait le même défaut.

**La colonne** — le panneau occupait toute la largeur alors que `.jm-svg` plafonne à 760 px et se centre : sur un écran large, deux bandes vides. Deux effets de bord ont dû être réglés :

- La bascule automatique en pleine largeur se mesurait **avant** le dessin de la carte, donc sur une hauteur périmée, et empilait la rangée à tort. Elle vit maintenant dans `ajusterRangeeVoyage()` (`app.js:1965`), appelée après la carte et la soute, et compare la plus haute des **autres** colonnes.
- Resserrer « Voyage en cours » à 460 px repliait son en-tête de jambe sur deux lignes, et le centre de la zone cliquable tombait alors sur le bouton `✓ chargé` au lieu du dépliement. C'est la colonne de gauche qui cède 80 px à la place.

## Vérification

```
$ node --test
ℹ tests 339
ℹ pass 339
ℹ fail 0

$ npx playwright test
92 passed (46.1s)
```

Trois tests unitaires ajoutés pour le correctif (partir d'une passerelle, arriver à une passerelle, passerelle→passerelle qui doit rester un seul corridor). Les deux premiers **échouaient avant** le correctif — 1 jambe au lieu de 2 :

```
✖ journeyMap : partir DE la passerelle route quand même par celle d'EN FACE
  AssertionError: Expected values to be strictly equal: 1 !== 2
```

Les 7 tests e2e cassés par la version à 460 px sont repassés au vert après restitution des 640 px, et vérifiés au vert sur `main` avant la correction pour établir la référence.

Disposition mesurée sur le rendu réel, pas supposée :

| Fenêtre | Panneau carte | Dessin | Libellé d'escale | Disposition |
|---|---|---|---|---|
| 2560 | 1384 px | 760 px | 9,5 px | 3 colonnes |
| 1920 | 762 px | 727 px | 9,1 px | 3 colonnes |
| 1700 | 652 px | 617 px | 7,7 px | 3 colonnes |
| 1440 | 522 px | 487 px | 6,1 px | 3 colonnes |
| 1100 | 832 px | 760 px | 9,5 px | bandeau (repli) |

## Ce qui n'est pas couvert

- À 1440 px les libellés d'escale tombent à **6,1 px**. C'est lisible mais serré ; le repli en bandeau ne se déclenche qu'en dessous de ~460 px de place disponible pour la carte.
- Aucun test e2e ne verrouille la disposition en trois colonnes : les mesures ci-dessus viennent d'un script jeté après lecture. Un test qui figerait des largeurs casserait au moindre ajustement de gabarit.
- La bascule `stacked` reste une mesure impérative en JS. Une requête de conteneur CSS ferait le même travail de façon déclarative, mais c'est une refonte du gabarit, hors sujet ici.

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzcSQP1VNwreuXGSs9hUHr
