### PR TITLE
feat(data): les terminaux portent leur code UEX et leur photo

### DIFF
--- a/scripts/build-data.mjs
+++ b/scripts/build-data.mjs
@@ -255,7 +255,17 @@ function buildMarket(byCommodity, term) {
     if (index.has(id)) return index.get(id);
     const t = term.get(id);
     const i = terminals.length;
-    terminals.push({ name: t.name, system: t.system, planet: t.planet, outpost: t.outpost, autoload: t.autoload, maxBox: t.maxBox });
+    // `t` est ici l'entrée DÉJÀ normalisée par l'index (`term.get`), pas l'enregistrement UEX brut :
+    // les noms sont donc `shot`/`shotBy`, jamais `screenshot`/`screenshot_author`.
+    // Le `|| ""` est reposé bien que l'index le garantisse déjà, comme le fait la projection des
+    // commodités pour leur code : buildMarket est une fonction PURE exportée, testée sur des
+    // fixtures écrites à la main. Sans lui, la garantie « jamais undefined » ne tiendrait que par
+    // la fixture, et le test qui la vérifie ne testerait plus rien.
+    terminals.push({
+      name: t.name, system: t.system, planet: t.planet, outpost: t.outpost,
+      autoload: t.autoload, maxBox: t.maxBox,
+      code: t.code || "", shot: t.shot || "", shotBy: t.shotBy || "",
+    });
     index.set(id, i);
     return i;
   };
@@ -322,9 +332,20 @@ async function main() {
       id: t.id,
       orbit: t.id_orbit || 0,
       name: t.nickname || t.name,
-      code: t.code,
+      // Code court UEX (ARCL1, LEVSKI…). Il n'est PAS unique — PYROG désigne à la fois
+      // Pyro Gateway (Stanton) et Pyro Gateway (Nyx) — et ne sert donc jamais de clé : ni index,
+      // ni Map, ni déduplication. Il n'est là que pour s'afficher et se chercher.
+      code: t.code || "",
       system: t.star_system_name || "?",
       planet: t.planet_name || "",
+      // Capture du terminal, soumise par un joueur et hébergée par UEX. Recopiée VERBATIM : UEX
+      // sert deux formes d'URL selon l'âge de la soumission, et deux hôtes CDN distincts — une
+      // liste figée perdrait déjà une photo aujourd'hui (Nyx Gateway (Pyro)).
+      // Les deux champs sont INDÉPENDANTS : 97 de nos 114 terminaux ont une photo, mais 89
+      // seulement un auteur. Huit ont donc une photo sans crédit, et un rendu qui écrit
+      // « photo de {auteur} » dès que la photo existe y afficherait un crédit vide.
+      shot: t.screenshot || "",
+      shotBy: t.screenshot_author || "",
       // Avant-poste de surface = élévateur de fret peu fiable. Stations/villes = fiables.
       outpost: t.id_outpost > 0,
       // Le (dé)chargement automatique n'existe pas partout : sans ce drapeau, l'app facturerait

--- a/scripts/build-data.test.mjs
+++ b/scripts/build-data.test.mjs
@@ -114,7 +114,9 @@ test("buildMarket déduplique les terminaux et compacte achats/ventes en tuples"
   ]);
   const m = buildMarket(byCommodity, term);
   assert.equal(m.commodities.length, 1); // la commodité sans vente est écartée
-  assert.deepEqual(m.terminals[0], { name: "A", system: "Stanton", planet: "Hurston", outpost: false, autoload: true, maxBox: 32 });
+  // deepEqual compare le terminal ENTIER : toute clé ajoutée à la projection doit apparaître ici,
+  // fût-elle vide. C'est voulu — c'est ce test qui signale qu'on a changé la forme publiée.
+  assert.deepEqual(m.terminals[0], { name: "A", system: "Stanton", planet: "Hurston", outpost: false, autoload: true, maxBox: 32, code: "", shot: "", shotBy: "" });
   const c = m.commodities[0];
   assert.deepEqual(c.buys[0], [0, 100, 50, 111, 4]);  // [idxTerminal, prix, stock, maj, statut]
   assert.deepEqual(c.sells[0], [1, 250, 80, 222, 2]); // [idxTerminal, prix, demande, maj, statut]
