### PR TITLE
feat(trajets): un ▶ visible, et un dépliant qui ne montre plus que le chargement

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Six vues, un même moteur de calcul (soute SCU + budget aUEC → unités, coût,
 
 | Vue | Ce qu'elle fait |
 |-----|-----------------|
-| **Trajets simples** | Meilleures routes A→B, triables, avec un **score de fiabilité** composite (rentabilité × fraîcheur × disponibilité) par défaut. Coche **Multi commodité** : liste plutôt les **chargements combinés** (plusieurs commodités d'un même A vers un même B), dépliables (🗺) pour voir le détail par commodité |
+| **Trajets simples** | Meilleures routes A→B, triables, avec un **score de fiabilité** composite (rentabilité × fraîcheur × disponibilité) par défaut. Coche **Multi commodité** : liste plutôt les **chargements combinés** (plusieurs commodités d'un même A vers un même B), dépliables (📦) pour voir le détail par commodité |
 | **Boucles ⇄** | Meilleures boucles A⇄B (une commodité à l'aller, une autre au retour) pour ne jamais repartir à vide |
 | **En route 🧭** | Depuis un terminal de départ : le fret rentable + un **manifeste optimal** qui remplit la soute avec **plusieurs commodités** vers une même destination (avec suggestions pour combler l'espace libre) |
 | **Chaîne ⛓️** | Trajets **multi-sauts A→B→C…** (2 à 4 sauts) : achète, vends, rachète sur place, revends plus loin — recherche par faisceau du circuit le plus rentable. Chaque saut retient la commodité qui **rapporte** le plus une fois plafonnée par le stock et la demande, pas celle à la plus forte marge affichée |
@@ -45,7 +45,7 @@ signe et **en rouge**, jamais dans le vert des gains.
 - **Mode Butin** (vue Commodités) : quand le coût d'acquisition est nul, la marge n'a plus de sens — seul compte le **prix de revente**. Ce mode liste **tout ce qui se vend** chez UEX, y compris les ~36 commodités sans aucun point d'achat, et n'affiche que **où l'écouler**. Sa heatmap se calcule **par rang** et non par ratio : les prix de revente s'étalent sur cinq ordres de grandeur (34 M aUEC/SCU pour le Saldynium contre 1 000 pour l'Iron Ore), une échelle linéaire écraserait tout le board.
 - **Décomposition SCU en caisses** (32/24/16/8/4/2/1) sur le manifeste et en infobulle.
 - **Manifeste ajustable** : chaque ligne se modifie à la main — tu peux **dépasser le stock UEX** (vol de fret, relevé périmé…) ; le champ passe en ambre pour le signaler.
-- **Schéma de trajet** dépliable (🗺) : système › planète › terminal, type de saut, temps estimé.
+- **Détail du chargement** dépliable (📦), sur les lignes **multi commodité** : ce que contient le chargement, commodité par commodité (stock, demande, prix, marge, profit, caisses). Les autres tables n'ont pas de dépliant — la **carte du parcours** y montre la géographie, et le temps estimé se lit en infobulle de « Profit/heure ».
 - **Fiabilité des données** : pastille d'âge par relevé, filtre de fraîcheur (< 24 h / 3 j / 7 j), point de statut d'inventaire, tag « à vérifier », bandeau global « données d'il y a X h ».
 - **Filtres** : commodité, système, même système uniquement, exclure les avant-postes, commodités légales uniquement, limiter au stock & à la demande UEX. Ils ne s'appliquent pas tous à toutes les vues — voir la **[matrice ci-dessous](#portée-des-filtres-par-vue)**.
 - **Permaliens & persistance** : l'état (filtres, tri, vue, vaisseau) est mémorisé (localStorage) et encodé dans l'URL → bouton **Partager**.
@@ -409,7 +409,7 @@ Les relevés bruts et le raisonnement complet sont dans
   strictement inchangés). Runner intégré `node --test`, **zéro dépendance**.
 - **E2E de fumée** ([`e2e/smoke.pw.mjs`](e2e/smoke.pw.mjs), Playwright) : non-régression des bugs vécus
   (carte vaisseau au reload, demande corrigée à 0, contrôles qui ne fuient plus, persistance des corrections,
-  navigation, schéma) et **cohérence des filtres par vue** (« légales » agit sur Trajets/Boucles/Commodités,
+  navigation, cible tactile du ▶, dépliant de chargement) et **cohérence des filtres par vue** (« légales » agit sur Trajets/Boucles/Commodités,
   « même système » contraint la Chaîne). Playwright est une dépendance **de dev uniquement** — le site livré reste sans dépendance.
 - **CI** ([`ci.yml`](.github/workflows/ci.yml)) : unitaires + E2E sur chaque push/PR.
 

--- a/app.js
+++ b/app.js
@@ -520,7 +520,7 @@ function multiRowHTML(t, i) {
   return `
       <tr data-row="${i}">
         <td class="loc">
-          <div class="commodity-cell"><button class="route-toggle" data-row="${i}" title="Voir le chargement" aria-label="Voir le chargement">🗺</button><button class="journey-pick" data-row="${i}" title="Faire ce trajet — compagnon de voyage" aria-label="Sélectionner ce trajet">▶</button><span class="multi-icons" title="${esc(names)}">${icons}${more}</span><span class="cname">${n} commodité${n > 1 ? "s" : ""}</span></div>
+          <div class="commodity-cell"><button class="journey-pick" data-row="${i}" title="Faire ce trajet — compagnon de voyage" aria-label="Sélectionner ce trajet">▶</button><button class="route-toggle" data-row="${i}" title="Voir le chargement" aria-label="Voir le chargement">📦</button><span class="multi-icons" title="${esc(names)}">${icons}${more}</span><span class="cname">${n} commodité${n > 1 ? "s" : ""}</span></div>
           <div class="loc-badges">${t.lines.some((l) => l.illegal) ? illegalTag(true) : ""}${cross}</div>
         </td>
         <td class="loc">
@@ -544,11 +544,13 @@ function multiRowHTML(t, i) {
       </tr>`;
 }
 
-// Détail déplié d'un trajet multi-commodité : schéma départ→arrivée + chargement ligne par ligne.
-function multiSchemaHTML(t) {
-  const info = `${t.cross ? "⚡ saut inter-système" : "même système"} · ~${Math.round(t.minutes)} min`;
-  const end = (x) => ({ system: x.system, planet: x.planet, terminal: x.name, outpost: x.outpost });
-  const schema = `<div class="schema">${schemaLeg("Départ", end(t.origin))}<div class="schema-arrow"><span class="al">⟶</span><span class="ai">${info}</span></div>${schemaLeg("Arrivée", end(t.dest))}</div>`;
+// Détail déplié d'un trajet multi-commodité : le CHARGEMENT, ligne par ligne — et rien d'autre.
+// Il portait aussi un schéma « système › planète › terminal », retiré avec les autres dépliants
+// (#30) : la carte 2D du parcours montre la même géographie. Ce dépliant-ci survit parce que la
+// carte, elle, n'affiche aucun chiffre — c'est le seul endroit qui dit ce que contient une ligne
+// « 3 commodités ». La durée du trajet, qui vivait dans le schéma, reste lisible dans l'infobulle
+// de la colonne « Profit/heure ».
+function multiCargoHTML(t) {
   const lines = t.lines.map((l) =>
     `<div class="sline">${commodityIcon(l.kind)}` +
     `<span class="mname">${esc(l.name)}${illegalTag(l.illegal)}</span>` +
@@ -557,27 +559,7 @@ function multiSchemaHTML(t) {
     `<span class="mprofit profit">${lineProfitText(l.units, l, t.fee)}</span>` +
     `<span class="mboxes" title="Caisses SCU standard à charger">📦 ${fmt(l.units)} SCU · ${scuBoxesLabel(l.units, t.origin.maxBox)}</span></div>`
   ).join("");
-  return `${schema}<div class="multi-cargo"><div class="suggest-head">Chargement — ${t.lines.length} commodité${t.lines.length > 1 ? "s" : ""}, ${fmt(t.units)}/${fmt(t.cargo)} SCU</div>${lines}</div>`;
-}
-
-// Un « nœud » du schéma (système › planète › terminal), réutilisé départ/arrivée.
-function schemaLeg(label, end) {
-  const nodes = [`<span class="sys ${esc(end.system.toLowerCase())}">${esc(end.system)}</span>`];
-  if (end.planet) nodes.push(`<span class="snode">${esc(end.planet)}</span>`);
-  nodes.push(`<span class="snode term">${esc(end.terminal)}</span>${end.outpost ? outpostTag(true) : ""}`);
-  return `<div class="schema-leg"><span class="schema-label">${label}</span><div class="schema-path">${nodes.join('<span class="sep">›</span>')}</div></div>`;
-}
-
-// Schéma d'un trajet simple : Départ (sys›planète›terminal) ⟶ Arrivée.
-function routeSchemaHTML(r) {
-  const info = `${r.same_system ? "même système" : "⚡ saut inter-système"} · ~${Math.round(r.minutes)} min${r.distance ? ` · ${fmt(r.distance)} u` : ""}`;
-  return `<div class="schema">${schemaLeg("Départ", r.buy)}<div class="schema-arrow"><span class="al">⟶</span><span class="ai">${info}</span></div>${schemaLeg("Arrivée", r.sell)}</div>`;
-}
-
-// Schéma d'une boucle : A ⇄ B.
-function loopSchemaHTML(l) {
-  const info = `${l.cross ? "⚡ inter-système" : "même système"} · ~${Math.round(l.minutes)} min (A/R)`;
-  return `<div class="schema">${schemaLeg("A", l.a)}<div class="schema-arrow"><span class="al">⇄</span><span class="ai">${info}</span></div>${schemaLeg("B", l.b)}</div>`;
+  return `<div class="multi-cargo"><div class="suggest-head">Chargement — ${t.lines.length} commodité${t.lines.length > 1 ? "s" : ""}, ${fmt(t.units)}/${fmt(t.cargo)} SCU</div>${lines}</div>`;
 }
 
 // Ligne de tableau pour une route évaluée (partagée par « Trajets simples » et « En route »).
@@ -592,7 +574,7 @@ function routeRowHTML(r, i) {
   return `
       <tr data-row="${i}">
         <td class="loc">
-          <div class="commodity-cell"><button class="route-toggle" data-row="${i}" title="Voir le trajet" aria-label="Voir le trajet">🗺</button><button class="journey-pick" data-row="${i}" title="Faire ce trajet — compagnon de voyage" aria-label="Sélectionner ce trajet">▶</button>${commodityIcon(r.kind)}<span class="cname">${esc(r.commodity)}</span></div>
+          <div class="commodity-cell"><button class="journey-pick" data-row="${i}" title="Faire ce trajet — compagnon de voyage" aria-label="Sélectionner ce trajet">▶</button>${commodityIcon(r.kind)}<span class="cname">${esc(r.commodity)}</span></div>
           <div class="loc-badges">${illegalTag(r.illegal)}${suspectTag(r)}${cross}</div>
         </td>
         <td class="loc">
@@ -661,7 +643,6 @@ function renderLoops() {
       return `
       <tr data-row="${i}"${l._fromHere ? ' class="from-here"' : ""}>
         <td class="loc loop-cell">
-          <button class="route-toggle" data-row="${i}" title="Voir le trajet" aria-label="Voir le trajet">🗺</button>
           <button class="journey-pick" data-row="${i}" title="Ajouter cette boucle au voyage" aria-label="Ajouter au voyage">▶</button>
           <div class="loop-ends">
             <div class="loop-end"><span class="term-name">${esc(l.a.terminal)}</span>${sysBadge(l.a.system)}${outpostTag(l.a.outpost)}</div>
@@ -2897,20 +2878,22 @@ async function init() {
   $("manifest").addEventListener("keydown", (e) => {
     if (e.target.id === "manifestAddInput" && e.key === "Enter") { e.preventDefault(); addManifestCommodity(e.target.value); }
   });
-  // Schéma de trajet : déplie/replie une ligne détaillée sous la ligne cliquée.
+  // Chargement d'un trajet multi-commodité : déplie/replie le manifeste sous la ligne cliquée.
+  // Seule table à porter encore un dépliant (#30) — ailleurs la carte 2D du parcours montre la
+  // géographie que le schéma répétait.
   document.addEventListener("click", (e) => {
     const btn = e.target.closest(".route-toggle");
     if (!btn) return;
     const tr = btn.closest("tr");
     const next = tr.nextElementSibling;
     if (next && next.classList.contains("schema-row")) { next.remove(); btn.classList.remove("open"); return; }
-    const tableId = btn.closest("table").id;
-    const multi = tableId === "routes" && isMultiRoutes();
-    const arr = tableId === "loops" ? shownLoops : tableId === "enroute" ? shownEnroute : multi ? shownMulti : shownRoutes;
-    const item = arr[Number(btn.dataset.row)];
+    // Le bouton n'est émis que par les lignes multi. Si la vue n'y est plus au moment du clic
+    // (marché encore en chargement, cf. #25), on ne déplie rien plutôt que d'indexer `shownMulti`
+    // avec le numéro de ligne d'un autre tableau.
+    if (!isMultiRoutes()) return;
+    const item = shownMulti[Number(btn.dataset.row)];
     if (!item) return;
-    const html = tableId === "loops" ? loopSchemaHTML(item) : multi ? multiSchemaHTML(item) : routeSchemaHTML(item);
-    tr.insertAdjacentHTML("afterend", `<tr class="schema-row"><td colspan="${tr.children.length}">${html}</td></tr>`);
+    tr.insertAdjacentHTML("afterend", `<tr class="schema-row"><td colspan="${tr.children.length}">${multiCargoHTML(item)}</td></tr>`);
     btn.classList.add("open");
   });
   // Carte du parcours : cliquer une escale déplace « je suis ici », comme le fil d'étapes.

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -94,10 +94,53 @@ test("correction locale : marqueur ✎, compteur, et persistance au rechargement
   await expect(page.locator("#rows .editv.ov").first()).toBeVisible();            // marqueur conservé
 });
 
-test("le schéma de trajet se déplie puis se replie", async ({ page }) => {
+test("▶ tient la cible tactile minimale (#29)", async ({ page }) => {
+  // ▶ est l'action PRINCIPALE d'une ligne : c'est lui qui démarre le compagnon de voyage. Il
+  // mesurait 20×20 px pour un glyphe de 9 px — sous les 24×24 exigés par WCAG 2.2 SC 2.5.8
+  // (niveau AA), et plus petit que le dépliant qui n'était que secondaire. Le seuil testé est
+  // la règle, pas la taille retenue (30×30) : c'est la règle qui ne doit jamais régresser.
+  const b = await page.locator("#rows .journey-pick").first().boundingBox();
+  expect(b.width).toBeGreaterThanOrEqual(24);
+  expect(b.height).toBeGreaterThanOrEqual(24);
+});
+
+test("plus de dépliant 🗺 là où la carte du voyage montre déjà la géographie (#30)", async ({ page }) => {
+  // Trajets simples et En route sortent tous deux de routeRowHTML : une seule suppression couvre
+  // les deux tables. Les boucles ont leur propre rendu, d'où la seconde vérification.
+  await expect(page.locator("#rows .route-toggle")).toHaveCount(0);
+  await page.click("#viewLoops");
+  await expect(page.locator("#loops tr").first()).toBeVisible();
+  await expect(page.locator("#loops .route-toggle")).toHaveCount(0);
+});
+
+test("multi-commodité : ▶ reste le seul bouton plein de la ligne, dépliant ouvert (#29)", async ({ page }) => {
+  // Le ▶ ayant pris le remplissage plein, l'état ouvert du dépliant ne peut plus le prendre aussi :
+  // deux carrés ambre pleins côte à côte annulent la hiérarchie qu'on vient d'établir, et l'emoji
+  // 📦 — glyphe en couleurs, que `color` ne repeint pas — devient illisible sur fond ambre.
+  await page.check("#multiCommodity");
   await page.locator("#rows tr:first-child .route-toggle").click();
-  await expect(page.locator("#rows tr.schema-row .schema")).toBeVisible();
-  await expect(page.locator("#rows tr.schema-row .schema-leg")).toHaveCount(2);
+  // `.route-toggle` porte une transition de 0,12 s sur `background` : lue tout de suite, la valeur
+  // calculée est celle du DÉPART, et l'assertion passait sans rien prouver. On attend donc la fin
+  // des animations des deux boutons — expect.poll ne conviendrait pas non plus, il s'arrête au
+  // PREMIER échantillon conforme, c'est-à-dire encore en pleine transition.
+  const memeFond = await page.evaluate(async () => {
+    const c = document.querySelector("#rows tr:first-child .commodity-cell");
+    const t = c.querySelector(".route-toggle.open"), p = c.querySelector(".journey-pick");
+    await Promise.all([...t.getAnimations(), ...p.getAnimations()].map((a) => a.finished.catch(() => {})));
+    return getComputedStyle(t).backgroundColor === getComputedStyle(p).backgroundColor;
+  });
+  expect(memeFond).toBe(false);
+});
+
+test("multi-commodité : le dépliant garde le chargement, et lui seul (#30)", async ({ page }) => {
+  // Seule table où le dépliant ne fait PAS doublon : la carte du voyage n'affiche aucun chiffre,
+  // et c'est le seul endroit qui dit ce que contient une ligne « 3 commodités ».
+  await page.check("#multiCommodity");
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+  await page.locator("#rows tr:first-child .route-toggle").click();
+  const detail = page.locator("#rows tr.schema-row");
+  await expect(detail.locator(".sline").first()).toBeVisible();
+  await expect(detail.locator(".schema")).toHaveCount(0); // la géographie part avec le doublon
   await page.locator("#rows tr:first-child .route-toggle").click();
   await expect(page.locator("#rows tr.schema-row")).toHaveCount(0);
 });

--- a/style.css
+++ b/style.css
@@ -269,13 +269,20 @@ input::placeholder { color: var(--muted); }
 .ship-card-scu b { color: var(--good); }
 
 /* ---------- Compagnon de voyage : résumé du parcours + bouton ▶ ---------- */
-/* ▶ encadré pour bien lire « bouton » (sélectionne / ajoute au voyage). */
+/* ▶ est l'action PRINCIPALE d'une ligne : c'est lui qui démarre le compagnon de voyage. Il faisait
+   20×20 px pour un glyphe de 9 px — sous les 24×24 exigés par WCAG 2.2 SC 2.5.8 (niveau AA), et
+   plus petit que le dépliant secondaire d'à côté (#29). Il passe à 30×30 et prend le remplissage
+   plein que le dépôt réserve à ce qui est actif (.vbtn.active, .route-toggle.open) : le contour
+   restait au bouton secondaire. */
 .journey-pick {
-  display: inline-grid; place-items: center; flex-shrink: 0; width: 20px; height: 20px; padding: 0;
-  color: var(--acc); background: rgba(255, 176, 32, 0.08); border: 1px solid var(--line2); border-radius: 3px;
-  cursor: pointer; font-size: 9px; line-height: 1;
+  display: inline-grid; place-items: center; flex-shrink: 0; width: 30px; height: 30px; padding: 0;
+  color: #1a1000; background: var(--acc); border: 1px solid var(--acc); border-radius: 3px;
+  cursor: pointer; font-size: 14px; line-height: 1;
+  transition: background 0.12s, border-color 0.12s;
 }
-.journey-pick:hover { background: rgba(255, 176, 32, 0.22); color: #fff; }
+.journey-pick:hover { background: #ffcf6b; border-color: #ffcf6b; }
+.journey-pick:focus-visible { outline: 2px solid var(--acc-2); outline-offset: 1px; }
+@media (prefers-reduced-motion: reduce) { .journey-pick { transition: none; } }
 /* Vaisseau + Voyage côte à côte : colonne de gauche (vaisseau + récap) | carte Voyage à droite.
    align-items: flex-start -> le vaisseau garde sa hauteur naturelle (image jamais étirée). */
 .ship-journey-row { display: flex; flex-wrap: wrap; gap: 14px; align-items: flex-start; margin: 16px 0 0; }
@@ -676,27 +683,25 @@ tbody tr:hover td { border-bottom-color: var(--line2); }
 .ovmark { font-size: 9px; margin-left: 2px; vertical-align: super; }
 input.editv-input { width: 80px; min-width: 0; padding: 2px 5px; font-size: 12px; font-family: var(--mono); text-align: right; background: rgba(8, 11, 20, 0.95); border: 1px solid var(--acc); color: var(--text); border-radius: 3px; }
 
-/* Bouton schéma */
+/* Bouton « voir le chargement » — lignes multi-commodité uniquement (#30). */
 .route-toggle {
   flex-shrink: 0; width: 24px; height: 24px; padding: 0; display: grid; place-items: center; font-size: 12px; line-height: 1;
   background: rgba(255, 255, 255, 0.04); border: 1px solid var(--line2); border-radius: 4px; cursor: pointer; color: var(--muted);
   transition: color 0.12s, border-color 0.12s, background 0.12s;
 }
 .route-toggle:hover { color: var(--acc); border-color: var(--acc); }
-.route-toggle.open { color: #04120a; background: var(--acc); border-color: var(--acc); }
+/* Ouvert, ce bouton prenait le remplissage ambre plein. Il ne le peut plus : le ▶ voisin l'a pris
+   (#29), et deux carrés pleins côte à côte annulent la hiérarchie. L'état actif se dit donc ici en
+   CONTOUR — d'autant que le glyphe est un emoji, que `color` ne repeint pas : sur fond ambre plein,
+   📦 devenait illisible. */
+.route-toggle.open { color: var(--acc); background: rgba(255, 176, 32, 0.14); border-color: var(--acc); }
 
+/* La rangée dépliée reste : elle porte désormais le seul chargement. Les règles du schéma
+   géographique (.schema, .schema-leg, .schema-label, .schema-path, .schema-arrow) sont parties
+   avec lui (#30). .snode survit : la vue Chaîne s'en sert encore pour ses terminaux. */
 .schema-row > td { background: rgba(255, 176, 32, 0.03); padding: 0; }
-/* Départ / Arrivée (ou A / B) sur des lignes DISTINCTES, libellés de MÊME largeur. */
-.schema { display: grid; grid-template-columns: 1fr; gap: 12px; padding: 18px 22px; border-left: 2px solid var(--acc); }
-.schema-leg { display: grid; grid-template-columns: 74px 1fr; align-items: baseline; gap: 14px; }
-.schema-label { font-size: 9.5px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--acc); font-weight: 600; }
-.schema-path { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; }
-.schema-path .sep { color: var(--line2); font-size: 14px; }
 .snode { padding: 4px 10px; border-radius: 3px; font-size: 13px; background: rgba(255, 255, 255, 0.03); border: 1px solid var(--line); color: var(--muted); }
 .snode.term { color: #fff; border-color: var(--line2); font-weight: 600; }
-.schema-arrow { display: flex; flex-direction: row; align-items: center; gap: 10px; padding-left: 88px; color: var(--muted); }
-.schema-arrow .al { font-size: 22px; color: var(--acc); line-height: 1; }
-.schema-arrow .ai { font-size: 10px; font-family: var(--mono); white-space: nowrap; }
 
 /* Score */
 .score-cell { display: flex; align-items: center; justify-content: center; gap: 8px; white-space: nowrap; }
@@ -993,5 +998,8 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 .multi-icons { display: inline-flex; align-items: center; gap: 2px; margin-right: 4px; }
 .multi-icons .muted { font-size: 10px; }
 /* Chargement détaillé (dépliage 🗺) : même grille que les suggestions, + une colonne caisses. */
-.multi-cargo { margin-top: 10px; border-top: 1px solid var(--line); }
+/* Le chargement est désormais SEUL dans la rangée dépliée : il y reprend le liseré ambre et le
+   retrait que .schema portait au-dessus de lui (#30). Le trait supérieur, qui ne servait qu'à l'en
+   séparer, n'a plus rien à séparer. */
+.multi-cargo { border-left: 2px solid var(--acc); padding: 8px 0; }
 .multi-cargo .sline { grid-template-columns: auto 1fr auto auto auto auto; }


### PR DESCRIPTION
## Ce que ça change

Le bouton **▶** de chaque ligne — celui qui démarre le compagnon de voyage — devient nettement plus grand (30×30 au lieu de 20×20) et passe en ambre plein : on le vise sans effort, et on voit tout de suite que c'est lui, l'action de la ligne.

Le dépliant **🗺** disparaît des trajets simples, d'En route et des boucles, où la carte du parcours montre déjà la même géographie. Il reste sur les lignes **multi commodité**, en **📦 « Voir le chargement »**, et n'y déplie plus que le manifeste — ce que la carte, elle, ne sait pas dire.

## Pourquoi

**Le ▶ (#29).** Cause racine `style.css:273` : `.journey-pick { width: 20px; height: 20px; font-size: 9px }`. Deux défauts distincts — 20×20 est **sous le minimum WCAG 2.2 SC 2.5.8** (« Target Size (Minimum) », niveau AA : 24×24 px CSS), et le bouton **secondaire** voisin `.route-toggle` (`style.css:687`) faisait 24×24 pour un glyphe de 12 px. La hiérarchie visuelle était inversée : le dépliant était plus lisible que l'action principale.

**Le dépliant (#30).** `routeSchemaHTML` (`app.js:572`) et `loopSchemaHTML` (`app.js:578`) n'affichaient que `système › planète › terminal`, le type de saut et le temps estimé — soit exactement ce que la carte 2D du parcours donne depuis l'ADR-001. Seul `multiSchemaHTML` (`app.js:548`) portait autre chose : le **manifeste complet**, stock / demande / prix / marge / profit / caisses par commodité. La carte n'affichant aucun chiffre, ce dépliant-là ne fait doublon avec rien : il est conservé, débarrassé de sa géographie, et renommé `multiCargoHTML`.

Le temps estimé n'est pas perdu : il vit déjà dans l'infobulle de la colonne « Profit/heure » (`app.js:616`).

Ce découpage évite de contredire l'**ADR-001**, qui déclare la carte **décorative** (« aucune décision de trading n'en dépend ») : elle ne devient l'unique aperçu de rien.

Code mort supprimé : `routeSchemaHTML`, `loopSchemaHTML`, `schemaLeg`, et les règles `.schema`, `.schema-leg`, `.schema-label`, `.schema-path`, `.schema-arrow`. `.snode` survit — la vue Chaîne s'en sert (`app.js:1126`).

## Vérification

```
$ node --test
ℹ tests 363
ℹ pass 363
ℹ fail 0

$ npx playwright test
102 passed (47.8s)
```

**TDD — les quatre tests neufs ont échoué avant le correctif :**

| Test | Échec constaté avant |
|---|---|
| `▶ tient la cible tactile minimale (#29)` | `Expected: >= 24 / Received: 20` |
| `plus de dépliant 🗺 là où la carte du voyage montre déjà la géographie (#30)` | `toHaveCount(0)` → `Received: 316` |
| `multi-commodité : le dépliant garde le chargement, et lui seul (#30)` | `.schema` → `Received: 1` |
| `multi-commodité : ▶ reste le seul bouton plein, dépliant ouvert (#29)` | `Expected: false / Received: true` |

Le quatrième mérite une note : il a d'abord **passé du premier coup**, donc sans rien prouver. `.route-toggle` porte une `transition` de 0,12 s sur `background` ; une lecture immédiate de `getComputedStyle` rend la valeur de **départ**. `expect.poll` ne corrigeait rien non plus — il s'arrête au premier échantillon conforme, encore en pleine transition. Le test attend désormais la fin des animations des deux boutons (`getAnimations()`), et c'est ce qui l'a fait virer au rouge — révélant une vraie régression que je venais d'introduire : ouvert, le 📦 prenait le **même** ambre plein que le ▶, deux carrés pleins côte à côte, avec un emoji illisible par-dessus (`color` ne repeint pas un glyphe en couleurs). L'état ouvert se dit maintenant en contour.

**Contrôle visuel** (Chromium propre, 1400×900) : hauteur de ligne inchangée — 110,68 px avant comme après, le bouton de 30 px tient dans une cellule qui empile déjà quatre lignes. Le ▶ forme une gouttière régulière sans dominer la table.

## Ce qui n'est pas couvert

- **#25 n'est pas corrigé** (▶ et 🗺 agissant sur les lignes d'un autre mode pendant le chargement du marché). Le nouveau gestionnaire est en revanche plus étroit : il refuse de déplier si `isMultiRoutes()` est faux, au lieu d'aller indexer `shownMulti` avec le numéro de ligne d'une autre table.
- Aucun aperçu de trajet **avant** de démarrer un voyage sur les trajets simples et les boucles : la carte n'existe qu'une fois le voyage lancé. Assumé — c'est le doublon qu'on retire.
- Les autres boutons de l'app n'ont pas été audités pour la cible tactile ; seul `.journey-pick` l'a été.

Closes #29
Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)