### PR TITLE
feat(corrections): un volume corrigé périme au bout de 3 h

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,18 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: 20
+          # Cache du registre npm (~/.npm), clé sur package-lock.json. Le job `unit` n'installe
+          # rien — il lance `node --test` sur des modules sans dépendance — donc il n'en a pas besoin.
+          cache: npm
+      # Le navigateur pèse plus lourd que les dépendances : sans cache, chaque run le retélécharge
+      # et le job passait ~3 min. La clé porte le lockfile, donc un bump de Playwright invalide le
+      # cache — un binaire d'une autre version ne peut pas être servi à la place.
+      - name: Cache du navigateur Playwright
+        id: playwright-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
       # `npm install` ne vérifie pas que package-lock.json est en phase avec package.json : quand il
       # ne l'est plus — un bump de plage oublié dans une PR, par exemple — il résout un arbre neuf,
       # ignore les hashes d'intégrité verrouillés et réécrit le lock dans le runner, en exécutant au
@@ -43,8 +55,15 @@ jobs:
       # le badge CI atteste d'un arbre que rien n'a validé. `npm ci` échoue bruyamment à la place.
       - name: Installer les dépendances de test
         run: npm ci --no-audit --no-fund
-      - name: Installer le navigateur Playwright
+      # Deux étapes exclusives, et non une seule avec `--with-deps` : le cache ne porte QUE le
+      # binaire du navigateur (~/.cache/ms-playwright). Les paquets système dont Chromium dépend
+      # vivent dans l'image du runner, hors du cache, et manqueraient donc sur un succès de cache.
+      - name: Installer le navigateur Playwright (cache manqué)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+      - name: Installer les dépendances système du navigateur (cache touché)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
       - name: Tests E2E de fumée
         run: npx playwright test
 

--- a/README.md
+++ b/README.md
@@ -305,7 +305,31 @@ jamais partagé ni mis dans l'URL) et **intelligent** :
 
 - Une correction est **ancrée** à la date UEX du point au moment où tu la fais.
 - Elle est **périmée automatiquement** dès qu'UEX republie ce point avec un relevé plus récent (retour à la valeur UEX, petit flash de notification).
