### PR TITLE
fix(soute): un arrêt retiré ne rend plus rechargeable une jambe déjà chargée

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ trouvée — un coût réellement nul.
 La soute tient un **lot par chargement** : la même commodité peut y figurer deux fois à des prix
 différents, et le panneau montre le détail. C'est plus lourd qu'une moyenne, mais c'est juste.
 
-Deux règles à connaître :
+Trois règles à connaître :
 
 - **Le prix payé ne se périme jamais.** Partout ailleurs le dépôt refuse de persister un prix — il
   ne garde que l'intention, et relit le marché. Le prix payé échappe à cette règle parce que ce
@@ -242,6 +242,11 @@ Deux règles à connaître :
 - **Effacer le voyage ne vide pas la soute.** Le parcours est un plan, la soute est du fret réel :
   reprendre le jeu une semaine plus tard avec un vaisseau rangé plein, c'est une soute exacte, pas
   une soute périmée. Elle a son propre ✕.
+- **Le lien avec la jambe suit la renumérotation, pas la disparition.** Retirer un arrêt renumérote
+  les jambes : l'étiquette de tes lots se décale avec elles, et le bouton reste `⬢ à bord`. Si la
+  jambe qui les a chargés disparaît — ou si tu effaces le voyage — le fret **reste en soute**, il
+  est réel ; il n'est simplement plus rattaché à une jambe, donc plus annulable depuis le voyage.
+  Le ✕ du lot et le panneau Soute restent les sorties.
 
 **Charger vide le rayon.** `✓ chargé` retire de la station ce que tu viens d'y prendre — c'est une
 **correction locale** comme une autre, ancrée à la date UEX du point, donc périmée dès qu'UEX

--- a/app.js
+++ b/app.js
@@ -18,6 +18,7 @@ import {
   startJourney, startJourneyAt, journeyStations, journeyEnd,
   journeyConnects, addToJourney, setJourneyPosition, currentLeg, journeyMargin,
   removeJourneyStop as removeStopPure,
+  reindexerRangsJambe, detacherLotsDeJambe,
   encodeJourney, decodeJourney,
 } from "./logic.mjs";
 
