### PR TITLE
test(ci): deux tests E2E ne dépendent plus de la péremption de l'amorce

### DIFF
--- a/e2e/autoload.pw.mjs
+++ b/e2e/autoload.pw.mjs
@@ -13,7 +13,13 @@ test.use({ serviceWorkers: "block" });
 // Enrichit market.json en vol. `mode` décide de ce que les terminaux déclarent :
 //   "all"  : tout le monde propose l'autoload (chemin actif complet) ;
 //   "none" : personne ne le propose (le champ EXISTE et vaut false -> « pas d'autoload ») ;
-//   "raw"  : on ne touche à rien (champs absents -> « donnée UEX absente »), le cas d'aujourd'hui.
+//   "raw"  : on ne touche à rien — l'instantané tel qu'il est committé, quel qu'il soit ;
+//   "strip": on RETIRE `autoload` et `maxBox` (-> « donnée UEX absente »), le chemin dégradé.
+// "strip" existe parce que "raw" ne suffisait plus : il testait le chemin dégradé en comptant sur la
+// PÉREMPTION de l'amorce, dont les deux champs étaient absents faute de régénération récente, alors
+// que le pipeline les émet depuis la fonctionnalité d'autoload. La première régénération les a fait
+// atterrir, et le test s'est mis à mesurer des frais bien réels au lieu de leur absence. Un chemin
+// de dégradation se teste en RETIRANT la donnée, jamais en espérant qu'elle manque.
 // `fixedMaxBox` impose le même plafond à tous les terminaux, pour les tests qui comparent un
 // montant à un chiffre de la spec : celle-ci ancre ses relevés sur des caisses de 32 SCU, et un
 // plafond plus bas change le nombre de caisses donc le montant (32 SCU font 1 caisse à 32, mais 2 à
