### PR TITLE
feat(soute): une carte Entrepôts pour le fret déposé, et le rendre à la soute

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,14 @@ Reculer ne revend rien.
 rien** — c'est précisément le cas où elle sert. Le fret quitte la soute sans être vendu : ni perdu,
 ni encaissé, du capital immobilisé qui reste tracé.
 
+Ce fret déposé vit dans une carte **⬓ Entrepôts**, sous la soute : une section par station, le SCU
+et le prix payé par commodité, et le **capital immobilisé** en bas — de l'argent déjà sorti, que
+rien d'autre dans l'app ne rappellerait. Chaque ligne porte un **↑ reprendre** qui remet le lot en
+soute *à son prix payé* : un dépôt suivi d'une reprise rend exactement la soute d'avant. Aucun
+contrôle de position — l'app ne sait pas où ton vaisseau se trouve vraiment, et refuser au motif
+« tu n'y es pas » bloquerait le geste au moment précis où il est vrai ; la station est écrite en
+toutes lettres sur la ligne. La carte disparaît dès qu'il ne reste rien nulle part.
+
 **Où écouler ?** Le panneau classe les destinations par **ce que ça rapporte, prix d'achat déduit** —
 `min(résidu, capacité) × prix`, net des frais, moins ce que les lots consommés ont coûté. Le chiffre
 descend **sous zéro** quand une destination te ferait vendre à perte : c'est une information, pas

