### PR TITLE
fix(corrections): choisir une station sans que son nom soit tronqué

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,7 +9,7 @@ import {
   routePasses, loopPasses,
   routeMetrics, loopMetrics, enRouteDeals, bestManifest, buildChainAdjacency, suggestionsFrom, netMarginRoi,
   commoditySummaries, commodityPoints, compactValue, valueTiers, resolveCommodity, ambiguousCodes,
-  manifestTotals, freeAddUnits, manifestLine, freeManifestLine, hydrateManifestLine, stationLabel, parseStationLabel,
+  manifestTotals, freeAddUnits, manifestLine, freeManifestLine, hydrateManifestLine, stationLabel, parseStationLabel, stationTree,
   multiTrips, tripMetrics, legFromTrip,
   legFromRoute, legsFromLoop, legsFromChain, legFromManifest, stopSuggestions, bestLegBetween,
   manifestJourneyState, manifestIntent, sameIntent, legsToPin, journeyMap,
@@ -777,8 +777,69 @@ function setupEnRoute() {
   $("commodityList").innerHTML = MARKET.commodities
     .map((c) => `<option value="${esc(c.name)}">${esc(c.code || "")}</option>`).join("");
 
+  monteStationPicker();
+
   enrouteReady = true;
   resolveOrigin(); // au cas où une valeur a été restaurée
+}
+
+// Sélecteur de station de la vue Corrections : les 114 terminaux rangés système › zone › station
+// (ADR-003). Monté une seule fois, depuis setupEnRoute, car il lui faut MARKET.
+function monteStationPicker() {
+  const input = $("station"), list = $("stationPickList");
+  if (!input || !list) return;
+  // On aplatit l'arbre : le filtre et la navigation travaillent sur une liste PLATE déjà triée,
+  // et c'est sa contiguïté par (système, zone) qui permet au rendu de reposer un en-tête au simple
+  // changement de clé. Filtrer l'arbre lui-même casserait cette propriété.
+  const plates = stationTree(MARKET.terminals).flatMap((s) => s.zones.flatMap((z) => z.stations));
+
+  // Un `<img onerror>` posé par innerHTML est INERTE sous `script-src 'self'` (index.html:23) et
+  // laisserait une image cassée. Les événements `error` ne remontent pas, mais ils descendent :
+  // un seul écouteur en phase de CAPTURE, posé une fois, couvre tous les rendus à venir.
+  list.addEventListener("error", (e) => {
+    if (e.target.tagName === "IMG") e.target.closest("li")?.classList.add("no-shot");
+  }, true);
+
+  montePicker({
+    input, list,
+    options: () => plates,
+    // Nom ET code : taper « PYROG » remonte les deux passerelles homonymes, que le badge distingue.
+    filtre: (s, q) => s.name.toLowerCase().includes(q) || s.code.toLowerCase().includes(q),
+    max: 0, // 114 lignes tiennent : plafonner masquerait des stations sans le dire
+    rendu: (m) => {
+      let grp = "", html = "";
+      m.forEach((s, i) => {
+        const cle = `${s.system} › ${s.zone}`;
+        // En-tête SANS data-i : ni sélectionnable au clavier, ni cliquable.
+        if (cle !== grp) { grp = cle; html += `<li role="presentation" class="opt-grp">${sysBadge(s.system)}<span>${esc(s.zone)}</span></li>`; }
+        html += `<li role="option" data-i="${i}">${vignetteStation(s)}` +
+          `<span class="stn-opt-name">${esc(s.name)}</span>` +
+          `<span class="stn-opt-code">${esc(s.code)}</span>` +
+          (s.outpost ? '<span class="stn-opt-post" title="Avant-poste : élévateur de fret parfois en panne">⚠ avant-poste</span>' : "") +
+          `</li>`;
+      });
+      return html;
+    },
+    // Écrit le LIBELLÉ CANONIQUE, jamais le nom seul : resolveStation résout par correspondance
+    // exacte via stationMap, et c'est cette même chaîne que le permalien transporte.
+    choisir: (s) => { input.value = s.label; resolveStation(); refresh(); saveState(); },
+  });
+}
+
+// Vignette d'une station : la photo UEX si elle existe, sinon un carré teinté par système portant
+// le code. 17 terminaux sur 114 n'ont pas de photo — la vignette générée évite le trou, sans
+// requête. Le filtre `^https://` est délibéré même si aucune URL non-https n'existe aujourd'hui :
+// l'attribut est interpolé dans du HTML, et c'est justement parce qu'aucune donnée ne le déclenche
+// qu'aucun test ne l'attraperait s'il manquait.
+function vignetteStation(s) {
+  // La photo se pose EN ABSOLU par-dessus le repli, dans un conteneur commun. La superposer à coups
+  // de marge négative les décalait de la valeur du `gap` flex, et le code débordait derrière la
+  // photo (« TA » derrière celle de Nyx Gateway (Stanton), dont le code est NYXSTA).
+  const photo = s.shot && /^https:\/\//i.test(s.shot)
+    ? `<img class="stn-shot" src="${esc(s.shot)}" alt="" loading="lazy" referrerpolicy="no-referrer" />`
+    : "";
+  return `<span class="stn-vign sys-${esc((s.system || "").toLowerCase())}">` +
+    `<span class="stn-shot-gen">${esc(s.code)}</span>${photo}</span>`;
 }
 
 // Résout le terminal de départ depuis le texte du champ (libellé exact).
@@ -2134,17 +2195,24 @@ function setupLoopSort() {
   });
 }
 
