### PR TITLE
ci: mettre en cache le navigateur Playwright et le registre npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,18 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: 20
+          # Cache du registre npm (~/.npm), clé sur package-lock.json. Le job `unit` n'installe
+          # rien — il lance `node --test` sur des modules sans dépendance — donc il n'en a pas besoin.
+          cache: npm
+      # Le navigateur pèse plus lourd que les dépendances : sans cache, chaque run le retélécharge
+      # et le job passait ~3 min. La clé porte le lockfile, donc un bump de Playwright invalide le
+      # cache — un binaire d'une autre version ne peut pas être servi à la place.
+      - name: Cache du navigateur Playwright
+        id: playwright-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
       # `npm install` ne vérifie pas que package-lock.json est en phase avec package.json : quand il
       # ne l'est plus — un bump de plage oublié dans une PR, par exemple — il résout un arbre neuf,
       # ignore les hashes d'intégrité verrouillés et réécrit le lock dans le runner, en exécutant au
@@ -43,8 +55,15 @@ jobs:
       # le badge CI atteste d'un arbre que rien n'a validé. `npm ci` échoue bruyamment à la place.
       - name: Installer les dépendances de test
         run: npm ci --no-audit --no-fund
-      - name: Installer le navigateur Playwright
+      # Deux étapes exclusives, et non une seule avec `--with-deps` : le cache ne porte QUE le
+      # binaire du navigateur (~/.cache/ms-playwright). Les paquets système dont Chromium dépend
+      # vivent dans l'image du runner, hors du cache, et manqueraient donc sur un succès de cache.
+      - name: Installer le navigateur Playwright (cache manqué)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+      - name: Installer les dépendances système du navigateur (cache touché)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
       - name: Tests E2E de fumée
         run: npx playwright test
 

--- a/scripts/workflows.test.mjs
+++ b/scripts/workflows.test.mjs
@@ -36,6 +36,25 @@ test("ci.yml : l'installation est verrouillée sur le lockfile", () => {
   assert.match(runs, /\bnpm ci\b/);
 });
 
+test("ci.yml : le navigateur est mis en cache, et les deux installations sont EXCLUSIVES", () => {
+  // Le cache ne porte que le binaire du navigateur. Les paquets système dont Chromium dépend vivent
+  // dans l'image du runner, hors du cache : sur un succès de cache il faut donc encore les poser.
+  // Une seule étape `install --with-deps` conditionnée au cache manqué laisserait un runner sans ces
+  // paquets, et l'échec serait un crash de navigateur — pas un message d'installation manquante.
+  const e2e = jobs(lire("ci.yml")).e2e;
+  assert.match(e2e, /uses: actions\/cache@[0-9a-f]{40}\s+# v\d/, "cache épinglé par SHA");
+  assert.match(e2e, /path: ~\/\.cache\/ms-playwright/);
+  assert.match(e2e, /key: .*hashFiles\('package-lock\.json'\)/, "la clé porte le lockfile");
+  assert.match(e2e, /cache: npm/, "le registre npm est mis en cache lui aussi");
+  // Exclusivité : exactement une étape par branche du cache, et jamais les deux ensemble.
+  const manque = e2e.match(/cache-hit != 'true'/g) || [];
+  const touche = e2e.match(/cache-hit == 'true'/g) || [];
+  assert.equal(manque.length, 1, "une seule étape sur cache manqué");
+  assert.equal(touche.length, 1, "une seule étape sur cache touché");
+  assert.match(e2e, /cache-hit != 'true'\n\s+run: npx playwright install --with-deps chromium/);
+  assert.match(e2e, /cache-hit == 'true'\n\s+run: npx playwright install-deps chromium/);
+});
+
 test("update-data.yml : les permissions du GITHUB_TOKEN sont scopées par job", () => {
   const y = lire("update-data.yml");
   const g = permissionsGlobales(y);


### PR DESCRIPTION
## Ce que ça change

Le job `e2e` met en cache le navigateur Chromium (`~/.cache/ms-playwright`) et le registre npm. Le job `unit` n'installe rien — il lance `node --test` sur des modules sans dépendance — donc il reste tel quel.

## Pourquoi

Le job `e2e` retéléchargeait le navigateur à chaque run. Mesuré sur la PR #3, dernier run avant ce changement :

| Job | Durée |
|---|---|
| `unit` | 11 s |
| `e2e` | **3 min 16 s** |

Trois décisions valent d'être expliquées :

- **La clé porte `package-lock.json`.** Un bump de Playwright invalide donc le cache : un binaire de navigateur d'une autre version ne peut pas être servi à la place de celui qu'attend la bibliothèque.
- **L'installation devient DEUX étapes exclusives**, et non une seule conditionnée au cache manqué. Le cache ne porte que le binaire ; les paquets système dont Chromium dépend vivent dans l'image du runner, hors du cache, et manqueraient sur un succès de cache. D'où `install --with-deps` quand le cache manque et `install-deps` quand il est touché. Le piège est vicieux : sans la seconde étape, l'échec ne serait pas un message d'installation manquante mais un crash de navigateur.
- **L'action est épinglée par SHA** (`actions/cache@0057852` = v4), comme les trois autres actions du dépôt. Le SHA a été résolu via l'API GitHub, pas recopié de mémoire.

## Vérification

Un test verrouille l'invariant — une régression ici laisserait la CI verte, donc rien ne la signalerait :

```
$ node --test
ℹ tests 340
ℹ pass 340
ℹ fail 0
```

Le nouveau test a été **vu rouge** contre l'ancien `ci.yml` avant d'être vert sur le nouveau :

```
✖ ci.yml : le navigateur est mis en cache, et les deux installations sont EXCLUSIVES
  AssertionError [ERR_ASSERTION]: cache épinglé par SHA
```

Le gain réel se lira sur le **deuxième** run de cette PR : le premier remplit le cache et ne peut rien accélérer.

## Ce qui n'est pas couvert

- Aucune mesure de l'après pour l'instant, par construction — le premier run est un cache manqué. À comparer sur le run suivant.
- Le cache n'est pas partagé entre branches divergentes : une PR qui bump Playwright repaiera un téléchargement complet, une fois.
- Rien n'expire ces entrées à la main ; on s'en remet à l'éviction de GitHub (7 jours sans accès, 10 Go par dépôt). Le dépôt n'a qu'une dépendance, on est très loin du plafond.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzcSQP1VNwreuXGSs9hUHr