+- Un **volume** (stock, demande, et la déduction d'un `✓ chargé`) périme **aussi au bout de 3 h**, même si UEX n'a rien republié. Un **prix**, non : les deux ne vieillissent pas pareil, [voir plus bas](#pourquoi-un-volume-périme-en-3-h-et-pas-un-prix).
 - Sémantique respectée : un **stock d'achat à 0 = terminal vide** (plafonne à 0), et une **demande que _tu_ corriges fait autorité** — y compris un 0, qui vaut « pas de demande » et plafonne à 0 même là où UEX ne renseignait rien. Les valeurs UEX brutes, elles, gardent leur sémantique propre (`null` = capacité inconnue, `0` = terminal saturé) : [voir le piège des volumes UEX](#sémantique-des-volumes-uex-piège).
+
+### Pourquoi un volume périme en 3 h, et pas un prix
+
+Un volume est une quantité qui **repousse**. Le jeu réapprovisionne un comptoir par paliers de l'ordre
+de 5 à 15 min, alors qu'**UEX ne republie un point que tous les 3,1 jours en médiane** — mesuré sur les
+2 592 relevés de `commodities_prices_all` ; seuls **29,9 %** des points ont un relevé de moins de 24 h.
+Attendre UEX, c'est donc annoncer un stock à zéro pendant des jours alors qu'il est revenu en moins
+d'une heure : un facteur ~70 entre les deux horizons. Un prix faux, lui, ne se régénère pas — rien ne
+justifie de l'oublier au bout de trois heures.
+
+**Les 3 h ne sont pas une mesure**, et aucune ne peut les fonder : depuis le patch **3.20** les
+inventaires de boutique ont quitté les fichiers du jeu, plus aucun outil ne peut les dataminer, et
+aucun site ne publie de débit de recharge par terminal. Les deux seuls chiffres qui circulent ne
+survivent pas à la confrontation avec UEX — les 15 points de vente de Quantainium y rapportent tous
+`scu_sell = 0`, et les 50 000 SCU annoncés à TDD Area 18 dépassent le 99ᵉ centile des capacités
+publiées (médiane 539 SCU). C'est pourquoi l'app ne tente **aucune** remontée progressive du stock :
+elle se contente de dire qu'au-delà de trois heures, ta valeur ne vaut plus rien. La durée vit dans
+`DUREE_VOL` (`logic.mjs`) et se passe en paramètre — elle n'a pas encore de réglage à l'écran.
+
+Contrepartie assumée : sur trois heures un comptoir vidé a très probablement déjà tout récupéré, donc
+l'app reste trop pessimiste pendant une partie du délai. En échange, une correction survit à une
+session de jeu entière. Le raisonnement complet est dans
+[la spec](docs/superpowers/specs/2026-08-12-peremption-des-volumes-et-corrections-groupees-design.md).
 
 ## Frais d'autoload
 

--- a/app.js
+++ b/app.js
@@ -5,7 +5,7 @@ import {
   tripMinutes, ageDays, pairAge,
   normalizeScores, bySort, addableUnits, scuBoxes, cargoBoxes, bestChain,
   AUTOLOAD, autoloadFee, autoloadPoint, haulFee, lineHaulFee,
-  ovKey, effFromStore, setInStore, safeKey, encodeState, decodeState,
+  ovKey, effFromStore, setInStore, DUREE_VOL, safeKey, encodeState, decodeState,
   routePasses, loopPasses,
   routeMetrics, loopMetrics, enRouteDeals, bestManifest, buildChainAdjacency, suggestionsFrom, netMarginRoi,
   commoditySummaries, commodityPoints, compactValue, valueTiers, resolveCommodity, ambiguousCodes,
@@ -166,7 +166,8 @@ const OV_KEY = "best-hauling-overrides";
 // base = date UEX (updated) du point AU MOMENT de la correction : la correction vaut
 // « contre cet export ». Elle n'est périmée que si UEX republie ce point plus récemment.
 let OVERRIDES = {};
-let supersededKeys = new Set(); // corrections périmées pendant le rendu courant (pour le flash)
+let supersededKeys = new Set(); // corrections périmées par UEX pendant le rendu courant (pour le flash)
+let expiredVolKeys = new Set(); // volumes périmés par l'ÂGE pendant le rendu courant (autre cause, autre message)
 
 const nowSec = () => Math.floor(Date.now() / 1000);
 
@@ -185,7 +186,10 @@ const ovCount = () => Object.keys(OVERRIDES).length; // ovKey vient de logic.mjs
 function effVals(commodity, terminal, side, price, vol, dataUpdated) {
   const k = ovKey(commodity, terminal, side);
   const r = effFromStore(OVERRIDES, k, price, vol, dataUpdated); // décision + suppression périmée (logic.mjs)
-  if (r.stale) { saveOverrides(); supersededKeys.add(k); } // effets de bord app : persistance + flash
+  // effets de bord app : persistance + flash. `staleVol` est l'autre cause — le volume a dépassé sa
+  // durée de vie (DUREE_VOL) et le prix, s'il y en avait un, est resté.
+  if (r.stale) { saveOverrides(); supersededKeys.add(k); }
+  else if (r.staleVol) { saveOverrides(); expiredVolKeys.add(k); }
   return r;
 }
 
@@ -344,12 +348,23 @@ function showToast(msg) {
   clearTimeout(toastTimer);
   toastTimer = setTimeout(() => el.classList.remove("show"), 4500);
 }
+// DEUX causes de péremption, donc deux messages : dire « mise à jour UEX » à propos d'un volume qui a
+// simplement vieilli serait faux, et enverrait chercher un changement de données qui n'a pas eu lieu.
+// Si les deux tombent dans le même rendu, la mise à jour UEX passe en premier — c'est un fait
+// extérieur, l'autre est une simple horloge.
 function notifySuperseded() {
-  if (!supersededKeys.size) return;
-  const n = supersededKeys.size;
+  const nUex = supersededKeys.size, nAge = expiredVolKeys.size;
+  if (!nUex && !nAge) return;
   supersededKeys = new Set();
+  expiredVolKeys = new Set();
   updateOvBadge();
-  showToast(`✎ ${n} correction${n > 1 ? "s" : ""} périmée${n > 1 ? "s" : ""} par une mise à jour UEX`);
+  const s = (n) => (n > 1 ? "s" : "");
+  if (nUex) showToast(`✎ ${nUex} correction${s(nUex)} périmée${s(nUex)} par une mise à jour UEX`);
+  if (nAge) {
+    const h = Math.round(DUREE_VOL / 3600);
+    const msg = `✎ ${nAge} volume${s(nAge)} corrigé${s(nAge)} périmé${s(nAge)} — plus de ${h} h, le comptoir s'est rempli depuis`;
+    if (nUex) setTimeout(() => showToast(msg), 1200); else showToast(msg);
+  }
 }
 
 // Applique les corrections à une paire buy/sell et renvoie des copies patchées + marge/roi.

--- a/logic.mjs
+++ b/logic.mjs
@@ -197,20 +197,40 @@ export function netMarginRoi(margin, buyPrice, units, fees) {
 }
 
 // ---------- Corrections locales : décision de fraîcheur (pure, sans effet de bord) ----------
-// o = correction { price?, vol?, base } (base = date UEX du point au moment de la correction).
-// Renvoie prix/volume effectifs + drapeaux + `stale` (true = périmée par un relevé plus récent).
-export function effValue(o, price, vol, dataUpdated) {
-  if (!o) return { price, vol, oprice: false, ovol: false, stale: false };
+// Durée de validité d'un VOLUME corrigé. Un stock et une demande sont des quantités qui REPOUSSENT :
+// le jeu réapprovisionne par paliers de 5 à 15 min, quand UEX ne republie un point que tous les
+// 3,1 jours en médiane (mesuré sur 2 592 relevés). Sans cette borne, la déduction d'un chargement
+// survivait des JOURS à un stock déjà revenu — un facteur ~70 entre les deux horizons. Un prix, lui,
+// n'a pas de durée de vie : rien ne régénère un prix faux, il reste faux.
+// Ce n'est PAS une mesure, et aucune ne peut la fonder : depuis le patch 3.20 les inventaires de
+// boutique ont quitté les fichiers du jeu, et aucun site ne publie de débit de recharge par terminal
+// (cf. docs/superpowers/specs/2026-08-12-peremption-des-volumes-et-corrections-groupees-design.md).
+export const DUREE_VOL = 3 * 3600;
+
+// o = correction { price?, vol?, base, pris? } — `base` = date UEX du point au moment de la
+// correction, `pris` = heure MURALE de la saisie du volume.
+// Renvoie prix/volume effectifs + drapeaux, et DEUX péremptions distinctes :
+//   `stale`    = UEX a republié le point -> toute la correction est morte ;
+//   `staleVol` = le volume a dépassé sa durée de vie -> lui seul est mort, le prix survit.
+// Deux drapeaux et non un objet : `stale` garde exactement son sens d'avant, donc un lecteur qu'on
+// aurait oublié de mettre à jour perd la nouveauté au lieu de lire un objet toujours vrai.
+export function effValue(o, price, vol, dataUpdated, nowSec = Date.now() / 1000, dureeVol = DUREE_VOL) {
+  if (!o) return { price, vol, oprice: false, ovol: false, stale: false, staleVol: false };
   const base = o.base != null ? o.base : o.ts != null ? o.ts : Infinity; // legacy: ts ; sinon jamais périmé
   if (dataUpdated && base !== Infinity && dataUpdated > base) {
-    return { price, vol, oprice: false, ovol: false, stale: true };
+    return { price, vol, oprice: false, ovol: false, stale: true, staleVol: false };
   }
+  // `pris` absent = correction d'un format antérieur : pas de péremption par durée, sinon toutes
+  // celles déjà en localStorage disparaîtraient au premier chargement. La frontière appartient à la
+  // correction (`> dureeVol`, pas `>=`), même convention que `base == relevé` juste au-dessus.
+  const staleVol = o.vol != null && o.pris != null && nowSec - o.pris > dureeVol;
   return {
     price: o.price != null ? o.price : price,
-    vol: o.vol != null ? o.vol : vol,
+    vol: o.vol != null && !staleVol ? o.vol : vol,
     oprice: o.price != null,
-    ovol: o.vol != null,
+    ovol: o.vol != null && !staleVol,
     stale: false,
+    staleVol,
   };
 }
 
@@ -520,21 +540,36 @@ export function addableUnits(it, rem) {
 // Le store est un objet { "commodité|terminal|side": { price?, vol?, base } }.
 export const ovKey = (commodity, terminal, side) => `${commodity}|${terminal}|${side}`;
 
-// Valeur effective (corrigée si besoin) + suppression de la correction périmée du store.
-// Renvoie { price, vol, oprice, ovol, stale }. Seul effet de bord : delete store[key] si périmé.
-export function effFromStore(store, key, price, vol, dataUpdated) {
-  const r = effValue(store[key], price, vol, dataUpdated);
+// Valeur effective (corrigée si besoin) + retrait de ce qui est périmé.
+// Renvoie { price, vol, oprice, ovol, stale, staleVol }. Effets de bord, et rien d'autre :
+//   UEX a republié -> la clé entière part ; le volume a vieilli -> lui seul part, et la clé avec
+//   s'il ne restait que lui.
+export function effFromStore(store, key, price, vol, dataUpdated, nowSec = Date.now() / 1000, dureeVol = DUREE_VOL) {
+  const r = effValue(store[key], price, vol, dataUpdated, nowSec, dureeVol);
   if (r.stale) delete store[key];
+  else if (r.staleVol) {
+    const o = store[key];
+    delete o.vol;
+    delete o.pris;
+    if (o.price == null) delete store[key];
+  }
   return r;
 }
 
 // Enregistre/efface une correction. field = "price"|"vol". value null/"" efface ce champ.
 // baseUpdated = date UEX du point (ancre de fraîcheur). Supprime la clé si plus rien de corrigé.
-export function setInStore(store, key, field, value, baseUpdated) {
+export function setInStore(store, key, field, value, baseUpdated, nowSec = Date.now() / 1000) {
   const o = store[key] || {};
   const n = value == null || value === "" ? NaN : Math.max(0, Math.round(Number(value)));
   if (Number.isFinite(n)) o[field] = n;
   else delete o[field];
+  // `pris` n'existe que pour un volume : lui seul a une durée de vie. Nom volontairement distinct de
+  // `ts`, que effValue lit encore comme alias historique de `base` — les confondre périmerait les
+  // corrections d'anciens formats au lieu de les épargner.
+  if (field === "vol") {
+    if (Number.isFinite(n)) o.pris = Number(nowSec) || 0;
+    else delete o.pris;
+  }
   if (o.price != null || o.vol != null) { o.base = Number(baseUpdated) || 0; store[key] = o; }
   else delete store[key];
   return store;

--- a/logic.test.mjs
+++ b/logic.test.mjs
@@ -278,7 +278,7 @@ test("computeUnits : prend la plus petite contrainte (soute vs budget)", () => {
 
 // ---------- effValue (corrections locales + fraîcheur) ----------
 test("effValue : pas de correction -> valeurs brutes", () => {
-  assert.deepEqual(effValue(undefined, 100, 50, 123), { price: 100, vol: 50, oprice: false, ovol: false, stale: false });
+  assert.deepEqual(effValue(undefined, 100, 50, 123), { price: 100, vol: 50, oprice: false, ovol: false, stale: false, staleVol: false });
 });
 
 test("effValue : correction appliquée si plus récente que le relevé", () => {
@@ -303,6 +303,69 @@ test("effValue : base == relevé n'est PAS périmé (correction fraîche contre 
   assert.equal(r.stale, false);
   assert.equal(r.vol, 5);
   assert.equal(r.ovol, true);
+});
+
+// ---------- Péremption par DURÉE des volumes corrigés (spec 2026-08-12) ----------
+// Un volume est une quantité qui repousse : le jeu réapprovisionne par paliers de 5 à 15 min, alors
+// qu'UEX ne republie un point que tous les 3,1 jours en médiane. Une déduction de chargement
+// survivait donc des jours à un stock déjà revenu. Un PRIX, lui, ne se régénère pas : il garde le
+// comportement d'avant. La péremption par durée est donc par CHAMP.
+const MAINTENANT = 1_700_000_000;
+const IL_Y_A = (s) => MAINTENANT - s;
+
+test("effValue : un volume corrigé depuis plus de 3 h revient à la valeur UEX", () => {
+  const o = { vol: 12, base: 1000, pris: IL_Y_A(3 * 3600 + 1) };
+  const r = effValue(o, 100, 500, 900, MAINTENANT);
+  assert.equal(r.vol, 500);        // retour au stock UEX
+  assert.equal(r.ovol, false);
+  assert.equal(r.staleVol, true);
+  assert.equal(r.stale, false);    // ce n'est pas UEX qui l'a périmée
+});
+
+test("effValue : un volume corrigé depuis moins de 3 h s'applique", () => {
+  const r = effValue({ vol: 12, base: 1000, pris: IL_Y_A(2 * 3600) }, 100, 500, 900, MAINTENANT);
+  assert.equal(r.vol, 12);
+  assert.equal(r.ovol, true);
+  assert.equal(r.staleVol, false);
+});
+
+test("effValue : à 3 h PILE le volume n'est pas encore périmé", () => {
+  // Même convention que `base == relevé` : la frontière appartient à la correction.
+  const r = effValue({ vol: 12, base: 1000, pris: IL_Y_A(3 * 3600) }, 100, 500, 900, MAINTENANT);
+  assert.equal(r.staleVol, false);
+  assert.equal(r.vol, 12);
+});
+
+test("effValue : le PRIX survit à la péremption du volume", () => {
+  // C'est tout l'intérêt d'une péremption par champ : rien ne régénère un prix faux.
+  const o = { price: 7000, vol: 12, base: 1000, pris: IL_Y_A(4 * 3600) };
+  const r = effValue(o, 100, 500, 900, MAINTENANT);
+  assert.equal(r.price, 7000);
+  assert.equal(r.oprice, true);
+  assert.equal(r.vol, 500);
+  assert.equal(r.ovol, false);
+});
+
+test("effValue : sans `pris` (corrections déjà en localStorage), aucune péremption par durée", () => {
+  // Sinon toutes les corrections existantes disparaîtraient au premier chargement de la nouvelle
+  // version. Elles s'aligneront à la prochaine saisie.
+  const r = effValue({ vol: 12, base: 1000 }, 100, 500, 900, MAINTENANT);
+  assert.equal(r.staleVol, false);
+  assert.equal(r.vol, 12);
+});
+
+test("effValue : un relevé UEX plus récent périme TOUT, même un volume de deux minutes", () => {
+  const o = { price: 7000, vol: 12, base: 1000, pris: IL_Y_A(120) };
+  const r = effValue(o, 100, 500, 1500, MAINTENANT);
+  assert.equal(r.stale, true);
+  assert.equal(r.price, 100);
+  assert.equal(r.vol, 500);
+});
+
+test("effValue : la durée est réglable", () => {
+  const o = { vol: 12, base: 1000, pris: IL_Y_A(3600) };
+  assert.equal(effValue(o, 100, 500, 900, MAINTENANT, 30 * 60).staleVol, true);  // 30 min
+  assert.equal(effValue(o, 100, 500, 900, MAINTENANT, 6 * 3600).staleVol, false); // 6 h
 });
 
 test("effValue : compat ascendante — legacy ts, et sans date jamais périmé", () => {
@@ -633,14 +696,16 @@ test("ovKey : clé stable commodité|terminal|side", () => {
 });
 
 test("setInStore : enregistre prix + base, efface un champ, supprime la clé si vide", () => {
+  // Horloge passée explicitement : un volume enregistre son heure de saisie (`pris`), qui serait
+  // sinon celle du run et rendrait la comparaison non déterministe.
   const store = {};
-  setInStore(store, "A|T|buy", "price", "7000", 111);
-  assert.deepEqual(store["A|T|buy"], { price: 7000, base: 111 }); // valeur arrondie + base
-  setInStore(store, "A|T|buy", "vol", 50, 222);
-  assert.deepEqual(store["A|T|buy"], { price: 7000, vol: 50, base: 222 });
-  setInStore(store, "A|T|buy", "price", "", 222); // efface le prix
-  assert.deepEqual(store["A|T|buy"], { vol: 50, base: 222 });
-  setInStore(store, "A|T|buy", "vol", null, 222);  // plus rien -> clé supprimée
+  setInStore(store, "A|T|buy", "price", "7000", 111, MAINTENANT);
+  assert.deepEqual(store["A|T|buy"], { price: 7000, base: 111 }); // valeur arrondie + base, pas de `pris`
+  setInStore(store, "A|T|buy", "vol", 50, 222, MAINTENANT);
+  assert.deepEqual(store["A|T|buy"], { price: 7000, vol: 50, base: 222, pris: MAINTENANT });
+  setInStore(store, "A|T|buy", "price", "", 222, MAINTENANT); // efface le prix
+  assert.deepEqual(store["A|T|buy"], { vol: 50, base: 222, pris: MAINTENANT });
+  setInStore(store, "A|T|buy", "vol", null, 222, MAINTENANT);  // plus rien -> clé supprimée
   assert.equal("A|T|buy" in store, false);
 });
 
@@ -654,7 +719,7 @@ test("setInStore : borne à >= 0 et arrondit", () => {
 
 test("effFromStore : valeur brute si pas de correction", () => {
   const store = {};
-  assert.deepEqual(effFromStore(store, "k", 100, 50, 123), { price: 100, vol: 50, oprice: false, ovol: false, stale: false });
+  assert.deepEqual(effFromStore(store, "k", 100, 50, 123), { price: 100, vol: 50, oprice: false, ovol: false, stale: false, staleVol: false });
 });
 
 test("effFromStore : applique la correction plus récente que le relevé", () => {
@@ -671,6 +736,37 @@ test("effFromStore : SUPPRIME du store la correction périmée par un relevé pl
   assert.equal(r.stale, true);
   assert.equal(r.price, 100);          // retour à la valeur UEX
   assert.equal("k" in store, false);   // effet de bord : périmée -> supprimée
+});
+
+test("setInStore : un volume enregistre l'heure de saisie, un prix non", () => {
+  const store = {};
+  setInStore(store, "A|T|buy", "vol", 12, 111, MAINTENANT);
+  assert.equal(store["A|T|buy"].pris, MAINTENANT);
+  const store2 = {};
+  setInStore(store2, "A|T|buy", "price", 7000, 111, MAINTENANT);
+  assert.equal("pris" in store2["A|T|buy"], false); // un prix n'a pas de durée de vie
+});
+
+test("setInStore : effacer le volume retire aussi son heure de saisie", () => {
+  const store = {};
+  setInStore(store, "k", "vol", 12, 111, MAINTENANT);
+  setInStore(store, "k", "price", 7000, 111, MAINTENANT);
+  setInStore(store, "k", "vol", null, 111, MAINTENANT);
+  assert.deepEqual(store.k, { price: 7000, base: 111 }); // ni vol, ni pris
+});
+
+test("effFromStore : le volume périmé quitte le store, le prix y reste", () => {
+  const store = { k: { price: 7000, vol: 12, base: 1000, pris: IL_Y_A(4 * 3600) } };
+  const r = effFromStore(store, "k", 100, 500, 900, MAINTENANT);
+  assert.equal(r.price, 7000);
+  assert.equal(r.vol, 500);
+  assert.deepEqual(store.k, { price: 7000, base: 1000 }); // le volume et son heure sont partis
+});
+
+test("effFromStore : un volume périmé seul fait disparaître la clé", () => {
+  const store = { k: { vol: 12, base: 1000, pris: IL_Y_A(4 * 3600) } };
+  effFromStore(store, "k", 100, 500, 900, MAINTENANT);
+  assert.equal("k" in store, false);
 });
 
 // ---------- safeKey / encodeState / decodeState (persistance) ----------

--- a/scripts/workflows.test.mjs
+++ b/scripts/workflows.test.mjs
@@ -36,6 +36,25 @@ test("ci.yml : l'installation est verrouillée sur le lockfile", () => {
   assert.match(runs, /\bnpm ci\b/);
 });
 
+test("ci.yml : le navigateur est mis en cache, et les deux installations sont EXCLUSIVES", () => {
+  // Le cache ne porte que le binaire du navigateur. Les paquets système dont Chromium dépend vivent
+  // dans l'image du runner, hors du cache : sur un succès de cache il faut donc encore les poser.
+  // Une seule étape `install --with-deps` conditionnée au cache manqué laisserait un runner sans ces
+  // paquets, et l'échec serait un crash de navigateur — pas un message d'installation manquante.
+  const e2e = jobs(lire("ci.yml")).e2e;
+  assert.match(e2e, /uses: actions\/cache@[0-9a-f]{40}\s+# v\d/, "cache épinglé par SHA");
+  assert.match(e2e, /path: ~\/\.cache\/ms-playwright/);
+  assert.match(e2e, /key: .*hashFiles\('package-lock\.json'\)/, "la clé porte le lockfile");
+  assert.match(e2e, /cache: npm/, "le registre npm est mis en cache lui aussi");
+  // Exclusivité : exactement une étape par branche du cache, et jamais les deux ensemble.
+  const manque = e2e.match(/cache-hit != 'true'/g) || [];
+  const touche = e2e.match(/cache-hit == 'true'/g) || [];
+  assert.equal(manque.length, 1, "une seule étape sur cache manqué");
+  assert.equal(touche.length, 1, "une seule étape sur cache touché");
+  assert.match(e2e, /cache-hit != 'true'\n\s+run: npx playwright install --with-deps chromium/);
+  assert.match(e2e, /cache-hit == 'true'\n\s+run: npx playwright install-deps chromium/);
+});
+
 test("update-data.yml : les permissions du GITHUB_TOKEN sont scopées par job", () => {
   const y = lire("update-data.yml");
   const g = permissionsGlobales(y);


### PR DESCRIPTION
Implémente la **partie 1** de la spec ([#4](https://github.com/0xKestrelNova/best-hauling/pull/4)), périmètre resserré à la règle de durée. La déduction de demande à la vente et la partie « vue Corrections » de la spec ne sont **pas** dans cette PR.

## Ce que ça change

Un **volume** corrigé — stock à l'achat, demande à la vente, déduction d'un `✓ chargé` — revient à la valeur UEX au bout de **3 h**, même si UEX n'a rien republié. Un **prix** garde exactement le comportement d'avant. La péremption devient donc **par champ** : une clé qui porte les deux perd son volume et garde son prix.

## Pourquoi

Un volume est une quantité qui repousse ; un prix faux ne se régénère pas. Mesuré sur les 2 592 relevés de `commodities_prices_all` :

| | p10 | p25 | **médiane** | p75 | p90 |
|---|---|---|---|---|---|
| âge du dernier relevé UEX | 3,8 h | 20 h | **3,1 j** | 6,6 j | 8,0 j |

Seuls **29,9 %** des points ont un relevé de moins de 24 h. Le jeu, lui, réapprovisionne par paliers de 5 à 15 min. Attendre UEX, c'était annoncer un stock à zéro **des jours** après son retour — facteur ~70.

Deux décisions valent d'être expliquées :

- **Deux drapeaux, pas un objet.** La spec proposait de transformer `stale` en `{ price, vol }`. J'ai préféré garder `stale` avec son sens exact d'avant et ajouter `staleVol`. Un objet aurait rendu `if (r.stale)` toujours vrai chez ses deux lecteurs (`effFromStore`, `effVals`) : un lecteur oublié aurait silencieusement effacé des corrections au lieu de simplement rater la nouveauté. **Écart assumé par rapport à la spec**, à corriger dans la spec si tu le valides.
- **`pris` et non `ts`.** `effValue` lit encore `ts` comme alias historique de `base` : réutiliser ce nom aurait périmé les corrections d'anciens formats au lieu de les épargner.

## Vérification

```
$ node --test
ℹ tests 351
ℹ pass 351
ℹ fail 0

$ npx playwright test
92 passed (48.1s)
```

Neuf tests écrits **avant** le code et vus rouges pour la bonne raison (fonctionnalité absente), puis verts :

```
✖ effValue : un volume corrigé depuis plus de 3 h revient à la valeur UEX
✖ effValue : à 3 h PILE le volume n'est pas encore périmé
✖ effValue : le PRIX survit à la péremption du volume
✖ effValue : sans `pris` (corrections déjà en localStorage), aucune péremption par durée
✖ effValue : un relevé UEX plus récent périme TOUT, même un volume de deux minutes
✖ effValue : la durée est réglable
✖ setInStore : un volume enregistre l'heure de saisie, un prix non
✖ effFromStore : le volume périmé quitte le store, le prix y reste
✖ effFromStore : un volume périmé seul fait disparaître la clé
ℹ fail 9
```

Trois tests **existants** ont dû être mis à jour — changement de contrat délibéré : `staleVol` s'ajoute au retour de `effValue`, et `pris` au store d'un volume. Ils comparaient l'objet entier par `deepEqual`.

## Ce qui n'est pas couvert

- **Les 3 h ne sont pas une mesure**, c'est un arbitrage — l'option 1 h était recommandée. Sur trois heures un comptoir vidé a très probablement tout récupéré, donc l'app reste trop pessimiste pendant une partie du délai. En échange une correction survit à une session entière.
- **Pas de réglage à l'écran.** `DUREE_VOL` vit dans `logic.mjs` et se passe en paramètre à `effValue`/`effFromStore` : la durée est ajustable par le code, pas encore par l'interface.
- **Rien ne se met à jour tout seul.** La péremption est évaluée au rendu, pas par un minuteur : une page laissée ouverte quatre heures montrera l'ancienne valeur jusqu'au prochain rafraîchissement. Décision assumée — un `setInterval` ferait scintiller des tableaux qu'on lit.
- **Aucun test e2e** sur le nouveau comportement : il faudrait piloter l'horloge du navigateur ou attendre trois heures. La logique est pure et couverte à l'unité ; le câblage `app.js` (deux messages de notification distincts) ne l'est pas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzcSQP1VNwreuXGSs9hUHr