@@ -170,12 +172,13 @@ test("une commodité « vente seule » ne produit ni route ni segment (inerte po
 const MARKET = JSON.parse(readFileSync(new URL("../data/market.json", import.meta.url), "utf8"));
 const SHIPS = JSON.parse(readFileSync(new URL("../data/ships.json", import.meta.url), "utf8"));
 
-// `autoload` / `maxBox` ne sont volontairement PAS vérifiés ici : `node --test` tourne AVANT
-// `npm run build` (update-data.yml) et la CI ne re-commite jamais les data/*.json. L'instantané
-// versionné ne portera donc les deux champs qu'après un build local recommité — les exiger ici
-// rendrait la CI rouge sur une PR par ailleurs correcte. Présence et repli sont couverts sur
-// fixture plus bas, là où ils sont de toute façon mieux testés (l'instantané du jour ne contient
-// qu'un seul terminal muet sur la taille de caisse, et aucun plafonné à 1 SCU).
+// `autoload`, `maxBox`, `code`, `shot` et `shotBy` ne sont volontairement PAS vérifiés ici :
+// `node --test` tourne AVANT `npm run build` (update-data.yml) et la CI ne re-commite jamais les
+// data/*.json. L'instantané versionné ne portera donc ces champs qu'après un build local recommité
+// — les exiger ici rendrait la CI rouge sur une PR par ailleurs correcte. Présence et repli sont
+// couverts sur fixture plus bas, là où ils sont de toute façon mieux testés (l'instantané du jour
+// ne contient qu'un seul terminal muet sur la taille de caisse, et aucun plafonné à 1 SCU ; il ne
+// contient pas non plus de terminal à photo sans auteur, cas pourtant réel sur huit d'entre eux).
 test("data/market.json : forme des terminaux", () => {
   assert.ok(MARKET.terminals.length > 0, "aucun terminal");
   for (const t of MARKET.terminals) {
@@ -344,4 +347,64 @@ test("numField : un champ UEX non numérique ne traverse jamais le pipeline", ()
 test("sellDemand : une capacité UEX non numérique ne devient pas un plafond fantaisiste", () => {
   assert.equal(sellDemand({ scu_sell: "toto", scu_sell_stock: 0 }), null); // illisible = inconnu
   assert.equal(sellDemand({ scu_sell: "100", scu_sell_stock: "40" }), 60); // chaînes numériques OK
+});
+
+test("buildMarket publie le code UEX et la photo par terminal", () => {
+  const term = new Map([
+    [10, { name: "GrimHEX", system: "Stanton", planet: "Yela", outpost: false, autoload: true, maxBox: 32,
+           code: "GRIMX", shot: "https://cdn.uexcorp.space/terminals/2/images/abc.jpg", shotBy: "Aazatgrabya" }],
+    // Terminal entièrement muet : c'est le cas des 17 terminaux sans photo, mesuré contre l'API.
+    [20, { name: "Muet", system: "Pyro", planet: "", outpost: true, autoload: false, maxBox: 24 }],
+  ]);
+  const byCommodity = new Map([
+    [1, {
+      name: "Laranite", kind: "metal", illegal: false,
+      buys: [buy({ id: 10, price: 100, stock: 50 })],
+      sells: [buy({ id: 20, price: 250, demand: 80 })],
+    }],
+  ]);
+  const m = buildMarket(byCommodity, term);
+  assert.equal(m.terminals[0].code, "GRIMX");
+  assert.equal(m.terminals[0].shot, "https://cdn.uexcorp.space/terminals/2/images/abc.jpg");
+  assert.equal(m.terminals[0].shotBy, "Aazatgrabya");
+  // Jamais `undefined` : le rendu interpole ces champs, et `undefined` s'y écrirait en toutes lettres.
+  assert.equal(m.terminals[1].code, "");
+  assert.equal(m.terminals[1].shot, "");
+  assert.equal(m.terminals[1].shotBy, "");
+});
+
+test("buildMarket : une photo sans auteur reste une photo (les deux champs sont indépendants)", () => {
+  // Mesuré contre l'API : 97 de nos 114 terminaux ont un screenshot, 89 seulement un auteur.
+  // Huit sont dans l'état photo renseignée / auteur vide — HUR-L2, Lorville L19, Orbituary,
+  // Orison Providence, Pickers Field, TDD Orison, Terra Gateway (Stanton), Terra Mills.
+  // C'est ce test qui verrouille le rendu contre un crédit « photo de  » vide sur ces huit-là.
+  const term = new Map([
+    [10, { name: "Orbituary", system: "Stanton", planet: "", outpost: false,
+           shot: "https://cdn.uexcorp.space/terminals/9/images/def.jpg" }],
+    [20, { name: "Cible", system: "Pyro", planet: "", outpost: false }],
+  ]);
+  const byCommodity = new Map([
+    [1, { name: "Laranite", kind: "metal", illegal: false,
+          buys: [buy({ id: 10, price: 100, stock: 50 })], sells: [buy({ id: 20, price: 250, demand: 80 })] }],
+  ]);
+  const m = buildMarket(byCommodity, term);
+  assert.ok(m.terminals[0].shot.length, "la photo doit survivre à l'absence d'auteur");
+  assert.equal(m.terminals[0].shotBy, "");
+});
+
+test("buildMarket : deux terminaux de même code restent deux entrées distinctes", () => {
+  // PYROG désigne à la fois Pyro Gateway (Stanton) et Pyro Gateway (Nyx), vérifié sur nos 114.
+  // Garde-fou contre un futur lecteur qui indexerait par code : la seule clé est l'index.
+  const term = new Map([
+    [10, { name: "Pyro Gateway (Stanton)", system: "Stanton", planet: "", outpost: false, code: "PYROG" }],
+    [20, { name: "Pyro Gateway (Nyx)", system: "Nyx", planet: "", outpost: false, code: "PYROG" }],
+  ]);
+  const byCommodity = new Map([
+    [1, { name: "Laranite", kind: "metal", illegal: false,
+          buys: [buy({ id: 10, price: 100, stock: 50 })], sells: [buy({ id: 20, price: 250, demand: 80 })] }],
+  ]);
+  const m = buildMarket(byCommodity, term);
+  assert.equal(m.terminals.length, 2);
+  assert.equal(m.terminals[0].code, m.terminals[1].code);
+  assert.notEqual(m.terminals[0].name, m.terminals[1].name);
 });


### PR DESCRIPTION
## Ce que ça change

Rien de visible encore. `data/market.json` publiera trois champs de plus par terminal — `code`, `shot`, `shotBy` — sur lesquels s'appuieront le nouveau sélecteur de station et la vue Corrections remaniée. C'est le premier des trois lots de l'ADR-003.

## Pourquoi

L'ADR-003 pose que la photo des terminaux vient du CDN UEX plutôt que d'un dossier d'images committées : pas de sourcing manuel, pas de binaires versionnés, pas de droits flous sur des captures Star Citizen, et un crédit à l'auteur. Il faut donc faire descendre `screenshot` et `screenshot_author` dans l'instantané.

Deux découvertes ont modifié le plan initial :

**`code` n'était pas à ajouter — il était mort.** `code: t.code` existe dans l'index des terminaux (`build-data.mjs:335`) depuis longtemps, mais aucune projection ne le ressortait : il transitait vers les commodités et s'arrêtait là. Le lire comme un ajout aurait dupliqué la clé dans le littéral d'objet — en JS la seconde écrase la première **en silence**, et selon l'ordre on perdait le repli.

**Les deux points d'édition ne parlent pas le même dialecte.** À l'index, `t` est l'enregistrement UEX brut : `t.screenshot`. À la projection (`:258`), dans `idxOf`, `t` vaut `term.get(id)` — l'entrée **déjà normalisée** : `t.shot`. Recopier la même forme aux deux endroits aurait produit trois `undefined` en silence.

Le `|| ""` est reposé à la projection bien que l'index le garantisse déjà, en suivant le précédent du fichier (`code: c.code || ""` pour les commodités). `buildMarket` est une fonction **pure exportée**, testée sur des fixtures écrites à la main : sans ce repli, la garantie « jamais `undefined` » ne tiendrait que par la fixture, et le test ne testerait plus rien.

## Vérification

```
$ node --test
ℹ tests 366
ℹ pass 366
ℹ fail 0

$ npx playwright test
102 passed (48.9s)
```

**TDD.** Le test neuf a échoué avant le correctif, pour la bonne raison :

```
AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+ undefined
- 'GRIMX'
```

Puis un second échec **attendu**, prévu par la reconnaissance : `assert.deepEqual` (`build-data.test.mjs:119`) compare le terminal **entier**, donc toute clé ajoutée le fait tomber, fût-elle vide. C'est précisément son rôle — c'est lui qui signale un changement de forme publiée. Son attendu est étendu, pas contourné.

**Deux tests de plus, sur des faits mesurés contre l'API** (`api.uexcorp.uk/2.0/terminals?type=commodity`, 114/114 appariés) :

- **97 photos pour 89 auteurs.** Les deux champs sont indépendants : huit terminaux ont une photo **sans** crédit (HUR-L2, Lorville L19, Orbituary, Orison Providence, Pickers Field, TDD Orison, Terra Gateway (Stanton), Terra Mills). Le test verrouille le rendu contre un « photo de » suivi de rien.
- **`code` n'est pas unique** : `PYROG` désigne à la fois Pyro Gateway (Stanton) et Pyro Gateway (Nyx). Le test interdit à un futur lecteur de s'en servir comme clé — la seule clé fiable est l'index dans `MARKET.terminals`.

## Ce qui n'est pas couvert

- **`data/market.json` n'est pas régénéré ici** : le CLAUDE.md l'interdit dans une PR de code. Un commit `chore(data)` séparé suit immédiatement, avant le LOT 2 — qui en dépend, le picker filtrant sur `code`.
- Le test d'instantané n'assert **pas** les nouveaux champs, seulement son commentaire les nomme : `node --test` tourne avant `npm run build` et la CI ne recommite jamais `data/*.json`. Les exiger rendrait la CI rouge sur une PR correcte. Même traitement que `autoload`/`maxBox`, absents de l'amorce pour la même raison.
- `screenshot_full` n'est pas repris : pas de visionneuse plein écran au programme.
- Aucun rendu ne consomme encore ces champs.

Réf. ADR-003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)