### PR TITLE
fix(voyage): l'en-tête d'une jambe s'active au clavier, et les raccourcis se taisent sur un élément activable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ Autres éléments :
 - **Fiabilité des données** : pastille d'âge par relevé, filtre de fraîcheur (< 24 h / 3 j / 7 j), point de statut d'inventaire, tag « à vérifier », bandeau global « données d'il y a X h ».
 - **Filtres** : commodité, système, même système uniquement, exclure les avant-postes, commodités légales uniquement, limiter au stock & à la demande UEX. Ils ne s'appliquent pas tous à toutes les vues — voir la **[matrice ci-dessous](#portée-des-filtres-par-vue)**.
 - **Permaliens & persistance** : l'état (filtres, tri, vue, vaisseau) est mémorisé (localStorage) et encodé dans l'URL → bouton **Partager**.
-- **Copier le manifeste**, **raccourcis clavier** (`/` recherche, `1`–`6` vues).
+- **Copier le manifeste**, **raccourcis clavier** (`/` recherche, `1`–`6` vues) ; tout ce qui s'active
+  au clic s'active aussi à **Entrée/Espace** (en-têtes de tri, escales de la carte, valeurs
+  corrigeables, en-tête d'une jambe), et les raccourcis se taisent tant que le focus est sur l'un d'eux.
 - Systèmes couverts : **Stanton**, **Pyro**, **Nyx**.
 
 ### Portée des filtres par vue

--- a/app.js
+++ b/app.js
@@ -1652,7 +1652,14 @@ function legSuggestCtx(leg, lines, f) {
 }
 
 // Actions d'édition d'une jambe (i = index de jambe).