--- a/app.js
+++ b/app.js
@@ -14,7 +14,7 @@ import {
   legFromRoute, legsFromLoop, legsFromChain, legFromManifest, stopSuggestions, bestLegBetween,
   manifestJourneyState, manifestIntent, sameIntent, legsToPin, journeyMap,
   loadHold, holdScu, freeCargo, holdByCommodity, sellFromHold, refuseHere, sellableAt, sellAllAt,
-  offloadPlan, storeFromHold, stockApres,
+  offloadPlan, storeFromHold, takeFromStore, stockApres,
   startJourney, startJourneyAt, journeyStations, journeyEnd,
   journeyConnects, addToJourney, setJourneyPosition, currentLeg, journeyMargin,
   removeJourneyStop as removeStopPure,
@@ -1274,8 +1274,53 @@ function deposerIci(nom, units) {
   SOUTE = r.hold; DEPOTS = r.entrepots;
   saveSoute(); saveDepots();
   venteEnCours = null;
-  renderSoute(); refresh();
+  renderSoute(); renderEntrepots(); refresh();
   showToast(`⬓ ${fmt(units)} SCU de ${nom} déposés à ${t.name} — ni vendus ni perdus`);
+}
+
+// Reprendre : le fret déposé remonte à bord avec son prix payé. Aucun contrôle de position — l'app
+// ne sait pas où le vaisseau est RÉELLEMENT, et refuser au motif « tu n'y es pas » bloquerait le
+// geste au moment exact où il est vrai. La station est écrite en toutes lettres sur la ligne :
+// savoir qu'on y est relève de l'utilisateur, pas d'une donnée qu'on n'a pas.
+function reprendreIci(station, nom, units) {
+  const r = takeFromStore(SOUTE, DEPOTS, nom, units, station);
+  if (r.hold === SOUTE) return;
+  const repris = holdScu(r.hold) - holdScu(SOUTE); // ce qui est VRAIMENT revenu, pas ce qu'on demandait
+  SOUTE = r.hold; DEPOTS = r.entrepots;
+  saveSoute(); saveDepots();
+  renderSoute(); renderEntrepots(); refresh();
+  showToast(`◈ ${fmt(repris)} SCU de ${nom} repris à ${parseStationLabel(station).name} — de retour en soute`);
+}
+
+// Les entrepôts : le fret déposé, station par station. Masquée tant que rien n'y dort, comme la
+// soute. Elle ne peut PAS vivre dans renderSoute : celle-ci sort dès que la soute est vide, ce qui
+// est justement le cas le plus fréquent quand on vient de tout déposer.
+// Le capital immobilisé est le chiffre qui compte : de l'argent déjà sorti, que plus rien dans
+// l'app ne rappelait — c'était tout le sujet.
+// Les clés de DEPOTS viennent du localStorage : elles sont échappées comme n'importe quelle donnée
+// tierce (cf. e2e/injection.pw.mjs).
+function renderEntrepots() {
+  const box = $("depotsCard");
+  if (!box) return;
+  const stations = Object.entries(DEPOTS).filter(([, lots]) => Array.isArray(lots) && lots.length);
+  if (!stations.length) { box.hidden = true; return; }
+  box.hidden = false;
+  const tous = stations.flatMap(([, lots]) => lots);
+  const invest = holdByCommodity(tous).reduce((s, g) => s + g.invest, 0);
+  const blocs = stations.map(([label, lots]) => {
+    const { name, system } = parseStationLabel(label);
+    const lignes = holdByCommodity(lots).map((g) => `<div class="hold-line">
+        <span class="hold-name">${esc(g.name)}</span>
+        <span class="hold-scu"><b>${fmt(g.units)}</b> SCU</span>
+        <span class="hold-paid" title="Prix payé au SCU${g.lots.length > 1 ? " (moyenne des lots)" : ""}">@ ${fmt(Math.round(g.paidMoyen))}</span>
+        <button class="depot-take" data-station="${esc(label)}" data-name="${esc(g.name)}" data-units="${g.units}" title="Remettre ces ${fmt(g.units)} SCU en soute, à leur prix payé">↑ reprendre</button>
+      </div>`).join("");
+    return `<div class="depot-station"><div class="depot-lieu">${esc(name)}${sysBadge(system)} <span class="muted">${fmt(holdScu(lots))} SCU</span></div>${lignes}</div>`;
+  }).join("");
+  box.innerHTML =
+    `<div class="hold-head"><span class="hold-title">⬓ Entrepôts</span></div>
+     <div class="depot-stations">${blocs}</div>
+     <div class="hold-meta"><b>${fmt(holdScu(tous))}</b> SCU déposés · capital immobilisé <b>${fmt(invest)}</b> aUEC</div>`;
 }
 
 // « Où écouler ce qui reste ? » — le détour manuel par la vue Commodités, en un panneau.
@@ -1850,6 +1895,7 @@ function renderJourney() {
     const row0 = $("shipJourneyRow"); if (row0) row0.classList.remove("stacked");
     renderJourneyMap();
     renderSoute();
+    renderEntrepots();
     card.innerHTML =
       `<div class="journey-head"><span class="journey-title">◈ Nouveau voyage</span></div>
        <p class="journey-hint">Choisis un trajet (▶) dans une vue, ou démarre de zéro :</p>
@@ -1936,6 +1982,7 @@ function renderJourney() {
   renderJourneyRecap({ n, totalProfit, totalScu, totalFees, systems: new Set(stations.map((s) => s.system)).size });
   renderJourneyMap();
   renderSoute();
+  renderEntrepots();
   ajusterRangeeVoyage(); // après la carte ET la soute : les deux pèsent sur l'équilibre des colonnes
 }
 
@@ -1993,6 +2040,7 @@ function refresh() {
   // le marché et sur les filtres (cf. README). Le coût est celui d'un manifeste par jambe, sur un
   // parcours qui en compte une poignée ; les champs à saisie libre passent déjà par un debounce.
   if (JOURNEY) renderJourney();
+  else renderEntrepots(); // le fret déposé survit à l'effacement du voyage, comme la soute
   saveState();
 }
 const refreshDebounced = debounce(refresh);
@@ -2841,6 +2889,13 @@ async function init() {
     if (!e.target.classList.contains("hold-sell-qty")) return;
     if (e.key === "Enter") { e.preventDefault(); vendreIci(venteEnCours, Number(e.target.value)); }
     else if (e.key === "Escape") { e.preventDefault(); venteEnCours = null; renderSoute(); }
+  });
+  // Entrepôts : « reprendre » remet le lot en soute. Un seul geste, pas de champ de quantité — on
+  // reprend ce qu'on a laissé ; une reprise partielle se ferait en redéposant. La fonction pure,
+  // elle, accepte déjà des SCU : l'UI pourra suivre sans la toucher.
+  $("depotsCard").addEventListener("click", (e) => {
+    const b = e.target.closest(".depot-take");
+    if (b) reprendreIci(b.dataset.station, b.dataset.name, Number(b.dataset.units));
   });
   $("journeyMap").addEventListener("click", (e) => {
     const a = e.target.closest(".jm-arret");

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -620,6 +620,42 @@ test("Soute : déposer à la station libère la place sans vendre", async ({ pag
   expect(tout[0].paid).toBeGreaterThan(0); // ni vendu ni perdu : le capital reste tracé
 });
 
+test("Entrepôts : le fret déposé s'affiche, et « reprendre » le rend à la soute (#10)", async ({ page }) => {
+  // Le dépôt n'existait qu'en localStorage : sans panneau, il était indiscernable d'une perte, et
+  // rien ne permettait de le récupérer — alors que le toast promet « ni vendus ni perdus ».
+  await expect(page.locator("#depotsCard")).toBeHidden();
+  await jambeChargeable(page);
+  await page.locator("#journeyCard .jleg-load").first().click();
+  const avant = await lots(page);
+  const nom = avant[0].name;
+
+  await page.locator("#holdCard .hold-line", { hasText: nom }).locator(".hold-sell-btn").click();
+  await page.locator("#holdCard .hold-sell-qty").fill("5");
+  await page.locator("#holdCard .hold-store").click();
+
+  // La carte apparaît, nomme la station et chiffre le capital immobilisé.
+  await expect(page.locator("#depotsCard")).toBeVisible();
+  await expect(page.locator("#depotsCard")).toContainText("5 SCU");
+  await expect(page.locator("#depotsCard .hold-meta")).toContainText("capital immobilisé");
+  expect(holdScuDe(await lots(page))).toBe(holdScuDe(avant) - 5);
+
+  // Reprendre : le fret revient à bord, la station vidée disparaît, la carte se masque.
+  await page.locator("#depotsCard .depot-take").first().click();
+  expect(holdScuDe(await lots(page))).toBe(holdScuDe(avant));
+  await expect(page.locator("#depotsCard")).toBeHidden();
+  const depotsApres = JSON.parse(await page.evaluate(() => localStorage.getItem("best-hauling-depots") || "{}"));
+  expect(Object.keys(depotsApres)).toEqual([]);
+
+  // Et il survit à un rechargement : c'est du fret réel, pas un état de vue.
+  await page.locator("#holdCard .hold-line", { hasText: nom }).locator(".hold-sell-btn").click();
+  await page.locator("#holdCard .hold-sell-qty").fill("3");
+  await page.locator("#holdCard .hold-store").click();
+  await expect(page.locator("#depotsCard")).toBeVisible();
+  await page.reload();
+  await expect(page.locator("#depotsCard")).toBeVisible({ timeout: 8000 });
+  await expect(page.locator("#depotsCard")).toContainText("3 SCU");
+});
+
 test("Soute : reculer d'une étape ne revend rien", async ({ page }) => {
   // Revenir sur ses pas n'est pas une transaction : seule l'AVANCÉE vaut « j'ai fait mon affaire ».
   await jambeChargeable(page);

--- a/index.html
+++ b/index.html
@@ -150,6 +150,12 @@
             <!-- La soute : ce qui est à bord et ce qu'on l'a payé (ADR-002). Affichée en permanence
                  tant qu'elle n'est pas vide — c'est ce rappel qui remplace une date de péremption. -->
             <aside id="holdCard" class="hold-card" hidden></aside>
+
+            <!-- Les entrepôts : le fret DÉPOSÉ à une station. Sous la soute et dans la même
+                 colonne, pour la même raison qu'elle : ce n'est pas un plan, c'est du fret réel
+                 déjà payé. Masquée tant qu'aucun dépôt n'existe — sinon elle occuperait la colonne
+                 pour rien, et pèserait sur l'équilibre calculé par ajusterRangeeVoyage. -->
+            <aside id="depotsCard" class="hold-card depots-card" hidden></aside>
           </div>
 
           <aside id="journeyCard" class="journey-card" hidden></aside>

--- a/logic.mjs
+++ b/logic.mjs
@@ -1479,6 +1479,23 @@ export function storeFromHold(hold, entrepots, name, units, station) {
   return { hold: r.hold, entrepots: { ...entrepots, [station]: deja.concat(r.lots) } };
 }
 
+// Reprend `units` SCU d'une commodité DÉPOSÉE à une station : elle repasse en soute avec son prix
+// payé intact. Duale exacte de storeFromHold — un dépôt suivi d'une reprise doit rendre la soute
+// d'avant, sinon le capital immobilisé devient un capital perdu, et déposer redevient un piège.
+// Un lot d'entrepôt a la forme d'un lot de soute : sellFromHold sait donc déjà les consommer en
+// FIFO, à recette nulle — reprendre n'est pas une vente, c'est le dépôt joué à l'envers.
+// La station vidée DISPARAÎT plutôt que de laisser un entrepôt à zéro : il s'afficherait comme un
+// lieu où l'on a du fret.
+export function takeFromStore(hold, entrepots, name, units, station) {
+  const stock = entrepots[station];
+  if (!stock || !stock.length) return { hold, entrepots };
+  const r = sellFromHold(stock, name, units, 0); // même consommation FIFO, sans recette
+  if (!r.vendu) return { hold, entrepots };
+  const suivant = { ...entrepots };
+  if (r.hold.length) suivant[station] = r.hold; else delete suivant[station];
+  return { hold: hold.concat(r.lots), entrepots: suivant };
+}
+
 // ---------- Carte 2D du parcours (cf. ADR-001) ----------
 // Projection PURE d'un parcours en coordonnées de dessin. app.js n'a plus qu'à émettre du SVG.
 // La géométrie vient de data/starmap.json : `au` (distance à l'étoile) et `lon` (degrés), relevés

--- a/logic.test.mjs
+++ b/logic.test.mjs
@@ -17,7 +17,7 @@ import {
   legFromRoute, legsFromLoop, legsFromChain, legFromManifest, stopSuggestions, bestLegBetween,
   manifestJourneyState, manifestIntent, sameIntent, legsToPin,
   journeyMap, nameAngle, CARTE, nomPasserelle,
-  loadHold, holdScu, freeCargo, holdByCommodity, sellFromHold, storeFromHold,
+  loadHold, holdScu, freeCargo, holdByCommodity, sellFromHold, storeFromHold, takeFromStore,
   refuseHere, sellableAt, sellAllAt, offloadPlan, stockApres,
   startJourney, startJourneyAt, journeyStations, journeyEnd,
   journeyConnects, addToJourney, setJourneyPosition, currentLeg, journeyMargin,
@@ -2151,6 +2151,32 @@ test("storeFromHold : déposer libère la soute SANS vendre, et garde le capital
   assert.equal(r.entrepots["Ruin Station — Pyro"][0].paid, 1000); // ni vendu ni perdu : immobilisé
   // Un dépôt qui ne consomme rien ne crée pas d'entrepôt fantôme.
   assert.deepEqual(storeFromHold(h, {}, "Inconnue", 10, "X").entrepots, {});
+});
+
+test("takeFromStore : reprendre rend le lot à la soute avec son prix payé, et vide la station", () => {
+  // Duale de storeFromHold : sans elle, déposer est un aller simple et le capital « immobilisé »
+  // est en fait perdu. Le tour complet dépôt -> reprise doit rendre la soute d'avant, à l'unité.
+  const h = loadHold([], [ligne(2200, 1000, 1400)], "Megumi", 1);
+  const depose = storeFromHold(h, {}, "Gold", 2170, "Ruin Station — Pyro");
+
+  // Reprise PARTIELLE : la station garde le reste, elle ne disparaît pas.
+  const p = takeFromStore(depose.hold, depose.entrepots, "Gold", 170, "Ruin Station — Pyro");
+  assert.equal(holdScu(p.hold), 200);                                 // 30 restés à bord + 170 repris
+  assert.equal(holdScu(p.entrepots["Ruin Station — Pyro"]), 2000);
+  assert.equal(p.hold.at(-1).paid, 1000);                             // le prix payé revient intact
+
+  // Reprise TOTALE : la soute d'avant le dépôt est rendue, et l'entrepôt vidé s'efface — une
+  // station à zéro s'afficherait comme un lieu où l'on a du fret.
+  const t = takeFromStore(depose.hold, depose.entrepots, "Gold", 2170, "Ruin Station — Pyro");
+  assert.equal(holdScu(t.hold), holdScu(h));
+  assert.deepEqual(t.entrepots, {});
+
+  // Pure : les deux appels ont lu le MÊME entrepôt, qui n'a pas bougé.
+  assert.equal(depose.entrepots["Ruin Station — Pyro"][0].units, 2170);
+
+  // Rien à reprendre : ni station inconnue, ni commodité absente ne fabriquent quoi que ce soit.
+  assert.deepEqual(takeFromStore([], depose.entrepots, "Gold", 10, "Nulle part").hold, []);
+  assert.deepEqual(takeFromStore([], depose.entrepots, "Inconnue", 10, "Ruin Station — Pyro").hold, []);
 });
 
 // ---------- Carte 2D du parcours (ADR-001) ----------

--- a/style.css
+++ b/style.css
@@ -439,6 +439,22 @@ input.jman-qty { width: 56px; min-width: 0; padding: 3px 5px; text-align: right;
 .hold-meta { margin-top: 10px; padding-top: 9px; border-top: 1px solid var(--line); font-size: 11px; color: var(--muted); font-variant-numeric: tabular-nums; }
 .hold-meta b { color: var(--text); }
 
+/* ---------- Les entrepôts : le fret déposé ---------- */
+/* Mêmes classes de ligne que la soute : c'est le même objet (des lots), il se lit pareil. Seule la
+   teinte change — violette, celle des panneaux qui ne décrivent pas ce qui est À BORD. Confondre
+   les deux serait recompter le fret déposé dans la place disponible. */
+.depots-card { border-left-color: var(--acc-2); }
+.depots-card .hold-title { color: var(--acc-2); }
+.depot-stations { display: flex; flex-direction: column; gap: 11px; }
+.depot-lieu { display: flex; align-items: center; gap: 6px; font-size: 11.5px; margin-bottom: 5px; }
+.depot-take {
+  margin-left: auto; font-family: var(--font); font-size: 10.5px; white-space: nowrap;
+  color: var(--acc-2); background: rgba(169, 112, 255, 0.1);
+  border: 1px solid rgba(169, 112, 255, 0.4); border-radius: 3px; padding: 2px 7px; cursor: pointer;
+}
+.depot-take:hover { background: rgba(169, 112, 255, 0.2); }
+.depot-take:focus-visible { outline: 2px solid var(--acc-2); outline-offset: 1px; }
+
 /* « ✓ chargé » sur la jambe : le moment où l'intention devient un fait. Vert quand c'est à bord. */
 .jleg-load {
   font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.5px; text-transform: uppercase;


### PR DESCRIPTION
## Ce que ça change

Le fret déposé à une station a enfin une carte : **⬓ Entrepôts**, sous la soute. Une section par station, le SCU et le prix payé par commodité, le **capital immobilisé** en bas — et un **↑ reprendre** par ligne, qui remet le lot en soute à son prix payé.

## Pourquoi

`⬓ Déposer` écrivait dans `DEPOTS` (`app.js:1268`), le store était relu au démarrage (`loadDepots`)… et **aucune vue ne le lisait jamais**. Le fret quittait l'écran pour de bon : ni dans la soute, ni ailleurs, impossible à voir ni à récupérer. Le toast promettait « ni vendus ni perdus » et le README « du capital immobilisé qui reste tracé » — c'était vrai du localStorage, pas de l'application.

La partie pure existait déjà à moitié : `storeFromHold` était écrit et testé, mais **sans duale**. Déposer était donc un aller simple, et le capital « immobilisé » en fait perdu. `takeFromStore` la complète, et c'est là que se joue la correction : un lot d'entrepôt a exactement la forme d'un lot de soute, donc `sellFromHold` sait déjà les consommer en FIFO — reprendre n'est pas une vente, c'est **le dépôt joué à l'envers**, à recette nulle. Le test verrouille le tour complet : dépôt → reprise rend la soute d'avant, à l'unité et au prix payé.

Trois décisions valent d'être dites :

- **Aucun contrôle de position.** L'app ne sait pas où le vaisseau est réellement ; refuser la reprise au motif « tu n'y es pas » bloquerait le geste au moment exact où il est vrai. La station est écrite en toutes lettres sur la ligne : savoir qu'on y est relève de l'utilisateur, pas d'une donnée qu'on n'a pas.
- **Une station vidée disparaît** plutôt que de laisser un entrepôt à zéro — il se lirait comme un lieu où l'on a du fret.
- **La carte ne peut pas vivre dans `renderSoute`**, qui sort dès que la soute est vide : c'est précisément le cas le plus fréquent quand on vient de tout déposer. D'où un `renderEntrepots()` appelé aux mêmes trois endroits que `renderSoute()`, y compris la branche « sans voyage » de `refresh()` — le fret déposé survit à `#journeyClear`, exactement comme la soute.

Pas de champ de quantité : on reprend ce qu'on a laissé, et une reprise partielle se ferait en redéposant. La fonction pure accepte déjà des SCU, donc l'UI pourra suivre sans qu'on la touche.

## Vérification

Test rouge d'abord (`e2e/smoke.pw.mjs:623`), sources revenues à l'état de `main` :

```
Error: expect(locator).toBeVisible() failed
  Expected: visible / element(s) not found     ← #depotsCard n'existe pas
1 failed
```

Après :

```
node --test          ℹ tests 340 · ℹ pass 340 · ℹ fail 0
npx playwright test  93 passed (42.8s)
```

Référence avant la PR : 339 unitaires, 92 e2e. Le test unitaire couvre la fonction pure (reprise partielle, reprise totale, station effacée, pureté, et les deux cas « rien à reprendre ») ; l'e2e couvre l'affichage, le geste, et la survie au rechargement — c'est ce qui manquait, le calcul étant déjà juste.

## Ce qui n'est pas couvert

- **Pas de reprise partielle à l'écran** : le bouton reprend tout le lot d'une commodité à une station. La fonction pure prend déjà des SCU, l'UI pourra suivre.
- **Le fret déposé n'entre dans aucun calcul** : ni `offloadPlan` (« où écouler » ne raisonne que sur ce qui est à bord), ni le récap du voyage. C'est délibéré — il n'est pas dans la soute — mais discutable pour le récap, où le capital immobilisé pourrait légitimement figurer.
- **Aucune péremption, aucune limite de capacité** : l'app ne modélise pas les inventaires de station et ne saurait pas dire si le jeu a repris le fret.
- `at` et `leg` ne sont pas restitués au retour en soute : ils étaient déjà perdus au dépôt, et `at` n'est lu nulle part.

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)