-// Charge les vaisseaux et gère une autocomplétion maison (filtre par sous-chaîne,
-// fiable sur tous les navigateurs, avec navigation clavier).
-async function loadShips() {
-  const ships = await fetch("data/ships.json").then((r) => r.json()).catch(() => []);
-  // Tri par capacité de soute décroissante : les plus gros haulers apparaissent en premier.
-  ships.sort((a, b) => b.scu - a.scu);
-  const input = $("ship");
-  const list = $("shipList");
-  const byName = new Map(ships.map((s) => [s.name.toLowerCase(), s.scu]));
+// Autocomplétion maison, partagée par le champ Vaisseau et le sélecteur de station (ADR-003).
+// Un `<datalist>` natif ne se met pas en forme et cale sa liste sur la largeur du champ : les noms
+// de station y sont tronqués (jusqu'à 33 caractères pour « Terra Gateway (Stanton) — Stanton »).
+//
+// Trois généralisations par rapport à l'autocomplétion vaisseau dont elle est tirée, chacune
+// indispensable au sélecteur de station :
+//   1. `options` est une FONCTION relue à chaque ouverture, et non un tableau capturé au montage :
+//      les vaisseaux existent dès le départ, les stations seulement après market.json.
+//   2. la navigation passe par `li[data-i]` et non par `list.children`. Des en-têtes de groupe
+//      brisent la bijection enfants ↔ résultats : sans ce filtre, la 3e flèche bas poserait
+//      `.active` sur un en-tête non sélectionnable et Entrée choisirait la mauvaise station.
+//   3. `rendu` reçoit le tableau ENTIER et rend le HTML en bloc, ce qui permet d'intercaler
+//      ces en-têtes.
+// `max: 0` = pas de plafond (les 114 stations tiennent ; les vaisseaux, eux, se coupent à 12).
+function montePicker({ input, list, options, filtre, rendu, choisir, max = 12 }) {
   let matches = [];
   let active = -1;
+  const items = () => [...list.querySelectorAll("li[data-i]")];
 
   function hide() {
     list.hidden = true;
@@ -2153,22 +2221,71 @@ async function loadShips() {
     input.setAttribute("aria-expanded", "false");
   }
 
-  // q vide -> toute la liste (parcours au focus) ; sinon filtre par sous-chaîne (max 12).
+  // q vide -> toute la liste (parcours au focus) ; sinon filtre par sous-chaîne.
   function show(q) {
-    const pool = q ? ships.filter((s) => s.name.toLowerCase().includes(q)) : ships;
-    matches = q ? pool.slice(0, 12) : pool;
+    const tout = options() || [];
+    const pool = q ? tout.filter((o) => filtre(o, q)) : tout;
+    matches = q && max > 0 ? pool.slice(0, max) : pool;
     if (!matches.length) return hide();
     active = 0;
-    list.innerHTML = matches
-      .map(
-        (s, i) =>
-          `<li role="option" data-i="${i}" class="${i === 0 ? "active" : ""}">` +
-          `<span>${esc(s.name)}</span><span class="scu">${s.scu.toLocaleString("fr-FR")} SCU</span></li>`
-      )
-      .join("");
+    list.innerHTML = rendu(matches);
+    highlight();
     list.hidden = false;
     input.setAttribute("aria-expanded", "true");
   }
+
+  function highlight() {
+    items().forEach((li, i) => li.classList.toggle("active", i === active));
+    items()[active]?.scrollIntoView({ block: "nearest" });
+  }
+
+  function valide(o) {
+    if (!o) return;
+    hide();
+    choisir(o);
+  }
+
+  input.addEventListener("input", () => show(input.value.trim().toLowerCase()));
+  input.addEventListener("focus", () => show(input.value.trim().toLowerCase()));
+
+  input.addEventListener("keydown", (e) => {
+    if (list.hidden) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      active = Math.min(active + 1, matches.length - 1);
+      highlight();
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      active = Math.max(active - 1, 0);
+      highlight();
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      valide(matches[active]);
+    } else if (e.key === "Escape") {
+      hide();
+    }
+  });
+
+  // mousedown (et non click) pour devancer le blur du champ.
+  list.addEventListener("mousedown", (e) => {
+    const li = e.target.closest("li[data-i]"); // les en-têtes de groupe n'en portent pas : inertes
+    if (!li) return;
+    e.preventDefault();
+    valide(matches[Number(li.dataset.i)]);
+  });
+
+  input.addEventListener("blur", () => setTimeout(hide, 150));
+  return { hide, show };
+}
+
+// Charge les vaisseaux et branche leur autocomplétion.
+async function loadShips() {
+  const ships = await fetch("data/ships.json").then((r) => r.json()).catch(() => []);
+  // Tri par capacité de soute décroissante : les plus gros haulers apparaissent en premier.
+  ships.sort((a, b) => b.scu - a.scu);
+  const input = $("ship");
+  const list = $("shipList");
+  const byName = new Map(ships.map((s) => [s.name.toLowerCase(), s.scu]));
 
   function showCard(s) {
     const card = $("shipCard");
@@ -2188,58 +2305,26 @@ async function loadShips() {
     card.hidden = false;
   }
 
-  function choose(s) {
-    if (!s) return;
-    input.value = s.name;
-    $("cargo").value = s.scu;
-    hide();
-    showCard(s);
-    refresh();
-  }
-
   // Affiche la carte du vaisseau déjà présent dans le champ (ex. après restauration d'état).
   showShipCard = () => {
     const s = ships.find((x) => x.name.toLowerCase() === input.value.trim().toLowerCase());
     if (s) showCard(s);
   };
 
-  function highlight() {
-    [...list.children].forEach((li, i) => li.classList.toggle("active", i === active));
-    list.children[active]?.scrollIntoView({ block: "nearest" });
-  }
-
-  input.addEventListener("input", () => show(input.value.trim().toLowerCase()));
-
-  // Cliquer/placer le curseur dans le champ ouvre la liste sans avoir à taper.
-  input.addEventListener("focus", () => show(input.value.trim().toLowerCase()));
-
-  input.addEventListener("keydown", (e) => {
-    if (list.hidden) return;
-    if (e.key === "ArrowDown") {
-      e.preventDefault();
-      active = Math.min(active + 1, matches.length - 1);
-      highlight();
-    } else if (e.key === "ArrowUp") {
-      e.preventDefault();
-      active = Math.max(active - 1, 0);
-      highlight();
-    } else if (e.key === "Enter") {
-      e.preventDefault();
-      choose(matches[active]);
-    } else if (e.key === "Escape") {
-      hide();
-    }
+  montePicker({
+    input, list,
+    options: () => ships,
+    filtre: (s, q) => s.name.toLowerCase().includes(q),
+    rendu: (m) => m.map((s, i) =>
+      `<li role="option" data-i="${i}"><span>${esc(s.name)}</span>` +
+      `<span class="scu">${s.scu.toLocaleString("fr-FR")} SCU</span></li>`).join(""),
+    choisir: (s) => {
+      input.value = s.name;
+      $("cargo").value = s.scu;
+      showCard(s);
+      refresh();
+    },
   });
-
-  // mousedown (et non click) pour devancer le blur du champ.
-  list.addEventListener("mousedown", (e) => {
-    const li = e.target.closest("li");
-    if (!li) return;
-    e.preventDefault();
-    choose(matches[Number(li.dataset.i)]);
-  });
-
-  input.addEventListener("blur", () => setTimeout(hide, 150));
 
   // Modifier la soute à la main efface le nom du vaisseau et la carte.
   $("cargo").addEventListener("input", () => {

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -1665,3 +1665,87 @@ test("saisie : pas un history.replaceState par frappe, et « Partager » ne copi
   const barre = await page.evaluate(() => location.hash.replace(/^#/, ""));
   expect(new URLSearchParams(barre).get("station")).not.toBe(gare);
 });
+
+// ---------- Sélecteur de station groupé (ADR-003, LOT 2) ----------
+// Ouvre le sélecteur de la vue Corrections et rend la main quand il est peuplé.
+async function ouvrePicker(page, q = "") {
+  await page.click("#viewCorrections");
+  await expect(page.locator("#stationList option").first()).toBeAttached({ timeout: 15000 }); // marché arrivé
+  if (q) await page.locator("#station").pressSequentially(q, { delay: 1 });
+  else await page.locator("#station").focus();
+  await expect(page.locator("#stationPickList")).toBeVisible();
+}
+
+test("sélecteur : le nom complet d'une station longue est lisible sans troncature (#36)", async ({ page }) => {
+  // « Terra Gateway (Stanton) — Stanton » fait 33 caractères, le plus long des 114 terminaux.
+  // Un <datalist> natif cale sa liste sur la largeur du champ et le coupe : c'est le défaut corrigé.
+  await ouvrePicker(page, "terra gateway");
+  const opt = page.locator("#stationPickList li[data-i]").first();
+  await expect(opt).toContainText("Terra Gateway (Stanton)");
+
+  // Aucun débordement interne : le texte tient dans sa ligne, il n'est pas rogné.
+  const rogne = await opt.evaluate((el) => el.scrollWidth > el.clientWidth + 1);
+  expect(rogne, "l'option ne doit pas déborder de sa propre ligne").toBe(false);
+
+  // Et la liste s'affranchit de la largeur du champ — c'est ce qui rend la place nécessaire.
+  const [wListe, wChamp] = await Promise.all([
+    page.locator("#stationPickList").evaluate((e) => e.getBoundingClientRect().width),
+    page.locator("#station").evaluate((e) => e.getBoundingClientRect().width),
+  ]);
+  expect(wListe).toBeGreaterThan(wChamp);
+});
+
+test("sélecteur : chercher par code UEX remonte les deux passerelles homonymes (#36)", async ({ page }) => {
+  // PYROG désigne À LA FOIS Pyro Gateway (Stanton) et Pyro Gateway (Nyx) : le code n'est pas unique,
+  // et c'est leur badge système qui les distingue à l'œil.
+  await ouvrePicker(page, "pyrog");
+  const opts = page.locator("#stationPickList li[data-i]");
+  await expect(opts).toHaveCount(2);
+  await expect(opts.nth(0)).toContainText("Pyro Gateway");
+  await expect(opts.nth(1)).toContainText("Pyro Gateway");
+  // Ce qui les distingue à l'œil, c'est leur EN-TÊTE : chacune tombe dans le groupe de son système,
+  // et le filtrage n'en conserve que deux. Sans cela l'utilisateur verrait deux lignes identiques.
+  const groupes = await page.locator("#stationPickList li.opt-grp .sys").allTextContents();
+  expect(new Set(groupes.map((s) => s.trim()))).toEqual(new Set(["Stanton", "Nyx"]));
+});
+
+test("sélecteur : les flèches ne s'arrêtent jamais sur un en-tête de groupe (#36)", async ({ page }) => {
+  // Les en-têtes brisent la bijection enfants ↔ résultats : sans filtrage sur li[data-i], la 3e
+  // flèche bas poserait .active sur un en-tête et Entrée choisirait la mauvaise station.
+  await ouvrePicker(page);
+  await expect(page.locator("#stationPickList li.opt-grp").first()).toBeVisible();
+  for (let i = 0; i < 3; i++) await page.locator("#station").press("ArrowDown");
+  await expect(page.locator("#stationPickList li.opt-grp.active")).toHaveCount(0);
+  await expect(page.locator("#stationPickList li[data-i].active")).toHaveCount(1);
+});
+
+test("sélecteur : Entrée écrit le libellé canonique, et la station s'affiche (#36)", async ({ page }) => {
+  await ouvrePicker(page, "levski");
+  await page.locator("#station").press("Enter");
+  // Libellé canonique « Nom — Système » : c'est ce qu'attend resolveStation, et ce qu'encode le lien.
+  await expect(page.locator("#station")).toHaveValue("Levski — Nyx");
+  await expect(page.locator("#correctionsStation .scomm").first()).toBeVisible();
+});
+
+test("sélecteur : la datalist historique survit pour les autres champs (#36)", async ({ page }) => {
+  // #destTerminal, #journeyStart et #journeyAddStop s'en servent encore, et huit assertions la lisent.
+  await ouvrePicker(page);
+  await expect(page.locator("#stationList option")).toHaveCount(114);
+  await expect(page.locator("#station")).not.toHaveAttribute("list", /.+/);
+});
+
+test("sélecteur : quand la photo existe, la vignette de repli ne dépasse pas derrière (#36)", async ({ page }) => {
+  // Photo et vignette générée occupent la MÊME case : la seconde n'est qu'un repli. Superposées à
+  // coups de marge négative, elles se décalaient de la valeur du `gap` flex et le code débordait —
+  // on lisait « TA » derrière la photo de Nyx Gateway (Stanton), dont le code est NYXSTA.
+  await ouvrePicker(page, "gate");
+  const avecPhoto = page.locator("#stationPickList li[data-i]:not(.no-shot)").filter({ has: page.locator("img.stn-shot") }).first();
+  await expect(avecPhoto).toBeVisible();
+  const boites = await avecPhoto.evaluate((li) => {
+    const img = li.querySelector("img.stn-shot").getBoundingClientRect();
+    const gen = li.querySelector(".stn-shot-gen").getBoundingClientRect();
+    return { img: [img.x, img.y, img.width, img.height], gen: [gen.x, gen.y, gen.width, gen.height] };
+  });
+  // Exactement superposées : aucun pixel du repli n'est visible à côté de la photo.
+  expect(boites.gen).toEqual(boites.img);
+});

--- a/index.html
+++ b/index.html
@@ -223,9 +223,15 @@
         </section>
 
         <section id="correctionsControls" class="enroute-controls" hidden>
-          <div class="field">
+          <div class="field picker-field">
             <label for="station">Station à corriger</label>
-            <input id="station" list="stationList" type="text" placeholder="Tape une station (ex : Levski)" autocomplete="off" />
+            <input id="station" type="text" placeholder="Tape une station ou son code (ex : Levski, ARCL1)" autocomplete="off"
+                   role="combobox" aria-autocomplete="list" aria-expanded="false" aria-controls="stationPickList" />
+            <ul id="stationPickList" class="autocomplete stn-pick" role="listbox" hidden></ul>
+            <!-- La datalist RESTE, et sans son `list` sur #station : trois autres champs s'en
+                 servent encore (#destTerminal, #journeyStart, #journeyAddStop) et huit assertions
+                 E2E la lisent, dont une comme barrière de synchro « market.json est arrivé ». Elle
+                 n'alimente simplement plus ce champ-ci, que le sélecteur groupé a repris. -->
             <datalist id="stationList"></datalist>
           </div>
           <p class="enroute-hint">Corrige les <b>prix et stocks</b> d'une station même hors trajet (clique un chiffre). Tes corrections sont <b>locales</b> (jamais partagées) et périment automatiquement dès qu'UEX publie un relevé plus récent. Utilise le champ <b>Commodité</b> pour filtrer la station.</p>

--- a/logic.mjs
+++ b/logic.mjs
@@ -1074,6 +1074,53 @@ export function parseStationLabel(label) {
   return i < 0 ? { name: s, system: "" } : { name: s.slice(0, i), system: s.slice(i + 3) };
 }
 
+// Ordre d'affichage des systèmes dans le sélecteur de station : par volume décroissant de
+// terminaux (Stanton 80, Pyro 27, Nyx 7). C'est aussi l'ordre dans lequel un joueur les rencontre.
+// Un système absent de cette liste n'est pas perdu : il passe en queue, trié par son nom.
+const ORDRE_SYSTEMES = ["Stanton", "Pyro", "Nyx"];
+
+// Zone d'un terminal : l'échelon intermédiaire entre le système et la station.
+// 12 terminaux sur 114 n'ont pas de planète — les 7 portes de saut, les 4 PSS et Levski. L'ADR-003
+// a d'abord voulu combler ce trou avec `orbit_name`, sur la foi qu'il recopiait le nom du terminal.
+// Mesuré contre l'API : il en donne une VARIANTE (« Pyro Gateway (Stanton system) » pour le
+// terminal « Pyro Gateway (Stanton) », « People's Service Station Alpha » pour « PSS Alpha »). Le
+// test « orbite ≠ nom » était donc vrai partout, et la règle fausse sur 11 des 12. Le champ
+// n'achetait qu'un seul libellé utile — « Delamar » pour Levski — au prix de cette erreur : on y a
+// renoncé, et les 12 tombent ensemble dans « Espace profond ».
+const zoneDe = (t) => t.planet || "Espace profond";
+
+// Range les terminaux en système › zone › station, pour un sélecteur qui se parcourt à l'œil.
+// Fonction PURE : elle reçoit le tableau, ne lit aucune globale, et ne le modifie pas.
+// Renvoie [{ systeme, zones: [{ zone, stations: [...] }] }].
+// Chaque station porte `i`, son index dans le tableau d'ENTRÉE : c'est la seule clé fiable, `code`
+// n'étant pas unique (PYROG désigne les deux Pyro Gateway). `label` est pré-calculé parce que c'est
+// lui, et lui seul, que le champ doit recevoir — resolveStation résout par correspondance exacte.
+export function stationTree(terminals) {
+  const parSysteme = new Map();
+  (terminals || []).forEach((t, i) => {
+    const systeme = t.system || "?";
+    const zone = zoneDe(t);
+    if (!parSysteme.has(systeme)) parSysteme.set(systeme, new Map());
+    const zones = parSysteme.get(systeme);
+    if (!zones.has(zone)) zones.set(zone, []);
+    zones.get(zone).push({
+      i, name: t.name, system: systeme, zone,
+      code: t.code || "", shot: t.shot || "", outpost: !!t.outpost,
+      label: stationLabel(t.name, systeme),
+    });
+  });
+
+  const rang = (s) => { const r = ORDRE_SYSTEMES.indexOf(s); return r < 0 ? ORDRE_SYSTEMES.length : r; };
+  return [...parSysteme.entries()]
+    .sort((a, b) => rang(a[0]) - rang(b[0]) || a[0].localeCompare(b[0], "fr"))
+    .map(([systeme, zones]) => ({
+      systeme,
+      zones: [...zones.entries()]
+        .sort((a, b) => a[0].localeCompare(b[0], "fr"))
+        .map(([zone, stations]) => ({ zone, stations: stations.sort((x, y) => x.name.localeCompare(y.name, "fr")) })),
+    }));
+}
+
 // ---------- Compagnon de voyage : modèle de « parcours » (pur, sérialisable) ----------
 // Un parcours = suite ORDONNÉE de sauts (legs) contigus + position courante (index de station).
 //   leg = { from, fromSystem, to, toSystem, commodity, buyPrice, sellPrice, margin }

--- a/logic.test.mjs
+++ b/logic.test.mjs
@@ -23,6 +23,7 @@ import {
   journeyConnects, addToJourney, setJourneyPosition, currentLeg, journeyMargin,
   encodeJourney, decodeJourney, removeJourneyStop, freeManifestLine, hydrateManifestLine,
   cleApresRetrait, reindexerRangsJambe, detacherLotsDeJambe,
+  stationTree,
 } from "./logic.mjs";
 
 // ---------- Temps de trajet ----------
@@ -3366,4 +3367,73 @@ test("interrupteur inactif : aucune fonction de métriques ne facture quoi que c
   assert.equal(manifestTotals(t.lines).fees, 0);
   assert.equal(buildChainAdjacency(MKT_NET(), { legalOnly: false, noOutpost: false }, idResolve).get(0)[0].fee, null);
   assert.equal(bestChain(ADJ, "A", 2, { cargo: 50 }).profit, 1_750); // fixture historique, sans `fee`
+});
+
+// ---------- stationTree : les 114 terminaux rangés système › zone › station (ADR-003) ----------
+// L'arbre qui alimente le sélecteur de station. La ZONE est ce qui demande le plus d'attention :
+// 12 terminaux sur 114 n'ont pas de planète — les 7 portes de saut, les 4 PSS et Levski. L'ADR-003
+// a d'abord voulu combler le trou avec `orbit_name`, avant de mesurer qu'il n'en recopie pas le nom
+// du terminal mais une variante (« Pyro Gateway (Stanton system) »), rendant la règle fausse sur 11
+// des 12. On s'en tient donc à : planète, sinon « Espace profond ».
+const TERMINAUX_ARBRE = () => [
+  { name: "Ruin Station", system: "Pyro", planet: "Pyro V", outpost: false, code: "RUIN", shot: "https://x/r.jpg" },
+  { name: "Levski", system: "Nyx", planet: "", outpost: false, code: "LEVSKI", shot: "" },
+  { name: "Écho", system: "Stanton", planet: "Ærea", outpost: true, code: "ECHO", shot: "" },
+  { name: "Area 18", system: "Stanton", planet: "ArcCorp", outpost: false, code: "A18", shot: "" },
+  { name: "Astor", system: "Stanton", planet: "Ærea", outpost: false, code: "AST", shot: "" },
+];
+
+test("stationTree range les systèmes dans l'ordre Stanton, Pyro, Nyx quelle que soit l'entrée", () => {
+  // L'entrée est délibérément dans l'ordre inverse : c'est la fonction qui ordonne, pas les données.
+  const arbre = stationTree(TERMINAUX_ARBRE());
+  assert.deepEqual(arbre.map((s) => s.systeme), ["Stanton", "Pyro", "Nyx"]);
+});
+
+test("stationTree : un système inconnu passe en queue plutôt que de disparaître", () => {
+  const arbre = stationTree([...TERMINAUX_ARBRE(), { name: "Ailleurs", system: "Terra", planet: "", outpost: false, code: "T", shot: "" }]);
+  assert.equal(arbre.at(-1).systeme, "Terra");
+  assert.equal(arbre.length, 4);
+});
+
+test("stationTree : sans planète, la zone est « Espace profond »", () => {
+  const nyx = stationTree(TERMINAUX_ARBRE()).find((s) => s.systeme === "Nyx");
+  assert.deepEqual(nyx.zones.map((z) => z.zone), ["Espace profond"]);
+  assert.equal(nyx.zones[0].stations[0].name, "Levski");
+});
+
+test("stationTree trie zones et stations en français (accents compris)", () => {
+  const stanton = stationTree(TERMINAUX_ARBRE()).find((s) => s.systeme === "Stanton");
+  // « Ærea » se classe avant « ArcCorp » en tri français, pas en tri par point de code.
+  assert.deepEqual(stanton.zones.map((z) => z.zone), ["Ærea", "ArcCorp"]);
+  assert.deepEqual(stanton.zones[0].stations.map((s) => s.name), ["Astor", "Écho"]);
+});
+
+test("stationTree : chaque station porte son index d'origine et son libellé canonique", () => {
+  // L'index est la SEULE clé fiable : `code` n'est pas unique (PYROG × 2 dans les vraies données).
+  // Le libellé est pré-calculé pour que le choix n'ait rien à reconstruire — c'est lui qu'attend
+  // resolveStation, par correspondance exacte.
+  const pyro = stationTree(TERMINAUX_ARBRE()).find((s) => s.systeme === "Pyro");
+  const ruin = pyro.zones[0].stations[0];
+  assert.equal(ruin.i, 0); // premier du tableau d'entrée
+  assert.equal(ruin.label, stationLabel("Ruin Station", "Pyro"));
+  assert.equal(ruin.code, "RUIN");
+  assert.equal(ruin.outpost, false);
+});
+
+test("stationTree : deux terminaux de même code restent deux stations distinctes", () => {
+  const arbre = stationTree([
+    { name: "Pyro Gateway (Stanton)", system: "Stanton", planet: "", outpost: false, code: "PYROG", shot: "" },
+    { name: "Pyro Gateway (Nyx)", system: "Nyx", planet: "", outpost: false, code: "PYROG", shot: "" },
+  ]);
+  const plates = arbre.flatMap((s) => s.zones.flatMap((z) => z.stations));
+  assert.equal(plates.length, 2);
+  assert.notDeepEqual(plates[0].i, plates[1].i);
+});
+
+test("stationTree : les stations d'une même zone sont CONTIGUËS une fois l'arbre aplati", () => {
+  // Contrainte structurelle du rendu groupé : il pose un en-tête dès que (système, zone) change,
+  // par simple comparaison au précédent. Sans contiguïté, le même en-tête reviendrait plusieurs fois.
+  const plates = stationTree(TERMINAUX_ARBRE()).flatMap((s) => s.zones.flatMap((z) => z.stations));
+  const cles = plates.map((s) => `${s.system} › ${s.zone}`);
+  assert.deepEqual(cles, [...new Set(cles)].flatMap((c) => cles.filter((x) => x === c)));
 });

--- a/style.css
+++ b/style.css
@@ -237,8 +237,10 @@ input:disabled, select:disabled { opacity: 0.4; cursor: not-allowed; }
 /* --muted plutôt qu'un gris plus sombre : ~6,3:1 sur le fond du champ, au-dessus du 4,5:1 exigé (AA). */
 input::placeholder { color: var(--muted); }
 
-/* ---------- Autocomplétion vaisseau ---------- */
-.ship-field { position: relative; }
+/* ---------- Autocomplétion (vaisseau, station) ---------- */
+/* Contexte d'ancrage de la liste déroulante. Posé sur ces deux classes et NON sur `.field` : celle-ci
+   est partagée par tous les panneaux de contrôle, `.field.sub-field` et `.field.checks` comprises. */
+.ship-field, .picker-field { position: relative; }
 .autocomplete {
   position: absolute; top: 100%; left: 0; right: 0; z-index: 40; margin: 4px 0 0; padding: 4px 0;
   list-style: none; background: var(--panel-solid); border: 1px solid var(--line2);
@@ -248,6 +250,54 @@ input::placeholder { color: var(--muted); }
 .autocomplete li .scu { color: var(--muted); font-size: 12px; white-space: nowrap; font-family: var(--mono); }
 .autocomplete li.active { background: rgba(255, 176, 32, 0.14); color: #fff; }
 .autocomplete li.active .scu { color: var(--acc); }
+
+/* ---------- Sélecteur de station groupé (ADR-003) ---------- */
+/* LE point du lot : la liste s'affranchit de la largeur du champ. C'est ce que le <datalist> natif
+   ne savait pas faire, et c'est pourquoi « Terra Gateway (Stanton) — Stanton » (33 caractères) y
+   était tronqué. `max-content` la dimensionne sur son plus long nom, borné pour ne pas déborder. */
+.stn-pick { right: auto; min-width: max-content; max-width: min(440px, 90vw); }
+.stn-pick li { align-items: center; justify-content: flex-start; gap: 10px; padding: 6px 12px; }
+/* En-tête de groupe : collant, pour savoir dans quel système on défile. Non sélectionnable — il ne
+   porte pas de data-i, ni au clavier ni à la souris. */
+.stn-pick li.opt-grp {
+  position: sticky; top: 0; z-index: 1; cursor: default; padding: 7px 12px 5px;
+  background: var(--panel-solid); border-bottom: 1px solid var(--line);
+  font-family: var(--display); font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--muted);
+}
+.stn-pick li.opt-grp + li { padding-top: 8px; }
+/* Surtout PAS de text-overflow ici : la troncature est précisément ce qu'on répare. */
+.stn-pick .stn-opt-name { flex: 1 1 auto; min-width: 0; white-space: nowrap; }
+.stn-pick .stn-opt-code { flex: 0 0 auto; font-family: var(--mono); font-size: 11px; color: var(--muted); }
+.stn-pick li.active .stn-opt-code { color: var(--acc); }
+/* Le glyphe ne suffit pas : le mot reste écrit, comme partout ailleurs dans ce dépôt. */
+.stn-pick .stn-opt-post { flex: 0 0 auto; font-size: 10px; color: var(--warn); white-space: nowrap; }
+
+/* Vignette de station — primitive PARTAGÉE avec la bande de la vue Corrections (LOT 3) : une seule
+   définition, sinon deux dégradés divergents pour la même chose. La photo se superpose au carré
+   généré, qui reste dessous en repli : 17 terminaux sur 114 n'en ont pas, et une URL peut tomber
+   (`.no-shot`, posé par l'écouteur `error` délégué). */
+/* Conteneur positionné : la photo se pose EN ABSOLU par-dessus le repli, donc exactement dans la
+   même case. Les superposer par marge négative les décalait de la valeur du `gap` flex, et le code
+   du repli débordait derrière la photo. */
+.stn-vign {
+  position: relative; flex: 0 0 auto; width: 34px; height: 24px; border-radius: 2px;
+  border: 1px solid var(--line); overflow: hidden;
+  background: linear-gradient(140deg, rgba(130, 150, 210, 0.16), rgba(11, 15, 28, 0.9));
+}
+.stn-vign.sys-stanton { background: linear-gradient(140deg, rgba(56, 189, 248, 0.28), rgba(11, 15, 28, 0.9)); }
+.stn-vign.sys-pyro { background: linear-gradient(140deg, rgba(255, 106, 61, 0.28), rgba(11, 15, 28, 0.9)); }
+.stn-vign.sys-nyx { background: linear-gradient(140deg, rgba(169, 112, 255, 0.28), rgba(11, 15, 28, 0.9)); }
+.stn-shot-gen {
+  position: absolute; inset: 0; display: grid; place-items: center; overflow: hidden;
+  font-family: var(--mono); font-size: 8px; letter-spacing: 0.5px; color: var(--muted);
+}
+.sys-stanton .stn-shot-gen { color: var(--stanton); }
+.sys-pyro .stn-shot-gen { color: var(--pyro); }
+.sys-nyx .stn-shot-gen { color: var(--nyx); }
+/* La photo couvre tout le conteneur. `.no-shot` (posé par l'écouteur `error` délégué) la retire et
+   laisse réapparaître le repli, sans laisser d'image cassée. */
+.stn-shot { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; }
+.no-shot .stn-shot { display: none; }
 
 /* ---------- Carte vaisseau ---------- */
 .ship-card {

--- a/sw.js
+++ b/sw.js
@@ -5,7 +5,7 @@
 // recevrait encore l'ANCIEN index.html — sans CSP et avec son <script> inline — pendant toute une
 // visite, tandis que rail.js, lui, serait déjà là. `activate` purge tout cache au nom différent :
 // le bump garantit que la nouvelle page et son script arrivent ENSEMBLE.
-const CACHE = "best-hauling-v5";
+const CACHE = "best-hauling-v6";
 // Coquille précachée. Les woff2 (mêmes-origine depuis fonts/) sont mis en cache au premier
 // rendu par le gestionnaire fetch ci-dessous (stale-while-revalidate) -> hors-ligne complet.
 const SHELL = ["./", "./index.html", "./app.js", "./rail.js", "./logic.mjs", "./style.css", "./fonts/fonts.css", "./icon.svg", "./manifest.webmanifest"];


### PR DESCRIPTION
## Ce que ça change

Le champ **« Station à corriger »** ne sert plus ses 114 terminaux dans une liste native tronquée, mais dans un sélecteur maison **groupé `système › zone › station`**, avec la vignette du terminal, son code UEX et son marqueur d'avant-poste. On peut chercher par nom **ou par code** (`ARCL1`, `PYROG`), parcourir aux flèches, et les noms longs sont lisibles en entier.

## Pourquoi

`index.html:228` — `<input id="station" list="stationList">`. La liste déroulante d'un `<datalist>` est calée sur la largeur du champ, et ce champ vit dans un panneau étroit : les libellés, 20,6 caractères en moyenne et jusqu'à **33** (« Terra Gateway (Stanton) — Stanton »), y étaient coupés. Un `<datalist>` ne se met pas en forme non plus, donc ni vignette, ni badge, ni regroupement — et 114 entrées à plat ne se parcourent pas.

**L'autocomplétion existait déjà** pour le champ Vaisseau. Elle est extraite en `montePicker`, partagée par les deux champs, avec trois généralisations dont chacune est nécessaire aux stations :

1. `options` est une **fonction** relue à chaque ouverture, non un tableau capturé : les vaisseaux existent au montage, les stations seulement après `market.json`.
2. La navigation cible `li[data-i]` et non `list.children`. Les en-têtes de groupe brisent la bijection enfants ↔ résultats : sans ce filtre, la 3<sup>e</sup> flèche bas posait `.active` sur un en-tête et Entrée choisissait la mauvaise station. C'est le seul vrai défaut de réutilisabilité du code d'origine.
3. `rendu` reçoit le tableau **entier**, ce qui permet d'intercaler ces en-têtes.

`stationTree` (pure, dans `logic.mjs`) range les terminaux. Sa règle de zone est celle que **l'ADR-003 a amendée** : `planète || « Espace profond »`. La règle initiale s'appuyait sur `orbit_name`, mesuré faux sur **11 des 12** terminaux sans planète — il n'en recopie pas le nom du terminal mais une variante (« Pyro Gateway (Stanton system) »).

**Deux pièges traités**, tous deux vérifiés dans le code :

- **CSP.** `script-src 'self'` (`index.html:23`) rend inerte un `<img onerror>` posé par `innerHTML`, laissant une image cassée. Le repli photo passe donc par un écouteur `error` **délégué en phase de capture** — les événements `error` ne remontent pas, mais ils descendent.
- **Ancrage.** `.field` n'a pas `position: relative` ; seul `.ship-field` l'avait. Sans contexte, la liste s'ancrerait sur le viewport. L'ancrage va sur une classe dédiée `.picker-field`, et non sur `.field` — partagée par tous les panneaux de contrôle, `.field.sub-field` et `.field.checks` comprises.

`sw.js` passe de **v5 à v6** : `index.html` et `app.js` changent ensemble, ce que le commentaire d'en-tête de `sw.js` impose de protéger par un bump — sinon un visiteur déjà installé reçoit l'ancien HTML avec le nouveau script, et le sélecteur est mort pendant toute une visite.

## Vérification

```
$ node --test
ℹ tests 373   ℹ pass 373   ℹ fail 0

$ npx playwright test
106 passed, 2 skipped (48.6s)   — 0 échec
```

**TDD.** Les six tests E2E neufs échouaient avant, `#stationPickList` n'existant pas. Les sept tests unitaires de `stationTree` échouaient au **chargement du module** (`SyntaxError: does not provide an export named 'stationTree'`) — en ESM un import nommé manquant fait tomber le fichier entier, pas un test.

**Un septième test E2E est né du contrôle visuel**, et c'est le plus instructif : la capture montrait le code de la vignette de repli **dépasser derrière la photo** — on lisait « TA » derrière celle de Nyx Gateway (Stanton), dont le code est `NYXSTA`. Les deux éléments, superposés par marge négative, se décalaient exactement de la valeur du `gap` flex (10 px), que la marge ne compensait pas. Le test mesure l'égalité des deux rectangles ; il a échoué avec `273 !== 283`. La superposition passe désormais par un conteneur positionné, et la photo se pose en absolu par-dessus le repli.

Ce que les tests couvrent : nom long non tronqué et liste plus large que le champ · recherche par code remontant les **deux** passerelles homonymes `PYROG`, distinguées par leur en-tête de groupe · les flèches ne s'arrêtent jamais sur un en-tête · Entrée écrit le **libellé canonique** `Nom — Système` et affiche la station · la datalist historique conserve ses 114 options et `#station` n'a plus d'attribut `list` · photo et repli exactement superposés.

## Ce qui n'est pas couvert

- **Les quatre autres champs de terminal gardent le `<datalist>` natif** — `#destTerminal`, `#journeyStart`, `#journeyAddStop`, `#origin`. C'est délibéré : l'ADR-003 en fait une PR de suivi, pour ne pas quadrupler la surface de test dans celle-ci. Le composant est écrit pour eux.
- **Aucune navigation aux flèches entre groupes**, et pas de `role="tablist"` : la liste reste un `listbox` plat avec des en-têtes `role="presentation"`.
- La photo ne s'affiche pas hors-ligne : `sw.js:41` ignore volontairement le cross-origin. Le repli teinté prend sa place, sans case vide.
- Deux tests continuent de se sauter tout seuls (`smoke.pw.mjs:1057` et `:1097`), préexistant et documenté par la PR #34.

Closes #36
Réf. ADR-003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)