-function toggleLegEditor(i) { journeyExpandedLeg = journeyExpandedLeg === i ? -1 : i; renderJourney(); }
+function toggleLegEditor(i) {
+  journeyExpandedLeg = journeyExpandedLeg === i ? -1 : i;
+  renderJourney();
+  // renderJourney() réécrit tout le compagnon : l'en-tête qu'on vient d'activer n'existe plus et le
+  // focus retombe sur <body>. À la souris ça ne se voit pas ; au clavier on perdait sa place, la
+  // deuxième Entrée (replier) ne partait plus de nulle part et Tab reprenait au début du document.
+  $("journeyCard")?.querySelector(`.jleg-head[data-leg="${i}"]`)?.focus();
+}
 function editLegQty(i, li, val) {
   // Le voyage peut avoir été effacé entre le focus et le blur (cliquer ✕ blure d'abord le champ) :
   // sans cette garde, l'édition en vol était réécrite APRÈS la purge et ressuscitait toute seule.
@@ -1906,7 +1913,7 @@ function renderJourney() {
       </div>`;
     }
     return `<div class="jleg${i === JOURNEY.current ? " current" : ""}${expanded ? " expanded" : ""}">
-        <div class="jleg-head" data-leg="${i}" role="button" tabindex="0" title="Éditer le manifeste de cette jambe"><span class="jleg-n">${i + 1}</span><span class="jleg-route">${esc(leg.from)} → ${esc(leg.to)}</span>${edited ? (pinned
+        <div class="jleg-head" data-leg="${i}" role="button" tabindex="0" aria-expanded="${expanded}" title="Éditer le manifeste de cette jambe"><span class="jleg-n">${i + 1}</span><span class="jleg-route">${esc(leg.from)} → ${esc(leg.to)}</span>${edited ? (pinned
           ? '<span class="jleg-pinned" title="Quantités figées : le stock ou la demande de ce chargement a été corrigé depuis. Le trajet reste tel que tu l\'as décidé — les prix, eux, continuent de suivre le marché. « ↺ optimal » recalcule tout.">🔒</span>'
           : '<span class="jleg-edited" title="Manifeste personnalisé">✎</span>') : ""}${MARKET && lines && lines.length ? `<button class="jleg-load${charge ? " charge" : ""}" data-leg="${i}" title="${charge ? "Annuler : ce chargement n'est plus à bord" : "J'ai payé et chargé ce manifeste — il entre en soute à ce prix"}">${charge ? "⬢ à bord" : "✓ chargé"}</button>` : ""}<span class="jleg-profit profit">+${total}</span><span class="jleg-caret">${expanded ? "▾" : "▸"}</span></div>
         <div class="jleg-cargo">${cargo}</div>
@@ -2890,6 +2897,16 @@ async function init() {
     const step = e.target.closest(".jstep");
     if (step) setJourneyStop(Number(step.dataset.i));
   });
+  // L'en-tête d'une jambe est annoncé `role="button"` : Entrée/Espace doivent l'activer comme le clic
+  // (même corps, cf. sortableHeader). On teste `e.target` LUI-MÊME et non `closest()` — modèle
+  // `.editv` plutôt que `.jm-arret` : le bouton « ✓ chargé » vit DANS l'en-tête, et un closest()
+  // déplierait l'éditeur EN PLUS de charger la soute à chaque Entrée sur ce bouton.
+  $("journeyCard").addEventListener("keydown", (e) => {
+    if (!e.target.classList || !e.target.classList.contains("jleg-head")) return;
+    if (e.key !== "Enter" && e.key !== " ") return;
+    e.preventDefault(); // Espace ne doit pas défiler la page
+    toggleLegEditor(Number(e.target.dataset.leg));
+  });
   // Ajout d'arrêt / de commodité à la touche Entrée.
   document.addEventListener("keydown", (e) => {
     if (e.target.id === "journeyStart" && e.key === "Enter") { e.preventDefault(); beginJourney(e.target.value); }
@@ -2925,7 +2942,12 @@ async function init() {
   document.addEventListener("keydown", (e) => {
     if (e.ctrlKey || e.metaKey || e.altKey) return;
     const el = document.activeElement;
-    if (el && (el.tagName === "INPUT" || el.tagName === "SELECT" || el.tagName === "TEXTAREA" || el.classList.contains("editv"))) return;
+    // `role="button"` couvre d'un coup tout ce que l'app rend activable sans être un <button> :
+    // l'en-tête d'une jambe, une escale de la carte, une valeur corrigeable. Sans lui, tabuler
+    // jusqu'à l'un d'eux puis taper « 1 »…« 6 » changeait de vue — l'utilisateur clavier perdait son
+    // contexte au moment précis où il essayait d'agir dessus.
+    if (el && (el.tagName === "INPUT" || el.tagName === "SELECT" || el.tagName === "TEXTAREA" ||
+               el.getAttribute("role") === "button" || el.classList.contains("editv"))) return;
     if (e.key === "/") { e.preventDefault(); $("search").focus(); }
     else if (e.key === "1") switchView("routes");
     else if (e.key === "2") switchView("loops");

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -1356,7 +1356,7 @@ test("permalien : une ancre quelconque n'est pas un état — les défauts du HT
   await expect(page.locator("#budget")).toHaveValue("1000000");
 });
 
-// ---------- Accessibilité : tri au clavier, aria-sort, noms accessibles (#57, #58, #59) ----------
+// ---------- Accessibilité : tri au clavier, activation des jambes, aria, noms accessibles (#9, #57, #58, #59) ----------
 
 test("tri : Entrée puis Espace sur un en-tête trient la table, et aria-sort suit (#58)", async ({ page }) => {
   const score = page.locator('#routes th[data-sort="score"]');
@@ -1388,6 +1388,47 @@ test("tri : les en-têtes de Boucles sont eux aussi actionnables au clavier (#58
   await expect(profit).toHaveAttribute("aria-sort", "descending");
   await expect(score).toHaveAttribute("aria-sort", "none");
   await expect(profit).toHaveClass(/sorted-desc/); // l'indicateur ▾ visuel suit la même colonne
+});
+
+test("jambe : Entrée puis Espace sur l'en-tête déplient et replient l'éditeur, aria-expanded suit (#9)", async ({ page }) => {
+  // L'en-tête est annoncé `role="button"` et prend le focus (tabindex=0) : ne rien faire sous Entrée
+  // promet une action qui n'existe pas. L'éditeur de manifeste était donc à la souris seulement.
+  await page.locator("#rows tr").first().locator(".journey-pick").click();
+  await expect(page.locator("#journeyCard .jcargo-item").first()).toBeVisible({ timeout: 8000 });
+  const head = () => page.locator("#journeyCard .jleg-head").first();
+
+  await head().press("Enter");
+  await expect(page.locator("#journeyCard .jman")).toBeVisible();          // avant le correctif : rien
+  await expect(head()).toHaveAttribute("aria-expanded", "true");           // le caret ▾ est visuel seul
+  // Le re-rendu détruit l'en-tête activé : sans restitution du focus, la deuxième Entrée part de
+  // <body> et la tabulation repart du haut du document.
+  expect(await page.evaluate(() => document.activeElement?.classList.contains("jleg-head"))).toBe(true);
+  expect(await page.evaluate(() => document.activeElement?.dataset.leg)).toBe("0");
+
+  await head().press(" ");                                                // et la page ne défile pas
+  await expect(page.locator("#journeyCard .jman")).toHaveCount(0);
+  await expect(head()).toHaveAttribute("aria-expanded", "false");
+});
+
+test("jambe : Entrée sur « ✓ chargé » charge la soute SANS déplier l'éditeur (#9)", async ({ page }) => {
+  // Le bouton vit DANS l'en-tête : un handler clavier posé sur closest(".jleg-head") ferait les deux
+  // gestes d'un coup — charger la soute ET basculer l'éditeur.
+  await jambeChargeable(page);
+  await page.locator("#journeyCard .jleg-load").press("Enter");
+  await expect(page.locator("#journeyCard .jleg-load")).toHaveText(/à bord/i);
+  await expect(page.locator("#journeyCard .jman")).toHaveCount(0);
+  await expect(page.locator("#journeyCard .jleg-head").first()).toHaveAttribute("aria-expanded", "false");
+});
+
+test("raccourcis : focus sur un élément activable, « 1 »…« 6 » ne changent plus de vue (#9)", async ({ page }) => {
+  // La garde des raccourcis ne testait que INPUT/SELECT/TEXTAREA/.editv — un div `role="button"`
+  // n'est rien de tout ça. Tabuler jusqu'à l'en-tête d'une jambe puis taper « 2 » faisait basculer
+  // sur Boucles : l'utilisateur clavier perdait son contexte au moment d'agir dessus.
+  await page.locator("#rows tr").first().locator(".journey-pick").click();
+  await expect(page.locator("#journeyCard .jcargo-item").first()).toBeVisible({ timeout: 8000 });
+  await page.locator("#journeyCard .jleg-head").first().press("2");
+  await expect(page.locator("#viewRoutes")).toHaveClass(/active/); // on est resté sur Trajets
+  await expect(page.locator("#loops")).toBeHidden();
 });
 
 test("noms accessibles : soute et budget ont chacun le leur (#57)", async ({ page }) => {

--- a/style.css
+++ b/style.css
@@ -345,6 +345,9 @@ input::placeholder { color: var(--muted); }
 .jstop-suggest .muted { color: var(--muted); }
 /* Jambe dépliable + éditeur de manifeste inline. */
 .jleg-head { cursor: pointer; }
+/* Activable au clavier (role=button + tabindex) : le focus doit donc se voir, même accent que les
+   en-têtes triables. */
+.jleg-head:focus-visible { outline: none; box-shadow: inset 0 0 0 1px var(--acc); }
 .jleg-caret { color: var(--acc-2); font-size: 9px; margin-left: 4px; }
 .jleg-edited { color: var(--acc); font-size: 10px; margin-left: 4px; }
 /* Gel par correction de volume : même place que ✎, mais l'emoji porte sa propre couleur. */


### PR DESCRIPTION
## Ce que ça change

L'en-tête d'une jambe du voyage s'ouvre et se referme à **Entrée/Espace**, comme au clic. L'état plié/déplié est annoncé (`aria-expanded`), le focus revient sur l'en-tête après le re-rendu, et les raccourcis `1`–`6` ne volent plus le contexte quand le focus est sur un élément activable.

## Pourquoi

`.jleg-head` porte `role="button"` et `tabindex="0"` (`app.js:1909`) : il promet un bouton, prend le focus… et n'écoutait que le clic (`app.js:2887-2888`). Inventaire exhaustif des `keydown` du dépôt : aucun ne le visait. Et il n'existait **aucun autre chemin** vers l'éditeur — `toggleLegEditor` n'a qu'un appelant, et le panneau `.jman-*` n'est même pas dans le DOM tant que `expanded` est faux (`app.js:1894`), donc pas de contrôle « caché mais focusable » à atteindre au Tab. Déplier la jambe étant le seul accès à l'ajustement de cargaison, toute cette partie du compagnon était à la souris seulement (WCAG 2.1.1, niveau A).

La vérification a fait apparaître **deux effets de bord** que l'issue initiale ne mentionnait pas, et qui sont traités ici :

- la garde du handler de raccourcis (`app.js:2928`) ne testait que `INPUT`/`SELECT`/`TEXTAREA`/`.editv`. Un `div` n'est rien de tout ça : tabuler jusqu'à l'en-tête puis taper `2` **changeait de vue**. La garde couvre désormais `role="button"`, ce qui règle d'un coup l'en-tête, les escales de la carte et les valeurs corrigeables ;
- **Espace faisait défiler la page**, faute de `preventDefault`.

Trois choix d'implémentation méritent d'être dits :

1. Le handler teste **`e.target` lui-même**, pas `closest(".jleg-head")` — modèle `.editv` et non `.jm-arret`. Le bouton `✓ chargé` vit **dans** l'en-tête : un `closest()` déplierait l'éditeur *en plus* de charger la soute à chaque Entrée sur ce bouton. Un test dédié garde cette propriété.
2. `toggleLegEditor` **rend le focus** au nouvel en-tête. `renderJourney()` réécrit tout le compagnon : sans cela le focus retombe sur `<body>`, la deuxième Entrée ne part de nulle part et Tab reprend au début du document (WCAG 2.4.3).
3. `aria-expanded` est écrit **dans le gabarit**, jamais posé après coup : chaque rendu reconstruit l'en-tête et effacerait un attribut appliqué hors gabarit.

## Vérification

Trois tests rouges d'abord. Sources revenues à l'état de `main`, tests conservés :

```
Error: expect(locator).toHaveAttribute(expected) failed
  Expected: "false"  Received: ""              ← aria-expanded n'existe pas
Error: expect(locator).toBeVisible() failed
  Expected: visible / element(s) not found     ← Entrée ne déplie rien
Error: expect(locator).toHaveClass(expected) failed
  Expected pattern: /active/
  Received string:  "vbtn"                     ← « 2 » a fait basculer sur Boucles
3 failed
```

Après correctif :

```
node --test          ℹ tests 339 · ℹ pass 339 · ℹ fail 0
npx playwright test  95 passed (48.5s)
```

Référence avant la PR : 339 unitaires et 92 e2e. Le compte unitaire est inchangé : le correctif est entièrement dans la couche DOM.

## Ce qui n'est pas couvert

- **Un test e2e instable, sans lien avec ce correctif.** Au premier passage complet, `e2e/autoload.pw.mjs:315` (« relevé de station : k déduit d'un montant observé ») a échoué ; il passe isolément (`1 passed`) et la suite complète relancée donne **95 passed**. Ce diff ne touche ni le panneau d'autoload ni ses champs, et la garde modifiée ne peut qu'*empêcher* un raccourci, jamais en provoquer un. La CI a `retries: 1`, donc le symptôme y est masqué : à traiter dans une issue à part.
- La garde ne couvre que `role="button"` **explicite** : un vrai `<button>` focalisé laisse toujours passer `1`–`6` (comportement historique, inchangé).
- Aucun audit clavier systématique du reste de l'app : ce correctif traite l'élément signalé et la garde qu'il a révélée, pas plus.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)
