### PR TITLE
fix(soute): sans voyage, la carte suit de nouveau les filtres et vend là où le prix est affiché

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,9 @@ Deux règles à connaître :
   n'est pas un prix affiché : c'est le montant d'une transaction qui a eu lieu.
 - **Effacer le voyage ne vide pas la soute.** Le parcours est un plan, la soute est du fret réel :
   reprendre le jeu une semaine plus tard avec un vaisseau rangé plein, c'est une soute exacte, pas
-  une soute périmée. Elle a son propre ✕.
+  une soute périmée. Elle a son propre ✕. Sans voyage, la carte continue de **suivre tes filtres** :
+  la place libre, « où écouler » et le prix de vente se recalculent au **terminal de départ
+  d'« En route »**.
 
 **Charger vide le rayon.** `✓ chargé` retire de la station ce que tu viens d'y prendre — c'est une
 **correction locale** comme une autre, ancrée à la date UEX du point, donc périmée dès qu'UEX

--- a/app.js
+++ b/app.js
@@ -1225,8 +1225,12 @@ function stationCourante() {
 
 // Vend `units` SCU ici. Si le comptoir n'a pas tout pris, le reste est marqué REFUSÉ à cette
 // station : il traversera la vente implicite du départ sans être effacé.
-function vendreIci(nom, units) {
-  const idx = stationCourante();
+// `idxFige` : l'index porté par `.hold-sell[data-idx]`, résolu AU RENDU. On vend là où l'utilisateur
+// a lu le prix, pas là où il se trouve à la milliseconde du clic — sinon l'infobulle annonce une
+// station et la vente en encaisse une autre. Repli sur `stationCourante()` pour tout appel qui n'a
+// pas d'affichage derrière lui (venteImplicite, notamment).
+function vendreIci(nom, units, idxFige) {
+  const idx = Number.isFinite(idxFige) ? idxFige : stationCourante();
   if (idx == null || !MARKET) return;
   const pt = sellableAt(MARKET, idx, nom, effVals);
   if (!pt) return;
@@ -1265,8 +1269,9 @@ function loadDepots() {
 }
 function saveDepots() { try { localStorage.setItem(DEPOTS_KEY, JSON.stringify(DEPOTS)); } catch {} }
 
-function deposerIci(nom, units) {
-  const idx = stationCourante();
+// Même règle que `vendreIci` : on dépose à la station résolue au rendu, celle que le panneau nomme.
+function deposerIci(nom, units, idxFige) {
+  const idx = Number.isFinite(idxFige) ? idxFige : stationCourante();
   if (idx == null || !MARKET) return;
   const t = MARKET.terminals[idx];
   const r = storeFromHold(SOUTE, DEPOTS, nom, units, stationLabel(t.name, t.system));
@@ -1337,8 +1342,11 @@ function renderSoute() {
     const pt = ici != null && MARKET ? sellableAt(MARKET, ici, g.name, effVals) : null;
     // Vendre suppose que le comptoir reprenne la commodité ; DÉPOSER, non — c'est justement la
     // sortie quand il n'en veut pas. Les deux ouvrent le même champ de quantité.
+    // `data-idx` fige la station telle qu'elle a été résolue POUR CE RENDU : c'est elle qui a fixé
+    // le prix annoncé juste à côté. Sans lui, `vendreIci` relisait `stationCourante()` au clic et
+    // pouvait encaisser ailleurs qu'à l'endroit dont l'utilisateur venait de lire le chiffre.
     const vente = venteEnCours === g.name
-      ? `<span class="hold-sell open"><input class="hold-sell-qty" type="number" min="0" max="${g.units}" value="${g.units}" aria-label="SCU de ${esc(g.name)}" />
+      ? `<span class="hold-sell open" data-idx="${ici}"><input class="hold-sell-qty" type="number" min="0" max="${g.units}" value="${g.units}" aria-label="SCU de ${esc(g.name)}" />
            ${pt ? `<button class="hold-sell-ok" data-name="${esc(g.name)}" title="Vendre ici à ${fmt(pt.price)} aUEC/SCU">✓ vendre</button>` : ""}
            <button class="hold-store" data-name="${esc(g.name)}" title="Déposer à la station : ni vendu, ni perdu">⬓ déposer</button>
            <button class="hold-sell-no" title="Annuler">✕</button></span>`
@@ -1993,6 +2001,14 @@ function refresh() {
   // le marché et sur les filtres (cf. README). Le coût est celui d'un manifeste par jambe, sur un
   // parcours qui en compte une poignée ; les champs à saisie libre passent déjà par un debounce.
   if (JOURNEY) renderJourney();
+  // Effacer le parcours NE VIDE PAS la soute (c'est le contrat, cf. README) : hors du cycle de
+  // rendu, son « X libres », son « où écouler » et le prix de son bouton de vente restaient figés
+  // pendant que les tableaux d'à côté suivaient les filtres. On appelle renderSoute() DIRECTEMENT
+  // plutôt que renderJourney() : la branche « sans voyage » de celui-ci réécrit l'invite
+  // « Nouveau voyage », donc détruirait le champ #journeyStart en cours de saisie (texte et focus)
+  // à chaque frappe faite ailleurs dans l'app. Le coût est nul soute vide : renderSoute sort tout
+  // de suite en masquant sa carte.
+  else renderSoute();
   saveState();
 }
 const refreshDebounced = debounce(refresh);
@@ -2826,20 +2842,23 @@ async function init() {
   $("holdCard").addEventListener("click", (e) => {
     if (e.target.closest("#holdClear")) { viderSoute(); return; }
     if (e.target.closest("#holdOffload")) { ecoulerOuvert = !ecoulerOuvert; renderSoute(); return; }
+    // La quantité ET la station se lisent sur le MÊME conteneur : celui que le rendu a produit.
+    // `dataset.idx` absent -> undefined -> NaN -> repli sur stationCourante() ; jamais 0.
     const deposer = e.target.closest(".hold-store");
-    if (deposer) { deposerIci(deposer.dataset.name, Number(deposer.closest(".hold-sell").querySelector(".hold-sell-qty").value)); return; }
+    if (deposer) { const b = deposer.closest(".hold-sell"); deposerIci(deposer.dataset.name, Number(b.querySelector(".hold-sell-qty").value), Number(b.dataset.idx)); return; }
     const ouvrir = e.target.closest(".hold-sell-btn");
     if (ouvrir) { venteEnCours = ouvrir.dataset.name; renderSoute(); $("holdCard").querySelector(".hold-sell-qty")?.select(); return; }
     if (e.target.closest(".hold-sell-no")) { venteEnCours = null; renderSoute(); return; }
     const ok = e.target.closest(".hold-sell-ok");
-    if (ok) { vendreIci(ok.dataset.name, Number(ok.closest(".hold-sell").querySelector(".hold-sell-qty").value)); return; }
+    if (ok) { const b = ok.closest(".hold-sell"); vendreIci(ok.dataset.name, Number(b.querySelector(".hold-sell-qty").value), Number(b.dataset.idx)); return; }
     const del = e.target.closest(".hold-del");
     if (del) retirerLot(Number(del.dataset.i));
   });
   // Entrée valide la vente, Échap l'annule — même patron que les corrections inline.
   $("holdCard").addEventListener("keydown", (e) => {
     if (!e.target.classList.contains("hold-sell-qty")) return;
-    if (e.key === "Enter") { e.preventDefault(); vendreIci(venteEnCours, Number(e.target.value)); }
+    // Entrée doit encaisser à la même station que le bouton ✓ : même index figé, lu sur le conteneur.
+    if (e.key === "Enter") { e.preventDefault(); vendreIci(venteEnCours, Number(e.target.value), Number(e.target.closest(".hold-sell")?.dataset.idx)); }
     else if (e.key === "Escape") { e.preventDefault(); venteEnCours = null; renderSoute(); }
   });
   $("journeyMap").addEventListener("click", (e) => {

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -517,6 +517,42 @@ test("Soute : elle survit au rechargement, et effacer le VOYAGE ne la vide pas",
   await expect(page.locator("#holdCard")).toBeHidden();
 });
 
+test("Soute : sans voyage, la carte suit toujours les filtres (#8)", async ({ page }) => {
+  // Effacer le parcours ne vide pas la soute (c'est le contrat), mais `refresh()` ne repeignait le
+  // compagnon que `if (JOURNEY)` : la carte restait figée sur son dernier rendu pendant que les
+  // tableaux d'à côté, eux, suivaient les filtres.
+  await jambeChargeable(page);
+  await page.locator("#journeyCard .jleg-load").first().click();
+  await expect(page.locator("#holdCard")).toBeVisible();
+  const aBord = holdScuDe(await lots(page));
+  expect(aBord).toBeGreaterThan(0);
+
+  await page.locator("#journeyClear").click();
+  await expect(page.locator("#journeyCard .jstep")).toHaveCount(0);
+  await expect(page.locator("#holdCard")).toBeVisible(); // le fret est réel, il survit au plan
+
+  // Agrandir la soute doit rebattre « X libres » — sans voyage comme avec.
+  await page.fill("#cargo", String(aBord + 250));
+  await expect(page.locator("#holdCard .hold-meta")).toContainText(/\b250 libres/);
+
+  // Et décocher « Soute (SCU) » doit faire DISPARAÎTRE la place libre : plus de plafond, plus de
+  // chiffre — la carte ne doit pas garder l'ancien.
+  await page.uncheck("#useCargo");
+  await expect(page.locator("#holdCard .hold-meta")).not.toContainText("libres");
+});
+
+test("Soute : le champ de vente fige la station résolue au rendu (#8)", async ({ page }) => {
+  // L'infobulle annonce un prix ; sans index figé, `vendreIci` relisait `stationCourante()` au clic
+  // et pouvait encaisser à une AUTRE station que celle dont l'utilisateur venait de lire le chiffre.
+  await jambeChargeable(page);
+  await page.locator("#journeyCard .jleg-load").first().click();
+  await expect(page.locator("#holdCard")).toBeVisible();
+  await page.locator("#holdCard .hold-sell-btn").first().click();
+  // `toMatch` et non `Number.isFinite` : getAttribute rend `null` quand l'attribut manque, et
+  // `Number(null)` vaut 0 — un index de terminal parfaitement valide. Le test passerait à faux.
+  expect(await page.locator("#holdCard .hold-sell").first().getAttribute("data-idx")).toMatch(/^\d+$/);
+});
+
 test("Soute : recharger la même commodité crée un SECOND lot, sans fondre les prix", async ({ page }) => {
   await jambeChargeable(page);
   await page.locator("#journeyCard .jleg-load").click();


### PR DESCRIPTION
## Ce que ça change

Sans voyage en cours, la carte **Soute** suit de nouveau les filtres : sa place libre, son panneau « où écouler » et son bouton de vente se recalculent comme le reste de l'app. Et la vente encaisse désormais **à la station dont le panneau affichait le prix**, pas à celle résolue à la milliseconde du clic.

## Pourquoi

`refresh()` ne repeignait le compagnon que `if (JOURNEY)` (`app.js:1995`), et `renderSoute()` n'était appelée que depuis `renderJourney()`. Or effacer le parcours **ne vide pas la soute** — c'est le contrat, documenté dans le README — et on y entre aussi par un simple rechargement de page sans permalien de voyage (`loadSoute()` restaure la soute, `JOURNEY` reste `null`). La carte restait donc figée sur son dernier rendu pendant que les tableaux d'à côté suivaient les filtres, alors qu'elle lit `readFilters()` et `stationCourante()` à chaque rendu (`app.js:1320-1323`).

Second défaut, indépendant du premier : le prix annoncé venait de `sellableAt(MARKET, ici, …)` figé au rendu (`app.js:1337`), quand `vendreIci()` relisait `stationCourante()` à l'exécution (`app.js:1229`). Un champ de vente laissé ouvert pendant qu'on change le terminal de départ suffisait à désaccorder les deux — et si le nouveau comptoir ne reprend pas la commodité, le clic était **muet** (`app.js:1230-1232` sort sans rien dire).

Deux points tranchés par la vérification, contre ce que proposait l'issue :

- **Ne pas** rendre `renderJourney()` inconditionnel. Sa branche sans voyage réécrit `card.innerHTML`, donc détruirait le champ `#journeyStart` — texte saisi et position du curseur — à chaque frappe débouncée faite ailleurs dans l'app. C'est exactement le piège déjà documenté en `app.js:1669` et `app.js:2359`. `renderSoute()` en direct est plus sûr et strictement moins coûteux (soute vide, elle sort immédiatement en masquant sa carte).
- Figer l'index **n'était pas facultatif** : c'est le seul correctif qui ferme le cas « champ resté ouvert », lequel contourne le repeint par construction.

`data-idx` est posé sur le conteneur `.hold-sell` et non sur les boutons, parce que le raccourci Entrée part de l'input : le clic et la touche doivent lire le même index. La lecture se fait par `dataset.idx` (absent → `undefined` → `NaN` → repli sur `stationCourante()`) et jamais par `getAttribute` : `Number(null)` vaut `0`, un index de terminal parfaitement valide, ce qui vendrait silencieusement au terminal 0.

## Vérification

Deux tests rouges d'abord (`e2e/smoke.pw.mjs:520` et `:544`). Avant correctif :

```
Error: expect(locator).toContainText(expected) failed
  Expected pattern: /\b250 libres/
  Received string:  "96 SCU à bord · 0 libres · capital engagé 252 548 aUEC"

TypeError: expect(received).toMatch(expected)
  Received has value: null          ← l'attribut data-idx n'existe pas
2 failed
```

Après correctif :

```
node --test          ℹ tests 339 · ℹ pass 339 · ℹ fail 0
npx playwright test  94 passed (46.3s)
```

Référence avant la PR : 339 unitaires et 92 e2e. Le compte unitaire est inchangé — cette PR ne déplace aucun calcul pur, elle corrige de l'orchestration de rendu, qui ne se teste qu'en e2e.

## Ce qui n'est pas couvert

- **Le champ de vente ouvert reste réinitialisé par un repeint** (`renderSoute` réécrit `box.innerHTML`) : la quantité saisie repart au défaut et le focus est perdu. Le défaut existait déjà **avec** un voyage (`app.js:1938`) ; ce correctif l'étend au cas sans voyage. En pratique aucun listener ne déclenche `refresh()` pendant qu'on tape dans `.hold-sell-qty`, mais c'est à savoir avant de toucher à ce champ.
- **Le bouton de vente absent** quand `enrouteOrigin` valait `null` au dernier repeint est corrigé par ricochet (la carte se repeint), mais aucun test ne le couvre spécifiquement.
- `ajusterRangeeVoyage()` n'est **pas** appelé dans la nouvelle branche : la branche sans voyage de `renderJourney` sort par `return` avant lui, l'invite « Nouveau voyage » ne dépassera jamais les autres colonnes de 140 px, et ce serait un `getBoundingClientRect` forcé à chaque `refresh()` de toutes les vues.

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
