### PR TITLE
docs(ui): les commentaires ne citent plus un bouton 🗺 disparu depuis

### DIFF
--- a/style.css
+++ b/style.css
@@ -675,7 +675,7 @@ tbody tr:hover td { border-bottom-color: var(--line2); }
 /* Pastille de fraîcheur : dernière ligne, en bas de la cellule. */
 .loc-fresh { margin-top: 6px; }
 /* Boucles : Départ / ⇄ inter-système / Arrivée empilés sur 3 lignes, mêmes styles pour les
-   deux noms (via .term-name). Le bouton 🗺 est le 1er enfant du td -> la règle générique
+   deux noms (via .term-name). Le bouton ▶ est le 1er enfant du td -> la règle générique
    « .loc > div:first-child » ne cible pas .loop-ends (aucun div n'est premier enfant). */
 .loop-arrow { color: var(--acc); font-weight: 700; font-size: 13px; }
 .loop-cell { display: flex; align-items: flex-start; gap: 8px; }
@@ -1047,7 +1047,7 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 /* Icônes des commodités chargées, dans la cellule de gauche du tableau. */
 .multi-icons { display: inline-flex; align-items: center; gap: 2px; margin-right: 4px; }
 .multi-icons .muted { font-size: 10px; }
-/* Chargement détaillé (dépliage 🗺) : même grille que les suggestions, + une colonne caisses. */
+/* Chargement détaillé (dépliage 📦) : même grille que les suggestions, + une colonne caisses. */
 /* Le chargement est désormais SEUL dans la rangée dépliée : il y reprend le liseré ambre et le
    retrait que .schema portait au-dessus de lui (#30). Le trait supérieur, qui ne servait qu'à l'en
    séparer, n'a plus rien à séparer. */


### PR DESCRIPTION
## Ce que ça change

Rien à l'écran. Deux commentaires de `style.css` décrivaient l'interface avec un bouton 🗺 qui
n'existe plus, dont un qui expliquait une règle CSS en nommant le mauvais élément — de quoi
envoyer le prochain lecteur casser la règle en croyant la corriger.

## Pourquoi

Le glyphe 🗺 a **zéro occurrence** dans `app.js`, `index.html` et `style.css` : seuls deux
commentaires le mentionnaient encore. Le commit `ced5f06` (« un ▶ visible, et un dépliant qui ne
montre plus que le chargement ») a supprimé ce dépliant de trajet des Trajets simples et des
Boucles — la carte du voyage montrait déjà la géographie (#30) — et, là où il survit en
multi-commodité, l'a fait passer à 📦 tout en le plaçant **après** le ▶.

- `style.css:678` — « Le bouton 🗺 est le 1er enfant du td ». Faux **deux fois** : le glyphe a
  disparu, et depuis `ced5f06` le premier enfant du `td` des Boucles est le bouton `▶`
  (`.journey-pick`, `app.js:646`). Le raisonnement du commentaire, lui, reste juste — c'est bien un
  `<button>` et non un `<div>` qui ouvre la cellule, donc `.loc > div:first-child` ne cible
  toujours pas `.loop-ends`. Seul le nom de l'élément était périmé, la règle CSS est correcte et
  n'est pas touchée.
- `style.css:1050` — « Chargement détaillé (dépliage 🗺) ». Le dépliant existe encore mais porte
  📦 (`app.js:523`).

Le titre du test `e2e/smoke.pw.mjs:107` (« plus de dépliant 🗺 ») **garde volontairement** le
glyphe : il nomme ce qui a été supprimé, c'est tout son propos.

## Vérification

- `node --test` → **373 tests, 373 pass, 0 fail** (231 ms).
- `npx playwright test` → **106 passed, 2 skipped, 0 failed** (48,3 s), 108 tests au total.
- `grep -rn "🗺"` sur `*.css`, `*.js`, `*.html`, `*.mjs`, `*.md` → une seule occurrence restante,
  le titre du test e2e, conservée à dessein.

Aucun test n'échouait avant : ce n'est pas un correctif de comportement, aucun test ne pouvait le
voir. C'est précisément pour ça que ces commentaires ont survécu à trois refontes.

## Ce qui n'est pas couvert

- La **règle CSS** elle-même n'est pas modifiée : elle est correcte, seul son commentaire mentait.
- Le corps de l'issue #25 citait le même glyphe fantôme ; il a été rectifié directement sur
  l'issue, hors de cette PR. Les numéros de ligne de son paragraphe « Où » datent d'avant
  plusieurs refontes et restent à revérifier avant tout correctif — non traité ici.
- Aucun balayage systématique des autres commentaires périmés du dépôt n'a été fait : seul le
  glyphe 🗺 a été poursuivi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