@@ -1500,6 +1501,11 @@ function clearJourney() {
   // sur un parcours ULTÉRIEUR passant par les mêmes terminaux, badge ✎ compris.
   JOURNEY_EDITS = {}; saveJourneyEdits();
   JOURNEY_PINS = {}; saveJourneyPins();
+  // Troisième porteur du rang : l'étiquette posée sur les lots. Le fret, lui, RESTE à bord — le
+  // parcours est un plan, la soute est du fret payé (ADR-002). Sans ce détachement, un voyage
+  // ultérieur dont la jambe 0 relie les deux mêmes terminaux s'affichait « ⬢ à bord », et le clic
+  // déchargeait les lots de l'ancien voyage en restaurant leurs stocks.
+  SOUTE = detacherLotsDeJambe(SOUTE); saveSoute();
   journeyExpandedLeg = -1;
   renderJourney();
   saveState();
@@ -1792,30 +1798,18 @@ function beginJourney(label) {
   refresh();
 }
 
-// Retire un arrêt (index de station) et RECONNECTE les voisins (recalcule la jambe A->C).
-// Réindexe les manifestes édités après une modification du parcours : la clé porte le RANG de la
-// jambe, donc retirer un arrêt décalerait sinon l'édition d'une jambe sur sa voisine.
-function reindexLegEdits(removedFrom, removedCount, insertedCount) {
-  const decalage = removedCount - insertedCount;
-  // Les deux stores sont indexés par le MÊME rang de jambe : les décaler séparément les ferait
-  // diverger, et un 🔒 se retrouverait sur une jambe dont l'intention a disparu.
-  const decale = (store) => {
-    const suivant = {};
-    for (const [k, v] of Object.entries(store)) {
-      const sep = k.indexOf("|");
-      const i = Number(k.slice(0, sep));
-      if (i < removedFrom) suivant[k] = v;                       // avant la coupe : inchangé
-      else if (i < removedFrom + removedCount) continue;         // jambe disparue : son édition part
-      else suivant[`${i - decalage}${k.slice(sep)}`] = v;        // après : recule d'autant
-    }
-    return suivant;
-  };
-  JOURNEY_EDITS = decale(JOURNEY_EDITS);
-  JOURNEY_PINS = decale(JOURNEY_PINS);
-  if (journeyExpandedLeg >= removedFrom) journeyExpandedLeg = -1; // le panneau déplié n'existe plus
-  saveJourneyEdits(); saveJourneyPins();
+// Réindexe tout ce qui est indexé par le RANG des jambes après une modification du parcours. Les
+// TROIS porteurs — manifeste édité, 🔒, étiquette `leg` des lots de la soute — passent par le même
+// appel pur : les décaler séparément les ferait diverger, et c'est d'en avoir oublié un que venait
+// le double chargement (la jambe renumérotée se croyait vide alors que son fret était à bord).
+function reindexerApresRetrait(retrait) {
+  const r = reindexerRangsJambe({ edits: JOURNEY_EDITS, pins: JOURNEY_PINS, lots: SOUTE }, retrait);
+  JOURNEY_EDITS = r.edits; JOURNEY_PINS = r.pins; SOUTE = r.lots;
+  if (journeyExpandedLeg >= retrait.removedFrom) journeyExpandedLeg = -1; // le panneau déplié n'existe plus
+  saveJourneyEdits(); saveJourneyPins(); saveSoute();
 }
 
+// Retire un arrêt (index de station) et RECONNECTE les voisins (recalcule la jambe A->C).
 function removeJourneyStop(stopIndex) {
   if (!JOURNEY) return;
   const legs = JOURNEY.legs;
@@ -1830,7 +1824,7 @@ function removeJourneyStop(stopIndex) {
   }
   const r = removeStopPure(JOURNEY, stopIndex, bridge);
   if (!r) { clearJourney(); return; }
-  reindexLegEdits(r.removedFrom, r.removedCount, r.insertedCount);
+  reindexerApresRetrait(r);
   // `start` n'est présent que sur le parcours réduit à un seul arrêt : le reporter tel quel, sinon
   // la station survivante n'a plus rien pour se décrire (journeyStations la lit là) et le voyage
   // s'affiche vide alors qu'il reste un point de départ.

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -517,6 +517,33 @@ test("Soute : elle survit au rechargement, et effacer le VOYAGE ne la vide pas",
   await expect(page.locator("#holdCard")).toBeHidden();
 });
 
+test("Soute : retirer un arrêt AVANT une jambe chargée ne la rend pas rechargeable (#7)", async ({ page }) => {
+  // L'étiquette du lot portait le RANG de la jambe, et seuls DEUX des trois porteurs de ce rang
+  // étaient renumérotés. Retirer un arrêt d'avant faisait donc repasser le bouton à « ✓ chargé »
+  // alors que le fret était à bord — et le clic suivant doublait la soute en redéduisant le stock.
+  await jambeChargeable(page);
+  await expect(page.locator("#journeyCard .jstop-suggest").first()).toBeVisible({ timeout: 8000 });
+  await page.locator("#journeyCard .jstop-suggest").first().click();
+  await expect(page.locator("#journeyCard .jstep")).toHaveCount(3);
+  // Le bouton n'existe que sur une jambe qui a du fret : viser nth(1) à l'aveugle pourrait
+  // désigner la jambe 0 — celle qui va disparaître — et rendre le test faussement vert.
+  await expect(page.locator("#journeyCard .jleg-load")).toHaveCount(2);
+
+  await page.locator("#journeyCard .jleg-load").nth(1).click(); // on charge la SECONDE jambe (rang 1)
+  await expect(page.locator("#journeyCard .jleg-load").nth(1)).toHaveText(/à bord/i);
+  const scu = holdScuDe(await lots(page));
+  expect(scu).toBeGreaterThan(0);
+
+  await page.locator("#journeyCard .jstep-del").nth(0).click(); // ✕ 1er arrêt : la jambe passe au rang 0
+  await expect(page.locator("#journeyCard .jstep")).toHaveCount(2);
+  await expect(page.locator("#journeyCard .jleg-load").first()).toHaveText(/à bord/i); // avant : « ✓ chargé »
+  expect(holdScuDe(await lots(page))).toBe(scu);
+
+  // Et re-cliquer ANNULE le chargement, au lieu d'en ajouter un second exemplaire.
+  await page.locator("#journeyCard .jleg-load").first().click();
+  expect(holdScuDe(await lots(page))).toBe(0);
+});
+
 test("Soute : recharger la même commodité crée un SECOND lot, sans fondre les prix", async ({ page }) => {
   await jambeChargeable(page);
   await page.locator("#journeyCard .jleg-load").click();

--- a/logic.mjs
+++ b/logic.mjs
@@ -1226,6 +1226,61 @@ export function removeJourneyStop(journey, stopIndex, bridge) {
   };
 }
 
+// ---------- Le RANG d'une jambe, et ses TROIS porteurs ----------
+// Trois choses sont indexées par le rang d'une jambe : le manifeste ÉDITÉ, le 🔒 qui dit pourquoi
+// il l'est, et l'étiquette `leg` que le chargement pose sur les lots de la soute. Retirer un arrêt
+// renumérote les jambes : n'en décaler que deux les fait diverger. C'est le troisième, oublié, qui
+// rendait « ✓ chargé » une jambe dont le fret était déjà à bord — et un second clic la doublait.
+
+// Nouvelle clé d'une jambe après un retrait d'arrêt : la même, renumérotée — ou `null` si la jambe
+// a disparu du parcours. Une clé illisible ressort INTACTE : on ne renumérote pas ce qu'on n'a pas
+// su lire, et surtout on n'écrit pas de « NaN| » dans un store persisté.
+// `retrait` = ce que removeJourneyStop vient de renvoyer.
+export function cleApresRetrait(cle, { removedFrom, removedCount, insertedCount = 0 }) {
+  const s = String(cle), sep = s.indexOf("|");
+  const i = sep < 0 ? NaN : Number(s.slice(0, sep));
+  if (!Number.isInteger(i) || i < 0) return cle;
+  if (i < removedFrom) return cle;                               // avant la coupe : inchangée
+  if (i < removedFrom + removedCount) return null;               // jambe disparue
+  return `${i - (removedCount - insertedCount)}${s.slice(sep)}`; // après : recule d'autant
+}
+
+const sansEtiquette = (lot) => { const { leg, ...reste } = lot; return reste; };
+
+// Réindexe LES TROIS PORTEURS d'un seul appel — c'est tout l'intérêt : ils ne peuvent plus
+// diverger, et un appelant ne peut plus en oublier un. Les STORES perdent l'entrée d'une jambe
+// disparue (le plan qu'elle portait n'existe plus) ; les LOTS, jamais : le fret est réellement à
+// bord. On leur retire seulement leur étiquette — ils restent en soute, visibles, vendables, mais
+// rattachés à aucune jambe. Les recoller au pont A→C serait pire : sa cargaison est RECALCULÉE, le
+// voyage prétendrait l'avoir chargée, et son vrai chargement deviendrait impossible.
+export function reindexerRangsJambe({ edits = {}, pins = {}, lots = [] }, retrait) {
+  const decale = (store) => {
+    const suivant = {};
+    for (const [k, v] of Object.entries(store)) {
+      const n = cleApresRetrait(k, retrait);
+      if (n != null) suivant[n] = v;
+    }
+    return suivant;
+  };
+  return {
+    edits: decale(edits),
+    pins: decale(pins),
+    lots: lots.map((l) => {
+      if (l.leg == null) return l;
+      const n = cleApresRetrait(l.leg, retrait);
+      return n === l.leg ? l : n != null ? { ...l, leg: n } : sansEtiquette(l);
+    }),
+  };
+}
+
+// Effacer le parcours DÉLIE les lots sans les débarquer : le parcours est un plan, la soute est du
+// fret payé (ADR-002). Sans ça, un voyage ultérieur dont la jambe 0 relie les deux mêmes terminaux
+// s'affichait « ⬢ à bord » et le clic déchargeait les lots de l'ancien — la résurrection déjà
+// corrigée pour les manifestes édités, à laquelle les étiquettes avaient échappé.
+export function detacherLotsDeJambe(lots) {
+  return lots.map((l) => (l.leg == null ? l : sansEtiquette(l)));
+}
+
 // Déplace la position courante (bornée à 0..legs.length).
 export function setJourneyPosition(journey, i) {
   return { ...journey, current: Math.max(0, Math.min(journey.legs.length, i | 0)) };

--- a/logic.test.mjs
+++ b/logic.test.mjs
@@ -22,6 +22,7 @@ import {
   startJourney, startJourneyAt, journeyStations, journeyEnd,
   journeyConnects, addToJourney, setJourneyPosition, currentLeg, journeyMargin,
   encodeJourney, decodeJourney, removeJourneyStop, freeManifestLine, hydrateManifestLine,
+  cleApresRetrait, reindexerRangsJambe, detacherLotsDeJambe,
 } from "./logic.mjs";
 
 // ---------- Temps de trajet ----------
@@ -2608,6 +2609,55 @@ test("removeJourneyStop : retirer le dernier arrêt restant -> null (voyage effa
   const seul = removeJourneyStop(parcours(["A", "B"], 0), 1); // il ne reste que A
   assert.equal(removeJourneyStop(seul, 0), null);
   assert.equal(removeJourneyStop(startJourneyAt({ name: "A", system: "S" }), 0), null);
+});
+
+// ---------- Le rang de jambe et ses TROIS porteurs (manifeste, 🔒, étiquette de lot) ----------
+const lotDe = (leg) => ({ name: "Gold", units: 100, paid: 1000, from: "Megumi", at: 1, ...(leg ? { leg } : {}) });
+
+test("reindexerRangsJambe : une jambe qui recule emmène son manifeste, son 🔒 ET ses lots", () => {
+  // A→B→C, la jambe 1 (B→C) est chargée. On retire l'arrêt A : elle devient la jambe 0.
+  const retrait = removeJourneyStop(parcours(["A", "B", "C"], 0), 0);
+  const r = reindexerRangsJambe({
+    edits: { "1|B|C": [{ name: "Gold", units: 100 }] },
+    pins: { "1|B|C": true },
+    lots: [lotDe("1|B|C")],
+  }, retrait);
+  assert.deepEqual(Object.keys(r.edits), ["0|B|C"]);
+  assert.deepEqual(Object.keys(r.pins), ["0|B|C"]);
+  assert.equal(r.lots.length, 1);
+  assert.equal(r.lots[0].leg, "0|B|C"); // avant : l'étiquette restait sur « 1|B|C », la jambe se croyait vide
+});
+
+test("reindexerRangsJambe : les lots d'une jambe DISPARUE restent à bord, sans étiquette", () => {
+  const retrait = removeJourneyStop(parcours(["A", "B", "C"], 0), 0); // la jambe A→B disparaît
+  const r = reindexerRangsJambe({ edits: { "0|A|B": [] }, pins: {}, lots: [lotDe("0|A|B"), lotDe("1|B|C")] }, retrait);
+  assert.deepEqual(r.edits, {});          // le PLAN de la jambe retirée part avec elle
+  assert.equal(r.lots.length, 2);         // le FRET, lui, est réellement à bord : il ne part pas
+  assert.equal("leg" in r.lots[0], false);
+  assert.equal(r.lots[0].units, 100);
+  assert.equal(r.lots[1].leg, "0|B|C");
+});
+
+test("reindexerRangsJambe : un arrêt du MILIEU emporte deux jambes, le pont n'hérite de rien", () => {
+  // A→B→C→D, on retire B : A→B et B→C disparaissent au profit du pont A→C (rang 0).
+  const retrait = removeJourneyStop(parcours(["A", "B", "C", "D"], 0), 1, jambe("A", "C"));
+  const r = reindexerRangsJambe({ edits: {}, pins: {}, lots: [lotDe("0|A|B"), lotDe("2|C|D")] }, retrait);
+  assert.equal("leg" in r.lots[0], false); // recoller ces lots au pont le dirait chargé à tort
+  assert.equal(r.lots[1].leg, "1|C|D");
+});
+
+test("cleApresRetrait : une clé illisible traverse intacte plutôt que de devenir « NaN| »", () => {
+  const retrait = { removedFrom: 0, removedCount: 1, insertedCount: 0 };
+  assert.equal(cleApresRetrait("1|B|C", retrait), "0|B|C");
+  assert.equal(cleApresRetrait("0|A|B", retrait), null);
+  assert.equal(cleApresRetrait("sans-rang", retrait), "sans-rang");
+});
+
+test("detacherLotsDeJambe : effacer le voyage délie les lots sans les débarquer", () => {
+  const r = detacherLotsDeJambe([lotDe("0|A|B"), lotDe(null)]);
+  assert.equal(r.length, 2);
+  assert.equal("leg" in r[0], false);
+  assert.equal(r[0].units, 100); // le fret payé survit à l'effacement du parcours (ADR-002)
 });
 
 // ---------- Suggestions d'arrêts : mêmes filtres que la vue qui les affichera ----------


### PR DESCRIPTION
## Ce que ça change

Retirer un arrêt du voyage ne fait plus repasser à « ✓ chargé » une jambe dont le fret est déjà en soute : le bouton reste `⬢ à bord`, et le clic suivant annule le chargement au lieu d'en ajouter un second exemplaire. Effacer le voyage ne laisse plus non plus ses étiquettes derrière lui.

## Pourquoi

Trois choses sont indexées par le **rang** d'une jambe (`legKey`, `app.js:1557`) : le manifeste édité (`JOURNEY_EDITS`), le 🔒 qui dit pourquoi il l'est (`JOURNEY_PINS`), et l'étiquette `leg` que `chargerJambe` pose sur chaque lot de la soute (`app.js:1191`). `reindexLegEdits` (`app.js:1798-1817`) n'en décalait que **deux** ; `clearJourney` (`app.js:1501-1502`) ne purgeait que ces deux-là.

Cause racine : `jambeChargee` (`app.js:1214`) dérive l'état « chargée » de la seule présence d'un lot portant ce rang. Après renumérotation, la jambe se croit vide — et rien ne l'empêche de recharger : `legEffectiveLines` produit des lignes `aBord: false` (`logic.mjs:289/304`) que `loadHold` recharge sans garde (`logic.mjs:1257`). D'où la soute doublée et la déduction de stock appliquée une seconde fois.

Le commentaire de `reindexLegEdits` énonçait déjà l'invariant — « les décaler séparément les ferait diverger » — mais ne connaissait que deux porteurs sur trois. Ils passent maintenant par un seul appel pur, `reindexerRangsJambe`, dont c'est précisément la raison d'être : un appelant ne peut plus en oublier un.

Choix de conception, tranché par la revue : les **stores** perdent l'entrée d'une jambe disparue (le plan qu'elle portait n'existe plus), mais les **lots** ne sont jamais supprimés — le fret est réellement à bord et payé (ADR-002). On leur retire seulement leur étiquette. Les recoller au pont A→C d'un retrait du milieu serait pire : sa cargaison est recalculée, le voyage prétendrait l'avoir chargée, et son vrai chargement deviendrait impossible.

## Vérification

Test rouge d'abord, sur le comportement réel (`e2e/smoke.pw.mjs:520`). Avant correctif :

```
1 failed
  Expected pattern: /à bord/i
  Received string:  "✓ chargé"
  locator resolved to <button data-leg="0" class="jleg-load">✓ chargé</button>
```

Après correctif :

```
node --test          ℹ tests 344 · ℹ pass 344 · ℹ fail 0
npx playwright test  93 passed (53.3s)
```

Référence avant la PR : 339 tests unitaires et 92 e2e. Les 5 tests unitaires ajoutés couvrent la fonction pure (renumérotation, jambe disparue, arrêt du milieu, clé illisible, détachement) ; le 93e e2e est le rouge ci-dessus.

## Ce qui n'est pas couvert

- **Les soutes déjà corrompues** gardent leurs doublons : ils restent supprimables lot par lot (✕). Aucune migration n'est tentée — on ne sait pas distinguer un doublon d'un vrai second chargement.
- **`addToJourney` / `pickJourney`** (`app.js:1459`, `logic.mjs:1123`) : quand les jambes ne se raccordent pas, le parcours est REMPLACÉ par un `startJourney` qui ne purge ni les manifestes, ni les 🔒, ni les étiquettes. Même classe de résurrection, mais elle touche les trois stores et préexiste à cette issue — à traiter à part.
- **La restauration d'un parcours depuis un permalien** face à une soute locale déjà étiquetée : même risque de collision de rang, non traité ici.
- `jambeChargee` reste dérivée de la présence de lots plutôt que portée explicitement : la classe de bug « la soute vidée autrement rend la jambe rechargeable » subsiste (issue à ouvrir).

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