@@ -23,7 +29,9 @@ async function enrichMarket(page, mode, fixedMaxBox) {
   await page.route("**/data/market.json", async (route) => {
     const res = await route.fetch();
     const market = await res.json();
-    if (mode !== "raw") {
+    if (mode === "strip") {
+      market.terminals.forEach((t) => { delete t.autoload; delete t.maxBox; });
+    } else if (mode !== "raw") {
       market.terminals.forEach((t, i) => {
         t.autoload = mode === "all";
         t.maxBox = fixedMaxBox || [32, 24, 16][i % 3];
@@ -211,7 +219,7 @@ test("station sans autoload : le zéro est EXPLIQUÉ, jamais muet", async ({ pag
 
 test("dégradation : sans les champs UEX, les profits sont IDENTIQUES et rien ne casse", async ({ page }) => {
   const errors = watchErrors(page);
-  await enrichMarket(page, "raw"); // l'instantané réel : ni `autoload` ni `maxBox`
+  await enrichMarket(page, "strip"); // champs RETIRÉS : le chemin « donnée UEX absente »
   await page.goto("/index.html");
   await expect(page.locator("#rows tr").first()).toBeVisible();
 

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -885,8 +885,17 @@ test("Manifeste -> voyage : un départ étranger au parcours nomme les deux bout
   await page.click("#manifestToJourney");
   await expect(page.locator("#journeyCard .jstep")).toHaveCount(2);
   const fin = (await page.locator("#journeyCard .jstep").nth(1).innerText()).trim();
-  await page.fill("#origin", "Rod's Fuel — Pyro"); // ne part ni de la fin, ni d'une jambe planifiée
-  await expect(page.locator("#manifest .journey-hint")).toContainText("Rod's Fuel");
+  // Le terminal « étranger » est CHOISI DANS LES DONNÉES, jamais codé en dur : « Rod's Fuel » l'a
+  // été pendant un temps, jusqu'à ce qu'une régénération de l'amorce en fasse la jambe 1 du meilleur
+  // trajet — le test lisait alors « ✓ C'est déjà la jambe 1 de ton voyage » et échouait.
+  const arrets = (await page.locator("#journeyCard .jstep").allInnerTexts()).map((s) => s.trim().split(" — ")[0]);
+  const etranger = await page.locator("#originList option").evaluateAll(
+    (els, pris) => els.map((e) => e.value).find((v) => !pris.some((p) => v.includes(p))),
+    arrets,
+  );
+  expect(etranger, "l'instantané doit offrir un terminal de départ hors du parcours").toBeTruthy();
+  await page.fill("#origin", etranger);
+  await expect(page.locator("#manifest .journey-hint")).toContainText(etranger.split(" — ")[0]);
   await expect(page.locator("#manifest .journey-hint")).toContainText(memeStation(fin));
   await expect(page.locator("#manifestToJourney")).toHaveCount(0);
   await expect(page.locator("#journeyCard .jstep")).toHaveCount(2); // aucune modification du voyage


### PR DESCRIPTION
## Ce que ça change

Rien pour l'utilisateur. Deux tests E2E qui passaient **pour de mauvaises raisons** testent désormais ce qu'ils prétendent tester. Sans ça, la régénération de `data/market.json` prévue par l'ADR-003 fait tomber la suite.

## Pourquoi

En régénérant l'amorce pour y faire descendre `code`, `shot` et `shotBy` (PR #33), deux tests sont passés au rouge de façon **déterministe** — vérifié sur trois exécutions. Aucun des deux n'est cassé par les nouveaux champs : tous deux étaient couplés à l'état périmé de l'instantané.

**1. `autoload.pw.mjs` — « dégradation : sans les champs UEX ».** Il exerce le chemin « donnée UEX absente » via `enrichMarket(page, "raw")`, c'est-à-dire *« on ne touche à rien »*. Sa prémisse — écrite noir sur blanc dans le commentaire — était que l'amorce ne porte ni `autoload` ni `maxBox`. Or le pipeline les émet depuis la fonctionnalité d'autoload (`build-data.mjs:258`) : ils n'y manquaient que **faute de régénération**, la CI ne recommitant jamais `data/*.json`. Dès qu'ils atterrissent, le test mesure des frais réels au lieu de leur absence :

```
- "399 360"
+ "≈ 394 176"
```

`enrichMarket` gagne un mode **`strip`** qui retire explicitement les deux champs. Un chemin de dégradation se teste en **retirant** la donnée, jamais en espérant qu'elle manque.

**2. `smoke.pw.mjs:883` — « un départ étranger au parcours ».** Il codait `Rod's Fuel — Pyro` en dur comme terminal *« ne partant ni de la fin, ni d'une jambe planifiée »*. Avec les nouveaux prix, cette station est devenue la **jambe 1 du meilleur trajet** :

```
Expected substring: "Rod's Fuel"
3 × locator resolved to <span class="journey-hint">✓ C'est déjà la jambe 1 de ton voyage.</span>
```

Le terminal étranger est maintenant **choisi dans `#originList`** en excluant les arrêts du parcours courant, avec une assertion explicite si l'instantané n'en offre aucun — le test échouera bruyamment plutôt que de se tromper de cas.

## Vérification

Le point qui distingue un découplage d'un simple réalignement : **les deux tests passent avec l'ancienne amorce ET avec la régénérée.**

```
$ npx playwright test -g "dégradation : sans les champs UEX|un départ étranger au parcours"
=== amorce actuelle (main) ===   2 passed (2.0s)
=== amorce régénérée ===         2 passed (1.8s)
```

Suite complète sur `main` :

```
$ node --test
ℹ tests 363   ℹ pass 363   ℹ fail 0

$ npx playwright test
102 passed (47.1s)
```

Contre-épreuve de non-vacuité : avant ce correctif, les deux échouaient sur trois exécutions consécutives avec l'amorce régénérée, et passaient avec l'ancienne.

## Ce qui n'est pas couvert

- **Deux tests continuent de se sauter tout seuls** avec l'amorce régénérée : « libérer des SCU dans une jambe propose de quoi remplir » (`smoke.pw.mjs:1057`) et « les suggestions de remplissage restent rendues » (`:1097`). Ce sont des `test.skip` conditionnels de conception — le cas qu'ils couvrent (une commodité rentable à suggérer sur cette jambe) a disparu des données. Ils se taisent proprement et disent pourquoi, mais **la couverture baisse en silence**. Non traité ici : c'est une fragilité de conception distincte, qui mérite sa propre décision.
- Aucun audit systématique du reste de la suite n'a été mené pour trouver d'autres couplages du même genre. Seuls les deux tests que la régénération a fait tomber sont traités.
- La régénération elle-même (`chore(data)`) suit dans son propre commit, comme l'impose le CLAUDE.md.

Réf. ADR-003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)