### PR TITLE
chore(ci): déclarer une Content-Security-Policy et sortir le dernier script inline

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -68,7 +68,7 @@ jobs:
         if: steps.build.outputs.changed != 'false'
         run: |
           mkdir -p _site/data _site/fonts
-          cp index.html app.js logic.mjs style.css manifest.webmanifest sw.js icon.svg _site/
+          cp index.html app.js rail.js logic.mjs style.css manifest.webmanifest sw.js icon.svg _site/
           cp fonts/* _site/fonts/
           cp data/*.json _site/data/
 

--- a/README.md
+++ b/README.md
@@ -126,9 +126,10 @@ En cas d'échec, une **issue est ouverte automatiquement** (et refermée au reto
 └───────────────────────────┬───────────────────────────────────┘
                             │ artefact Pages
 ┌─ Front (statique, navigateur) ────────────────────────────────┐
-│  index.html                                                   │
+│  index.html  (+ <meta> Content-Security-Policy)               │
 │    ├─ logic.mjs   ← fonctions PURES (calcul), testées         │
-│    └─ app.js      ← module ES : rendu DOM, état, interactions │
+│    ├─ app.js      ← module ES : rendu DOM, état, interactions │
+│    └─ rail.js     ← bascule du menu (script classique)        │
 │  sw.js (service worker) + manifest.webmanifest → PWA offline  │
 └───────────────────────────────────────────────────────────────┘
 ```
@@ -137,6 +138,15 @@ En cas d'échec, une **issue est ouverte automatiquement** (et refermée au reto
 (temps de trajet, score, `computeUnits`, **filtres partagés** par vue, corrections, remplissage glouton,
 chaîne, **graphe de marché**, **résumés de commodités**, décodage d'état…), importée à la fois par
 `app.js` (navigateur) et par les tests. `app.js` ne fait que le rendu et le câblage.
+
+**Content-Security-Policy** : l'app injecte des données **communautaires** (noms de terminaux et de
+commodités venus d'UEX) dans `innerHTML`. L'échappement (`esc`) reste la défense qui compte, mais
+elle est doublée d'une politique déclarée en `<meta>` — GitHub Pages ne laisse configurer aucun
+en-tête HTTP. `script-src 'self'` est la directive utile : aucun script inline, aucun `eval`, aucune
+origine tierce. C'est pour elle que la bascule du menu a quitté `index.html` pour
+[`rail.js`](rail.js) ; `'unsafe-inline'` n'est concédé qu'au **style**, faute de quoi les barres de
+score et le vaisseau de la carte seraient figés. Toute retouche des `<script>` de la page se
+répercute dans `SHELL` (sw.js) **et** dans la ligne `cp` de l'assemblage — un test le tient.
 
 Fichiers de données (dans [`data/`](data/)) :
 

--- a/index.html
+++ b/index.html
@@ -2,6 +2,25 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8" />
+  <!-- GitHub Pages ne laisse configurer AUCUN en-tête HTTP : la <meta> est le seul vecteur de
+       politique dont dispose ce site. Elle est posée AVANT tout <link> — le préchargeur du
+       navigateur lance des requêtes dès qu'il croise une balise, et ce qui part avant la lecture de
+       la politique lui échappe. Directive par directive :
+         script-src 'self'  — aucun inline (rail.js a été sorti pour ça), aucun eval, aucune origine
+                              tierce : c'est la seule barrière si une interpolation échappait à esc().
+         style-src 'unsafe-inline' — app.js émet des style="" par innerHTML (barre de score,
+                              chevrons et vaisseau de la carte SVG). `style-src-attr` serait plus
+                              fin, mais Firefox l'ignore et retomberait sur style-src : les barres
+                              et le vaisseau y seraient figés. On assume donc l'inline sur le style.
+         img-src 'self' https: — les photos de vaisseaux viennent de data/ships.json, régénéré
+                              toutes les 30 min contre l'API UEX, qui recopie `url_photo` verbatim.
+                              Une liste figée ferait disparaître les photos en production sans
+                              qu'aucun test committé ne le voie.
+         connect-src 'self'  — l'app ne fetch que ses propres data/*.json : coupe l'exfiltration.
+         base-uri/form-action/object-src — surfaces inutilisées ici, donc fermées.
+       frame-ancestors, report-uri et sandbox sont SANS EFFET dans une <meta> : les y écrire ne
+       donnerait qu'une fausse assurance (et Chromium le signale en console). -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https:; font-src 'self'; connect-src 'self'; worker-src 'self'; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Best Hauling — Routes commerciales Star Citizen</title>
   <link rel="stylesheet" href="fonts/fonts.css" />
@@ -307,28 +326,10 @@
   </div>
 
   <script type="module" src="app.js"></script>
-  <script>
-    // Barre latérale rétractable (pur vanilla, indépendant de app.js).
-    (function () {
-      var btn = document.getElementById("railToggle");
-      var app = document.getElementById("app");
-      if (!btn || !app) return;
-      var KEY = "best-hauling-rail";
-      try { if (localStorage.getItem(KEY) === "1") app.classList.add("rail-collapsed"); } catch (e) {}
-      var sync = function () {
-        var c = app.classList.contains("rail-collapsed");
-        btn.textContent = c ? "»" : "«";
-        // Le caractère seul ne dit rien à un lecteur d'écran : on tient l'état et le nom à jour.
-        btn.setAttribute("aria-expanded", c ? "false" : "true");
-        btn.setAttribute("aria-label", c ? "Déplier le menu" : "Rétracter le menu");
-      };
-      sync();
-      btn.addEventListener("click", function () {
-        app.classList.toggle("rail-collapsed");
-        try { localStorage.setItem(KEY, app.classList.contains("rail-collapsed") ? "1" : "0"); } catch (e) {}
-        sync();
-      });
-    })();
-  </script>
+  <!-- Sorti de la page pour que `script-src 'self'` ait un sens (cf. la <meta> du <head>).
+       Script CLASSIQUE et non module : il doit continuer de s'exécuter AVANT app.js (différé),
+       sans quoi le rail s'afficherait déplié le temps d'un rendu. Toute retouche ici se répercute
+       dans SHELL (sw.js) et dans la ligne `cp` de update-data.yml — scripts/csp.test.mjs le tient. -->
+  <script src="rail.js"></script>
 </body>
 </html>

--- a/rail.js
+++ b/rail.js
@@ -1,0 +1,28 @@
+// Barre latérale rétractable (pur vanilla, indépendant de app.js).
+// Ce code vivait en <script> inline dans index.html. Il en est sorti pour que `script-src 'self'`
+// veuille dire quelque chose : GitHub Pages n'expose aucun en-tête, la CSP tient dans une <meta>,
+// et un seul inline toléré (par 'unsafe-inline' ou par un hash à recalculer à chaque retouche)
+// rouvrirait la porte à tout script injecté. Reste un script CLASSIQUE, en fin de <body> : en
+// module il deviendrait différé, s'exécuterait APRÈS app.js, et la classe `rail-collapsed`
+// s'appliquerait après le premier rendu — le rail déplié clignoterait à chaque chargement.
+// L'IIFE garde `btn`/`app`/`KEY`/`sync` hors du global, que ce fichier partage désormais.
+(function () {
+  var btn = document.getElementById("railToggle");
+  var app = document.getElementById("app");
+  if (!btn || !app) return;
+  var KEY = "best-hauling-rail";
+  try { if (localStorage.getItem(KEY) === "1") app.classList.add("rail-collapsed"); } catch (e) {}
+  var sync = function () {
+    var c = app.classList.contains("rail-collapsed");
+    btn.textContent = c ? "»" : "«";
+    // Le caractère seul ne dit rien à un lecteur d'écran : on tient l'état et le nom à jour.
+    btn.setAttribute("aria-expanded", c ? "false" : "true");
+    btn.setAttribute("aria-label", c ? "Déplier le menu" : "Rétracter le menu");
+  };
+  sync();
+  btn.addEventListener("click", function () {
+    app.classList.toggle("rail-collapsed");
+    try { localStorage.setItem(KEY, app.classList.contains("rail-collapsed") ? "1" : "0"); } catch (e) {}
+    sync();
+  });
+})();

--- a/scripts/csp.test.mjs
+++ b/scripts/csp.test.mjs
@@ -1,0 +1,65 @@
+// La CSP et la coquille sont des réglages qui, en régressant, ne cassent RIEN de visible en CI :
+// une directive relâchée s'affiche pareil, un script absent du `cp` ne manque qu'en production —
+// les e2e tournent depuis le dépôt, jamais depuis `_site`. Rien ne les signale sans un test.
+// Lancer : `node --test`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const RACINE = join(dirname(fileURLToPath(import.meta.url)), "..");
+// CRLF normalisés : git rend ces fichiers en CRLF sous Windows et les analyses raisonnent en lignes.
+const lire = (...p) => readFileSync(join(RACINE, ...p), "utf8").replace(/\r\n/g, "\n");
+// Les COMMENTAIRES sont retirés avant toute analyse : ceux du dépôt citent volontiers les balises
+// dont ils parlent (« posée AVANT tout <link> »), et une recherche naïve les prendrait pour du
+// markup — le test tomberait sur sa propre documentation plutôt que sur une régression.
+const html = lire("index.html").replace(/<!--[\s\S]*?-->/g, "");
+const brut = (html.match(/<meta http-equiv="Content-Security-Policy" content="([^"]+)"/) || [])[1];
+const directives = Object.fromEntries(
+  (brut || "").split(";").map((s) => s.trim()).filter(Boolean).map((s) => {
+    const [nom, ...val] = s.split(/\s+/);
+    return [nom, val.join(" ")];
+  })
+);
+
+test("index.html porte une CSP — seul vecteur possible sous GitHub Pages", () => {
+  assert.ok(brut, 'aucune <meta http-equiv="Content-Security-Policy">');
+  assert.equal(directives["default-src"], "'self'");
+  assert.equal(directives["connect-src"], "'self'");
+  assert.equal(directives["object-src"], "'none'");
+  assert.equal(directives["base-uri"], "'none'");
+  assert.equal(directives["form-action"], "'none'");
+  // 'unsafe-inline' est concédé au STYLE seulement (les style="" émis par innerHTML côté app.js).
+  // Le même mot sur script-src rendrait toute la politique décorative.
+  assert.match(directives["style-src"], /'unsafe-inline'/);
+  assert.equal(directives["script-src"], "'self'");
+  // Sans effet dans une <meta> : les y écrire ne donnerait qu'une fausse assurance anti-clickjacking.
+  for (const inop of ["frame-ancestors", "report-uri", "sandbox"]) {
+    assert.ok(!(inop in directives), `« ${inop} » est sans effet dans une <meta>`);
+  }
+});
+
+test("la CSP est déclarée avant tout <link> : le préchargeur ne doit rien lancer avant de la lire", () => {
+  const csp = html.indexOf("Content-Security-Policy");
+  const premierLink = html.indexOf("<link");
+  assert.ok(csp > 0 && csp < premierLink, "la <meta> CSP doit précéder le premier <link>");
+});
+
+test("aucun <script> inline dans index.html : script-src 'self' le bloquerait", () => {
+  // Réintroduire un inline ne casse rien tant qu'on relâche la CSP « le temps de » — et c'est
+  // exactement ce couple qu'on verrouille : l'un sans l'autre échoue ici.
+  const inlines = [...html.matchAll(/<script(?![^>]*\ssrc=)[^>]*>/g)].map((m) => m[0]);
+  assert.deepEqual(inlines, []);
+});
+
+test("tout script d'index.html est précaché (sw.js) ET copié à l'assemblage (update-data.yml)", () => {
+  const srcs = [...html.matchAll(/<script[^>]*\ssrc="([^"]+)"/g)].map((m) => m[1]);
+  assert.ok(srcs.includes("rail.js"), "ancre : la bascule du rail est bien devenue un fichier");
+  const shell = lire("sw.js").match(/const SHELL = \[([^\]]+)\]/)[1];
+  const cp = lire(".github", "workflows", "update-data.yml").match(/^ *cp (.*) _site\/$/m)[1].split(/\s+/);
+  for (const src of srcs) {
+    assert.ok(shell.includes(`"./${src}"`), `${src} manque à SHELL : hors-ligne, il ne serait pas servi`);
+    assert.ok(cp.includes(src), `${src} manque au cp de l'assemblage : 404 sur le site publié`);
+  }
+});

--- a/sw.js
+++ b/sw.js
@@ -1,10 +1,14 @@
 // Service worker : app installable + consultable hors-ligne.
 // Coquille (html/js/css/icône) en « stale-while-revalidate » ; données en « réseau
 // d'abord, cache en repli » pour rester fraîches en ligne mais disponibles hors-ligne.
-const CACHE = "best-hauling-v4";
+// v5 : la coquille est servie en stale-while-revalidate. Sans bump, un visiteur déjà installé
+// recevrait encore l'ANCIEN index.html — sans CSP et avec son <script> inline — pendant toute une
+// visite, tandis que rail.js, lui, serait déjà là. `activate` purge tout cache au nom différent :
+// le bump garantit que la nouvelle page et son script arrivent ENSEMBLE.
+const CACHE = "best-hauling-v5";
 // Coquille précachée. Les woff2 (mêmes-origine depuis fonts/) sont mis en cache au premier
 // rendu par le gestionnaire fetch ci-dessous (stale-while-revalidate) -> hors-ligne complet.
-const SHELL = ["./", "./index.html", "./app.js", "./logic.mjs", "./style.css", "./fonts/fonts.css", "./icon.svg", "./manifest.webmanifest"];
+const SHELL = ["./", "./index.html", "./app.js", "./rail.js", "./logic.mjs", "./style.css", "./fonts/fonts.css", "./icon.svg", "./manifest.webmanifest"];
 
 self.addEventListener("install", (e) => {
   e.waitUntil(caches.open(CACHE).then((c) => c.addAll(SHELL)).then(() => self.skipWaiting()));


### PR DESCRIPTION
## Ce que ça change

Le site déclare une **Content-Security-Policy**. Rien ne change à l'écran : c'est une seconde couche sous l'échappement, pour le jour où une interpolation lui échapperait. La bascule du menu quitte `index.html` pour `rail.js` — c'est la condition pour que `script-src 'self'` veuille dire quelque chose.

## Pourquoi

L'app injecte des données **communautaires** — noms de terminaux et de commodités venus d'UEX — dans `innerHTML`, sur une centaine de sites d'interpolation. La défense en place est bonne (`esc()` partout, `numField` qui coerce dès le pipeline, trois tests d'injection e2e) et **aucune faille n'a été trouvée** : ce n'est pas un correctif, c'est de la défense en profondeur. Il manquait simplement que quelque chose soit déclaré côté navigateur.

GitHub Pages n'expose aucun en-tête HTTP : la `<meta>` est le seul vecteur. Elle est posée **avant tout `<link>`** — le préchargeur lance des requêtes dès qu'il croise une balise, et ce qui part avant la lecture de la politique lui échappe.

Le choix qui coûte : **sortir le `<script>` inline**. Le tolérer aurait demandé `'unsafe-inline'` sur `script-src` (la politique devient décorative) ou un hash à recalculer à chaque retouche. `rail.js` reste un script **classique** et non un module : en module il deviendrait différé, s'exécuterait après `app.js`, et le rail clignoterait déplié à chaque chargement.

`'unsafe-inline'` n'est concédé qu'au **style**, parce qu'`app.js` émet des `style=""` par `innerHTML` (barre de score, chevrons et vaisseau de la carte SVG). `style-src-attr` serait plus fin, mais Firefox l'ignore et retomberait sur `style-src` : les barres et le vaisseau y seraient figés.

`img-src 'self' https:` reste large **volontairement** : les photos de vaisseaux viennent de `data/ships.json`, régénéré toutes les 30 min contre l'API UEX qui recopie `url_photo` verbatim. Une liste d'origines figée ferait disparaître les photos en production sans qu'aucun test committé ne le voie.

`frame-ancestors`, `report-uri` et `sandbox` sont **absents à dessein** : ils sont sans effet dans une `<meta>`, et les y écrire ne donnerait qu'une fausse assurance anti-clickjacking.

Deux effets de bord qu'il aurait été coûteux d'oublier, tous deux traités :

- **`sw.js`** : `rail.js` rejoint `SHELL`, sinon la bascule meurt en silence hors-ligne. Et `CACHE` passe en **v5** — la coquille est servie en *stale-while-revalidate* : sans bump, un visiteur déjà installé recevrait encore l'ancien `index.html` (sans CSP, avec l'inline) pendant toute une visite, alors que `rail.js` serait déjà là.
- **`update-data.yml`** : `rail.js` rejoint la ligne `cp`. C'est l'oubli le plus coûteux — les e2e tournent depuis le dépôt, jamais depuis `_site` : la CI resterait verte pendant que le site publié servirait une page au rail mort et un 404 bloqué par la CSP.

## Vérification

Nouveau `scripts/csp.test.mjs` (4 tests), qui verrouille le **couple** politique + fichiers : la directive, sa position avant les `<link>`, l'absence d'inline, et la présence de chaque script dans `SHELL` **et** dans le `cp`. Contre l'`index.html` d'avant la PR, les quatre tombent :

```
✖ index.html porte une CSP — seul vecteur possible sous GitHub Pages
✖ la CSP est déclarée avant tout <link>
✖ aucun <script> inline dans index.html : script-src 'self' le bloquerait
✖ tout script d'index.html est précaché (sw.js) ET copié à l'assemblage
ℹ tests 343 · ℹ pass 339 · ℹ fail 4
```

Après :

```
node --test          ℹ tests 343 · ℹ pass 343 · ℹ fail 0
npx playwright test  92 passed (46.3s)
```

Les 92 e2e sont le vrai juge ici : une CSP trop serrée casse le rendu, et rien dans les tests unitaires ne le verrait. Les deux tests `#59` exercent précisément la bascule du rail, donc `rail.js` chargé et exécuté sous la politique. Référence avant la PR : 339 unitaires, 92 e2e.

## Ce qui n'est pas couvert

- **Aucune vulnérabilité n'est corrigée** : la revue n'a trouvé aucun échappement manquant. Si la CSP mord un jour, ce sera sur du code écrit après elle.
- **`'unsafe-inline'` sur `style-src`** reste ouvert. Le fermer suppose de sortir les trois `style=""` d'`app.js` vers des variables CSS — faisable, mais c'est un autre changement.
- **`img-src https:`** autorise n'importe quelle origine en HTTPS : c'est un arbitrage assumé au profit des photos UEX, pas un oubli.
- La protection anti-cadrage reste **hors de portée** sur Pages (`frame-ancestors` ignoré en `<meta>`, et pas d'en-tête `X-Frame-Options` configurable).
- Aucun test ne vérifie que le navigateur n'émet **aucune violation CSP** en console sur les six vues : les e2e prouvent que l'app fonctionne, pas que la console est vierge.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)
