### PR TITLE
feat(corrections): ranger ses corrections par station, dans une bande de vignettes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Six vues, un même moteur de calcul (soute SCU + budget aUEC → unités, coût,
 | **Boucles ⇄** | Meilleures boucles A⇄B (une commodité à l'aller, une autre au retour) pour ne jamais repartir à vide |
 | **En route 🧭** | Depuis un terminal de départ : le fret rentable + un **manifeste optimal** qui remplit la soute avec **plusieurs commodités** vers une même destination (avec suggestions pour combler l'espace libre) |
 | **Chaîne ⛓️** | Trajets **multi-sauts A→B→C…** (2 à 4 sauts) : achète, vends, rachète sur place, revends plus loin — recherche par faisceau du circuit le plus rentable. Chaque saut retient la commodité qui **rapporte** le plus une fois plafonnée par le stock et la demande, pas celle à la plus forte marge affichée |
-| **Corrections ✎** | Voir/gérer ses corrections locales et en créer en **cherchant une station** (voir plus bas) |
+| **Corrections ✎** | Ses corrections locales **rangées par station** (bande de vignettes), et de quoi en créer via un sélecteur groupé `système › zone › station` (voir plus bas) |
 | **Commodités 📊** | *Big board* type « salle des marchés », en deux modes. **◈ Marché** : toutes les commodités échangeables avec leur **code officiel UEX** (AGRI, QUAN…), triables (marge / code / catégorie), et au clic **tous leurs points d'achat et de vente** — pratique pour trouver **où écouler** une commodité quand une station n'a plus de demande. **💰 Butin** : le board bascule sur le **prix de revente au SCU** et fait entrer les commodités qu'on **ne peut pas acheter** (minerais raffinés, salvage, drogues de wreck) — la réponse à « j'ai trouvé ça, ça vaut combien et où je l'écoule ? » |
 
 Autres éléments :
@@ -336,6 +336,18 @@ jamais partagé ni mis dans l'URL) et **intelligent** :
 - Elle est **périmée automatiquement** dès qu'UEX republie ce point avec un relevé plus récent (retour à la valeur UEX, petit flash de notification).
 - Un **volume** (stock, demande, et la déduction d'un `✓ chargé`) périme **aussi au bout de 3 h**, même si UEX n'a rien republié. Un **prix**, non : les deux ne vieillissent pas pareil, [voir plus bas](#pourquoi-un-volume-périme-en-3-h-et-pas-un-prix).
 - Sémantique respectée : un **stock d'achat à 0 = terminal vide** (plafonne à 0), et une **demande que _tu_ corriges fait autorité** — y compris un 0, qui vaut « pas de demande » et plafonne à 0 même là où UEX ne renseignait rien. Les valeurs UEX brutes, elles, gardent leur sémantique propre (`null` = capacité inconnue, `0` = terminal saturé) : [voir le piège des volumes UEX](#sémantique-des-volumes-uex-piège).
+- **Retour arrière par chiffre** : un chiffre corrigé porte, sous lui, un bouton `↺` qui annonce la valeur UEX vers laquelle il ramène. On défait là où on regarde.
+
+### La vue Corrections se range par station
+
+La vue est organisée autour de la **station**, pas de la correction ([ADR-003](docs/superpowers/specs/2026-08-13-refonte-vue-corrections-adr.md)) :
+
+- **Une bande de vignettes** en tête, une par station corrigée, avec sa photo et son compteur. Vingt corrections y tiennent en une rangée, là où la liste plate en faisait vingt lignes — rangées par commodité, donc jamais côte à côte pour un même comptoir.
+- La **station affichée est épinglée en première position** et mise en surbrillance (« en cours »). La bande se lit comme une barre d'onglets ; un clic sur une vignette recharge sa station.
+- Un **bandeau collant** porte la photo du terminal, son système, sa zone, son code UEX et le nombre de corrections qu'on y a faites — il reste à l'écran pendant qu'on fait défiler les 92 commodités de GrimHEX.
+- Le **sélecteur de station** est groupé `système › zone › station`, cherche par nom **ou par code** (`ARCL1`, `PYROG`), et n'est plus tronqué.
+
+Les photos viennent d'UEX (soumises par des joueurs, l'auteur est crédité) : **97 des 114 terminaux** en ont une. Les 17 autres reçoivent une vignette générée, teintée par système et portant le code — aucune requête, aucune case vide. Elles ne sont pas mises en cache hors-ligne (le service worker ignore volontairement le cross-origin) : le repli prend alors le relais.
 
 ### Pourquoi un volume périme en 3 h, et pas un prix
 

--- a/app.js
+++ b/app.js
@@ -5,7 +5,7 @@ import {
   tripMinutes, ageDays, pairAge,
   normalizeScores, bySort, addableUnits, scuBoxes, cargoBoxes, bestChain,
   AUTOLOAD, autoloadFee, autoloadPoint, haulFee, lineHaulFee, lineNet,
-  ovKey, effFromStore, setInStore, DUREE_VOL, safeKey, encodeState, decodeState,
+  ovKey, effFromStore, setInStore, DUREE_VOL, groupOverridesByTerminal, safeKey, encodeState, decodeState,
   routePasses, loopPasses,
   routeMetrics, loopMetrics, enRouteDeals, bestManifest, buildChainAdjacency, suggestionsFrom, netMarginRoi,
   commoditySummaries, commodityPoints, compactValue, valueTiers, resolveCommodity, ambiguousCodes,
@@ -683,6 +683,9 @@ let stationMap = new Map();   // libellé -> index, TOUS les terminaux (pour la 
 let termByName = new Map();
 let enrouteOrigin = null;     // index du terminal de départ sélectionné
 let stationSel = null;        // index de la station sélectionnée (vue Corrections)
+// Signature du panneau de frais déjà peint : tant qu'elle ne bouge pas, on ne le réécrit pas, et
+// une saisie en cours y survit (#24).
+let feesRendus = null;
 
 // Charge le graphe de marché à la demande. Deux règles, apprises à la dure :
 //   - on mémorise la PROMESSE en vol, pas seulement son résultat : sinon chaque frappe pendant le
@@ -2613,9 +2616,15 @@ function stationTableHTML(S, q) {
     if (!b && !s) return;
     const cote = (p, side, libelle, unite) => {
       const e = effVals(c.name, t.name, side, p[1], p[2], p[3]);
+      // Les boutons de retour vivent sur LEUR PROPRE ligne, sous les valeurs. Glissés parmi
+      // elles, ils comprimaient le texte de l'étiquette dans une tuile large de 236 px : « aUEC ·
+      // stock » se coupait en deux.
+      const retours = retourUEX(c.name, t.name, side, "price", p[1], e.oprice)
+        + retourUEX(c.name, t.name, side, "vol", p[2], e.ovol);
       return `<div class="scomm-side"><span class="scomm-lbl">${libelle}</span>` +
         `${editv(c.name, t.name, side, "price", e.price, e.oprice, p[3])} aUEC · ${unite} ` +
-        `${editv(c.name, t.name, side, "vol", e.vol, e.ovol, p[3])}</div>`;
+        `${editv(c.name, t.name, side, "vol", e.vol, e.ovol, p[3])}</div>` +
+        (retours ? `<div class="scomm-undos">${retours}</div>` : "");
     };
     // Une seule ligne par côté RÉEL : plus de « achat — » à afficher sous chaque vente.
     const corps = (b ? cote(b, "buy", "achat", "stock") : "") + (s ? cote(s, "sell", "vente", "dem.") : "");
@@ -2629,17 +2638,85 @@ function stationTableHTML(S, q) {
     (b ? achats : ventes).push(tuile);
   });
 
-  const fee = stationFeeHTML(S);
+  // Le panneau de frais N'EST PLUS rendu ici : il part dans #correctionsFees, hors du conteneur que
+  // renderCorrections réécrit à chaque rendu (#24). Il en sortait par DEUX chemins — l'interpolation
+  // nominale et la branche « aucune commodité » ci-dessous.
   const total = achats.length + ventes.length;
-  if (!total) return `${fee}<p class="empty">Aucune commodité ${q ? "correspondante " : ""}à ${esc(t.name)}.</p>`;
+  const hero = stationHeroHTML(S, total, q);
+  if (!total) return `${hero}<p class="empty">Aucune commodité ${q ? "correspondante " : ""}à ${esc(t.name)}.</p>`;
   const section = (cle, titre, aide, tuiles) => tuiles.length
     ? `<div class="station-section"><h4 class="station-section-head ${cle}">◈ ${titre} <span class="station-count">${tuiles.length}</span><span class="station-section-aide">${aide}</span></h4>
        <div class="station-grid">${tuiles.join("")}</div></div>`
     : "";
-  return `<div class="station-title">◈ ${esc(t.name)}${sysBadge(t.system)} — clique un chiffre pour le corriger localement <span class="station-count">${total} commodité${total > 1 ? "s" : ""}${q ? " filtrées" : ""}</span></div>
-    ${fee}
+  return `${hero}
     ${section("achat", "On y achète", "ce que la station te vend — prix et stock", achats)}
     ${section("vente", "On y vend", "ce qu'elle te reprend — prix et demande", ventes)}`;
+}
+
+// Bandeau COLLANT de la station affichée : sa photo, son nom, sa zone, son code, et ce qu'on y a
+// corrigé. Il remplace la ligne de titre, qui sortait de l'écran au premier coup de molette — après
+// quoi plus rien ne disait quelle station on éditait, au milieu de 92 tuiles.
+function stationHeroHTML(S, total, q) {
+  const t = MARKET.terminals[S];
+  const n = Object.keys(OVERRIDES).filter((k) => k.split("|")[1] === t.name).length;
+  const vign = vignetteStation({ name: t.name, system: t.system, code: t.code || "", shot: t.shot || "" });
+  // Crédit à l'auteur de la capture, et SEULEMENT s'il existe : 97 terminaux ont une photo pour 89
+  // auteurs, donc huit afficheraient sinon un « photo : » suivi de rien.
+  const credit = t.shot && t.shotBy ? `<span class="stn-hero-credit">photo : ${esc(t.shotBy)}</span>` : "";
+  return `<div class="stn-hero">
+    ${vign}
+    <div class="stn-hero-txt">
+      <div class="stn-hero-line">
+        <span class="stn-hero-name">${esc(t.name)}</span>${sysBadge(t.system)}
+        <span class="stn-hero-zone">${esc(t.planet || "Espace profond")}</span>
+        <span class="stn-hero-code">${esc(t.code || "")}</span>
+        <span class="station-count">${total} commodité${total > 1 ? "s" : ""}${q ? " filtrées" : ""}</span>
+        ${n ? `<button type="button" id="stnClear" class="reset-ov" title="Effacer les corrections de cette station">✕ ${n} correction${n > 1 ? "s" : ""}</button>` : ""}
+      </div>
+      <div class="stn-hero-sub">clique un chiffre pour le corriger localement${credit}</div>
+    </div>
+  </div>`;
+}
+
+// Retour à la valeur UEX d'un chiffre corrigé. Contrôle DÉDIÉ, posé dans la tuile et hors du
+// `.editv` : celui-ci porte déjà `role="button"`, et y imbriquer un second bouton serait invalide en
+// ARIA — tandis que sortir le `✎` casserait la restauration de startEdit (qui mémorise puis rejoue
+// les childNodes du span) et l'assertion qui la couvre. Il annonce la valeur vers laquelle il
+// ramène : c'est ce que l'ancienne liste plate ne montrait jamais.
+function retourUEX(commodity, terminal, side, field, brut, ov) {
+  if (!ov) return "";
+  const v = Number.isFinite(Number(brut)) ? Number(brut) : null;
+  const quoi = field === "price" ? "le prix" : side === "buy" ? "le stock" : "la demande";
+  return `<button type="button" class="scomm-undo" data-c="${esc(commodity)}" data-t="${esc(terminal)}" data-s="${side}" data-f="${field}"` +
+    ` title="Revenir à ${quoi} publié par UEX">↺ ${fmtVol(v)}</button>`;
+}
+
+// La bande : une vignette par station corrigée, la station affichée épinglée en tête. C'est elle qui
+// remplace la liste plate — vingt corrections y tenaient en 900 px, elles tiennent ici en une rangée.
+function correctionsIndexHTML() {
+  const actif = stationSel != null ? MARKET.terminals[stationSel].name : null;
+  const groupes = groupOverridesByTerminal(OVERRIDES, actif);
+  if (!groupes.length) {
+    return '<p class="empty">Aucune correction locale pour l\'instant. Cherche une station ci-dessus pour en créer.</p>';
+  }
+  const autres = groupes.filter((g) => !g.actif);
+  const total = groupes.reduce((s, g) => s + g.corrections, 0);
+  const tuiles = groupes.map((g) => {
+    const t = termByName.get(g.terminal);
+    // Terminal disparu de market.json : la vignette s'affiche quand même, sinon la correction
+    // deviendrait invisible ET ineffaçable. Elle n'est simplement pas cliquable.
+    const vign = vignetteStation({ name: g.terminal, system: t ? t.system : "", code: t ? t.code || "" : "", shot: t ? t.shot || "" : "" });
+    return `<button type="button" class="stn-tile${g.actif ? " active" : ""}${t ? "" : " orphelin"}"` +
+      `${g.actif ? ' aria-current="true"' : ""} data-terminal="${esc(g.terminal)}"${t ? "" : " disabled"}>` +
+      `${vign}<span class="stn-tile-name">${esc(g.terminal)}</span>` +
+      `<span class="stn-tile-meta">${t ? sysBadge(t.system) : '<span class="sys">inconnu</span>'}` +
+      `<b>${g.corrections}</b></span>` +
+      `${g.actif ? '<span class="stn-tile-flag">en cours</span>' : ""}</button>`;
+  }).join("");
+  return `<div class="corr-list-head">
+      <span>◈ ${autres.length ? `${autres.length} autre${autres.length > 1 ? "s" : ""} station${autres.length > 1 ? "s" : ""} · ` : ""}${total} correction${total > 1 ? "s" : ""}</span>
+      <button id="resetAll" class="reset-ov">Tout réinitialiser</button>
+    </div><div class="stn-band">${tuiles}</div>`;
 }
 
 // Liste des relevés d'autoload, à côté des corrections locales et sur le même modèle : ils sont de
@@ -2656,30 +2733,27 @@ function autoloadListHTML() {
   return `<div class="corr-list-head"><span>${keys.length} relevé${keys.length > 1 ? "s" : ""} d'autoload</span><button id="resetAllK" class="reset-ov">Tout oublier</button></div>${items}`;
 }
 
-// Liste de toutes les corrections locales, avec suppression individuelle.
-function correctionsListHTML() {
-  const keys = Object.keys(OVERRIDES);
-  if (!keys.length) return '<p class="empty">Aucune correction locale pour l\'instant. Cherche une station ci-dessus pour en créer.</p>';
-  const sideLabel = (s) => (s === "buy" ? "achat" : "vente");
-  const items = keys.sort().map((k) => {
-    const o = OVERRIDES[k];
-    const [commodity, terminal, side] = k.split("|");
-    const parts = [];
-    if (o.price != null) parts.push(`prix <b>${fmt(o.price)}</b>`);
-    if (o.vol != null) parts.push(`${side === "buy" ? "stock" : "demande"} <b>${fmt(o.vol)}</b>`);
-    return `<div class="corr-item"><div><b>${esc(commodity)}</b> · ${esc(terminal)} <span class="corr-side">${sideLabel(side)}</span><div class="loc-sub">${parts.join(" · ")}</div></div><button class="corr-del" data-key="${esc(k)}" title="Supprimer cette correction">✕</button></div>`;
-  }).join("");
-  return `<div class="corr-list-head"><span>${keys.length} correction${keys.length > 1 ? "s" : ""}</span><button id="resetAll" class="reset-ov">Tout réinitialiser</button></div>${items}`;
-}
-
 function renderCorrections() {
   if (!MARKET) { withMarket(refresh); return; }
   if (!enrouteReady) setupEnRoute();
   resolveStation();
   const q = $("search").value.trim().toLowerCase();
   const station = stationSel != null ? stationTableHTML(stationSel, q) : '<p class="manifest-hint">Cherche une station ci-dessus pour voir et corriger ses prix et stocks.</p>';
+  // La bande est peinte APRÈS le panneau, bien qu'elle s'affiche au-dessus : stationTableHTML
+  // appelle effVals, dont la purge des volumes périmés est un effet de bord. Compter d'abord
+  // afficherait une correction que le rendu suivant vient d'effacer.
   $("correctionsStation").innerHTML = station;
-  $("correctionsList").innerHTML = correctionsListHTML() + autoloadListHTML();
+  $("correctionsIndex").innerHTML = correctionsIndexHTML();
+  // Le panneau de frais n'est réécrit QUE si son contenu a changé (#24). Le sortir de
+  // #correctionsStation ne suffisait pas : renderCorrections réécrivait son nouveau conteneur tout
+  // aussi inconditionnellement, et un montant en cours de frappe repartait à vide au moindre
+  // re-rendu — un filtre tapé, une correction ailleurs. Le panneau ne dépend que de la station
+  // affichée et du store des relevés : cette signature suffit à décider.
+  const signature = `${stationSel}|${JSON.stringify(AUTOLOAD_K)}`;
+  if (signature !== feesRendus) {
+    feesRendus = signature;
+    $("correctionsFees").innerHTML = (stationSel != null ? stationFeeHTML(stationSel) : "") + autoloadListHTML();
+  }
   notifySuperseded();
 }
 
@@ -2920,12 +2994,55 @@ async function init() {
   $("chainOrigin").addEventListener("input", debounce(() => { resolveChainOrigin(); refresh(); }));
   $("hops").addEventListener("input", refresh);
   // Contrôles « Corrections » : recherche de station + suppression / reset (délégué).
-  $("station").addEventListener("input", debounce(() => { resolveStation(); refresh(); }));
+  // Ne re-rend QUE si la station résolue a CHANGÉ. Le sélecteur, lui, rend immédiatement au choix :
+  // sans ce garde, le rendu différé du debounce arrivait ~300 ms après et refaisait le même écran
+  // pour rien — en détachant au passage l'éditeur d'un chiffre ouvert entre les deux. Même famille
+  // que #24 : tout re-rendu gratuit de cette vue efface une saisie en cours.
+  $("station").addEventListener("input", debounce(() => {
+    const avant = stationSel;
+    resolveStation();
+    if (stationSel !== avant) refresh();
+  }));
   $("corrections").addEventListener("click", (e) => {
     // Les relevés d'autoload se testent AVANT les corrections : leur ✕ porte aussi `.corr-del`
     // (même bouton à l'écran) et tomberait sinon dans la branche qui écrit dans OVERRIDES.
     const alDel = e.target.closest(".al-del");
     if (alDel) { forgetStationReading(alDel.dataset.key); return; }
+    // Vignette de la bande : recharge sa station. Écrit le LIBELLÉ CANONIQUE, comme le sélecteur —
+    // resolveStation résout par correspondance exacte, et c'est lui que le permalien transporte.
+    const tuile = e.target.closest(".stn-tile");
+    if (tuile && !tuile.disabled) {
+      const t = termByName.get(tuile.dataset.terminal);
+      if (t) { $("station").value = stationLabel(t.name, t.system); resolveStation(); refresh(); saveState(); }
+      return;
+    }
+    // Retour à la valeur UEX d'un chiffre corrigé.
+    const undo = e.target.closest(".scomm-undo");
+    if (undo) {
+      const { c, t: term, s: side, f: field } = undo.dataset;
+      // Rendre son stock à UEX reste un changement de volume : sans ce gel, un voyage déjà planifié
+      // se rebattrait tout seul. Même règle que startEdit et que l'ancien ✕ de la liste plate.
+      if (field === "vol") pinLegsForVolume(c, term, side);
+      const o = OVERRIDES[ovKey(c, term, side)];
+      setOverride(c, term, side, field, null, o ? o.base : 0);
+      updateOvBadge();
+      refresh();
+      return;
+    }
+    // Efface les corrections de la SEULE station affichée (bouton du bandeau).
+    if (e.target.closest("#stnClear")) {
+      const nom = stationSel != null ? MARKET.terminals[stationSel].name : null;
+      if (nom) {
+        for (const k of Object.keys(OVERRIDES)) {
+          const [commodity, terminal, side] = k.split("|");
+          if (terminal !== nom) continue;
+          if (OVERRIDES[k].vol != null) pinLegsForVolume(commodity, terminal, side);
+          delete OVERRIDES[k];
+        }
+        saveOverrides(); updateOvBadge(); refresh();
+      }
+      return;
+    }
     const del = e.target.closest(".corr-del");
     if (del) {
       // Supprimer une correction de volume rend le stock d'UEX : c'est encore un changement de

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -1739,13 +1739,174 @@ test("sélecteur : quand la photo existe, la vignette de repli ne dépasse pas d
   // coups de marge négative, elles se décalaient de la valeur du `gap` flex et le code débordait —
   // on lisait « TA » derrière la photo de Nyx Gateway (Stanton), dont le code est NYXSTA.
   await ouvrePicker(page, "gate");
-  const avecPhoto = page.locator("#stationPickList li[data-i]:not(.no-shot)").filter({ has: page.locator("img.stn-shot") }).first();
-  await expect(avecPhoto).toBeVisible();
-  const boites = await avecPhoto.evaluate((li) => {
-    const img = li.querySelector("img.stn-shot").getBoundingClientRect();
-    const gen = li.querySelector(".stn-shot-gen").getBoundingClientRect();
-    return { img: [img.x, img.y, img.width, img.height], gen: [gen.x, gen.y, gen.width, gen.height] };
+  // La mesure est prise DANS le document, jamais via une poignée capturée à l'avance : chaque
+  // frappe réécrit la liste, et un élément détaché entre l'assertion de visibilité et la mesure
+  // rendait un rectangle [0,0,0,0]. On sonde donc jusqu'à obtenir une case réellement peinte.
+  const lis = () => page.evaluate(() => {
+    const li = [...document.querySelectorAll("#stationPickList li[data-i]")]
+      .find((e) => e.querySelector("img.stn-shot") && !e.classList.contains("no-shot"));
+    if (!li) return null;
+    const r = (s) => { const b = li.querySelector(s).getBoundingClientRect(); return [b.x, b.y, b.width, b.height]; };
+    return { img: r("img.stn-shot"), gen: r(".stn-shot-gen") };
   });
+  await expect.poll(async () => ((await lis())?.img?.[2] ?? 0) > 0, { timeout: 8000 }).toBe(true);
+  const boites = await lis();
   // Exactement superposées : aucun pixel du repli n'est visible à côté de la photo.
   expect(boites.gen).toEqual(boites.img);
+});
+
+// ---------- Vue Corrections rangée par station (ADR-003, LOT 3) ----------
+// Choisit une station dans le sélecteur groupé et attend son panneau.
+async function ouvreStation(page, nom) {
+  await page.click("#viewCorrections");
+  await expect(page.locator("#stationList option").first()).toBeAttached({ timeout: 15000 });
+  await page.locator("#station").fill(""); // sinon la 2e station s'AJOUTE à la première et rien ne résout
+  await page.locator("#station").pressSequentially(nom, { delay: 1 });
+  await page.locator("#station").press("Enter");
+  await expect(page.locator(".stn-hero-name")).toHaveText(nom);
+  await expect(page.locator("#correctionsStation .scomm").first()).toBeVisible();
+}
+// Corrige le premier chiffre éditable de la station affichée.
+async function corrigePremier(page, valeur) {
+  const cible = page.locator("#correctionsStation .editv").first();
+  const nom = await cible.getAttribute("data-c");
+  await cible.click();
+  const champ = page.locator("#correctionsStation input.editv-input").first();
+  await champ.fill(String(valeur));
+  await champ.press("Enter");
+  return nom;
+}
+
+test("corrections : la bande de stations remplace la liste plate (#38)", async ({ page }) => {
+  await ouvreStation(page, "Levski");
+  await corrigePremier(page, 4242);
+  // Une vignette par station, et non une ligne par correction.
+  await expect(page.locator("#correctionsIndex .stn-tile")).toHaveCount(1);
+  await expect(page.locator("#correctionsIndex .stn-tile").first()).toContainText("Levski");
+  // La liste plate n'existe plus.
+  await expect(page.locator("#correctionsList")).toHaveCount(0);
+  await expect(page.locator(".corr-item:not(.autoload)")).toHaveCount(0);
+});
+
+test("corrections : la bande est AU-DESSUS du panneau de station (#38)", async ({ page }) => {
+  // C'est le déplacement qui règle les coups de molette : la liste vivait sous 1 481 px de grille.
+  await ouvreStation(page, "Levski");
+  await corrigePremier(page, 4242);
+  const [yBande, yPanneau] = await Promise.all([
+    page.locator("#correctionsIndex").evaluate((e) => e.getBoundingClientRect().top),
+    page.locator("#correctionsStation").evaluate((e) => e.getBoundingClientRect().top),
+  ]);
+  expect(yBande).toBeLessThan(yPanneau);
+});
+
+test("corrections : la station affichée est épinglée en tête et en surbrillance (#38)", async ({ page }) => {
+  await ouvreStation(page, "Levski");
+  await corrigePremier(page, 4242);
+  await ouvreStation(page, "GrimHEX"); // station SANS correction : elle doit quand même s'épingler
+  const tuiles = page.locator("#correctionsIndex .stn-tile");
+  await expect(tuiles).toHaveCount(2);
+  await expect(tuiles.first()).toContainText("GrimHEX");
+  await expect(tuiles.first()).toHaveClass(/\bactive\b/);
+  await expect(tuiles.first()).toHaveAttribute("aria-current", "true");
+  // La surbrillance ne tient pas qu'à la couleur : le mot est écrit.
+  await expect(tuiles.first()).toContainText("en cours");
+});
+
+test("corrections : cliquer une vignette recharge sa station (#38)", async ({ page }) => {
+  await ouvreStation(page, "Levski");
+  await corrigePremier(page, 4242);
+  await ouvreStation(page, "GrimHEX");
+  await page.locator("#correctionsIndex .stn-tile", { hasText: "Levski" }).click();
+  await expect(page.locator("#station")).toHaveValue("Levski — Nyx");
+  await expect(page.locator("#correctionsIndex .stn-tile").first()).toContainText("Levski");
+});
+
+test("corrections : le retour arrière rend la valeur UEX, sur un contrôle dédié (#38)", async ({ page }) => {
+  await ouvreStation(page, "Levski");
+  const cible = page.locator("#correctionsStation .editv").first();
+  const avant = (await cible.innerText()).trim();
+  await corrigePremier(page, 4242);
+  await expect(page.locator("#correctionsStation .editv.ov").first()).toBeVisible();
+
+  // Le contrôle vit DANS la tuile, hors du .editv — qui porte déjà role="button" : un bouton dans
+  // un bouton est invalide en ARIA, et sortir le ✎ casserait la restauration de startEdit.
+  const retour = page.locator("#correctionsStation .scomm .scomm-undo").first();
+  await expect(retour).toBeVisible();
+  await expect(retour).toContainText(avant.replace(/\s+/g, " ")); // annonce la valeur de retour
+  const dansEditv = await retour.evaluate((el) => !!el.closest(".editv"));
+  expect(dansEditv, "le contrôle ne doit pas être imbriqué dans le .editv").toBe(false);
+
+  await retour.click();
+  await expect(page.locator("#correctionsStation .editv.ov")).toHaveCount(0);
+  await expect(page.locator("#correctionsIndex .stn-tile").first()).toContainText("0");
+});
+
+test("corrections : « Tout réinitialiser » survit au déménagement (#38)", async ({ page }) => {
+  await ouvreStation(page, "Levski");
+  await corrigePremier(page, 4242);
+  await expect(page.locator("#resetAll")).toBeVisible();
+  page.on("dialog", (d) => d.accept());
+  await page.locator("#resetAll").click();
+  await expect(page.locator("#correctionsStation .editv.ov")).toHaveCount(0);
+});
+
+test("corrections : le panneau de frais quitte le conteneur re-rendu (#24, #38)", async ({ page }) => {
+  // #24 : toute frappe dans le relevé d'autoload était effacée par un re-rendu de la vue, parce que
+  // renderCorrections réécrit #correctionsStation.innerHTML — qui contenait le panneau.
+  await ouvreStation(page, "Levski");
+  const panneau = page.locator("#correctionsFees .fee-panel");
+  await expect(panneau).toBeVisible();
+  const dedans = await panneau.evaluate((el) => !!el.closest("#correctionsStation"));
+  expect(dedans, "le panneau de frais ne doit plus vivre dans #correctionsStation").toBe(false);
+});
+
+test("corrections : le retour arrière ne comprime pas la ligne des valeurs (#38)", async ({ page }) => {
+  // Glissés parmi les valeurs, les boutons de retour écrasaient le texte de l'étiquette : « aUEC ·
+  // stock » se coupait en deux lignes, la tuile ne faisant que 236 px. Ils vivent sur leur propre
+  // ligne, et la hauteur de la ligne des valeurs ne bouge donc pas quand on corrige.
+  await ouvreStation(page, "Levski");
+  const ligne = page.locator("#correctionsStation .scomm").first().locator(".scomm-side").first();
+  const avant = await ligne.evaluate((e) => e.getBoundingClientRect().height);
+  await corrigePremier(page, 4242);
+  await expect(page.locator("#correctionsStation .scomm-undo").first()).toBeVisible();
+
+  const mesures = await page.locator("#correctionsStation .scomm").first().evaluate((tuile) => {
+    const v = tuile.querySelector(".scomm-side").getBoundingClientRect();
+    const u = tuile.querySelector(".scomm-undo").getBoundingClientRect();
+    return { hauteur: v.height, basValeurs: v.bottom, hautRetour: u.top };
+  });
+  // Le bouton est SOUS la ligne des valeurs, pas dedans : c'est la correction du défaut.
+  expect(mesures.hautRetour).toBeGreaterThanOrEqual(mesures.basValeurs);
+  // Et la ligne des valeurs n'a pas replié : elle gagne ~2 px, ceux du ✎ en vertical-align: super,
+  // là où un repli la faisait DOUBLER (17 -> 35 px mesurés avant correction du défaut).
+  expect(mesures.hauteur).toBeLessThan(avant * 1.4);
+});
+
+test("corrections : choisir une station ne rend pas l'écran deux fois (#24, #38)", async ({ page }) => {
+  // Le sélecteur rend immédiatement au choix ; le debounce du champ rendait une SECONDE fois ~300 ms
+  // plus tard. Un chiffre ouvert à l'édition entre les deux voyait son champ détaché du DOM.
+  await ouvreStation(page, "Levski");
+  await page.locator("#correctionsStation .editv").first().click();
+  const champ = page.locator("#correctionsStation input.editv-input").first();
+  await expect(champ).toBeVisible();
+  await page.waitForTimeout(600); // largement plus que le debounce
+  await expect(champ).toBeVisible(); // toujours là : aucun re-rendu gratuit ne l'a emporté
+  await champ.fill("4242");
+  await champ.press("Enter");
+  await expect(page.locator("#correctionsStation .editv.ov").first()).toBeVisible();
+});
+
+test("corrections : un relevé d'autoload en cours de saisie survit à un re-rendu (#24)", async ({ page }) => {
+  // Cause de #24 : renderCorrections réécrivait inconditionnellement le conteneur qui porte le
+  // panneau de frais. Le sortir de #correctionsStation ne suffit pas — encore faut-il ne pas
+  // réécrire son nouveau conteneur quand rien de ce qu'il affiche n'a changé.
+  await ouvreStation(page, "Seraphim"); // une des 45 stations qui proposent l’autoload
+  const montant = page.locator("#alAmount");
+  await expect(montant).toBeVisible();
+  await montant.fill("1159");
+  // Un re-rendu déclenché par autre chose que le panneau : le filtre par commodité.
+  await page.locator("#search").fill("aluminum");
+  await expect(page.locator("#correctionsStation .scomm")).toHaveCount(1);
+  await page.waitForTimeout(500); // le debounce du filtre est retombé
+  await expect(montant).toHaveValue("1159"); // la saisie n'a pas été effacée
 });

--- a/index.html
+++ b/index.html
@@ -237,9 +237,15 @@
           <p class="enroute-hint">Corrige les <b>prix et stocks</b> d'une station même hors trajet (clique un chiffre). Tes corrections sont <b>locales</b> (jamais partagées) et périment automatiquement dès qu'UEX publie un relevé plus récent. Utilise le champ <b>Commodité</b> pour filtrer la station.</p>
         </section>
 
+        <!-- L'ORDRE compte (ADR-003). La bande des stations corrigées passe AVANT le panneau :
+             c'est ce déplacement qui règle les coups de molette, la liste plate vivant jusqu'ici
+             sous 1 481 px de grille. Le panneau de frais sort en pied, dans son propre conteneur :
+             renderCorrections réécrit #correctionsStation à chaque rendu, et un relevé en cours de
+             saisie y était effacé (#24). -->
         <div id="corrections" class="corrections-wrap" hidden>
+          <div id="correctionsIndex"></div>
           <div id="correctionsStation"></div>
-          <div id="correctionsList"></div>
+          <div id="correctionsFees"></div>
         </div>
 
         <section id="commoditiesControls" class="enroute-controls" hidden>

--- a/logic.mjs
+++ b/logic.mjs
@@ -587,6 +587,44 @@ export function setInStore(store, key, field, value, baseUpdated, nowSec = Date.
   return store;
 }
 
+// Range les corrections locales PAR STATION, pour la bande de vignettes de la vue Corrections
+// (ADR-003). Renvoie [{ terminal, corrections, actif }], la station affichée épinglée en tête —
+// même à zéro correction, pour que la bande dise toujours quelque chose quand on ouvre une station
+// jamais corrigée. Les autres suivent, par nombre de corrections décroissant puis par nom.
+//
+// N'accepte que les clés à TROIS segments. La frontière n'est pas cosmétique : les relevés de tarif
+// d'autoload vivent dans un store séparé sous une clé à DEUX segments (`autoload|<terminal>`)
+// précisément pour qu'aucun lecteur de OVERRIDES ne les compte, et un test E2E exige que le badge
+// « ✎ Corrections » reste sans compteur quand seul un relevé existe.
+//
+// PURGE au passage, et c'est le point délicat. Un volume corrigé meurt au bout de `dureeVol` ; cette
+// péremption est un effet de bord d'effFromStore, déclenché par le RENDU de la seule station
+// affichée. Les corrections des autres stations ne sont donc jamais interrogées, donc jamais
+// purgées : sans cette passe, leur compteur annoncerait des corrections déjà mortes jusqu'à ce qu'on
+// clique dessus. La bande promet un décompte juste ; c'est ici qu'elle le tient.
+export function groupOverridesByTerminal(store, actif, nowSec = Date.now() / 1000, dureeVol = DUREE_VOL) {
+  const parTerminal = new Map();
+  for (const cle of Object.keys(store || {})) {
+    const seg = cle.split("|");
+    if (seg.length !== 3) continue;
+    const o = store[cle];
+    if (o && o.vol != null && o.pris != null && nowSec - o.pris > dureeVol) {
+      delete o.vol;
+      delete o.pris;
+      if (o.price == null) { delete store[cle]; continue; }
+    }
+    const terminal = seg[1];
+    parTerminal.set(terminal, (parTerminal.get(terminal) || 0) + 1);
+  }
+  if (actif) parTerminal.set(actif, parTerminal.get(actif) || 0);
+
+  return [...parTerminal.entries()]
+    .map(([terminal, corrections]) => ({ terminal, corrections, actif: terminal === actif }))
+    .sort((a, b) => (b.actif ? 1 : 0) - (a.actif ? 1 : 0)
+      || b.corrections - a.corrections
+      || a.terminal.localeCompare(b.terminal, "fr"));
+}
+
 // ---------- État partageable (URL / localStorage) ----------
 export const safeKey = (k) => typeof k === "string" && /^[a-zA-Z]+$/.test(k); // anti-injection de sélecteur
 

--- a/logic.test.mjs
+++ b/logic.test.mjs
@@ -23,7 +23,7 @@ import {
   journeyConnects, addToJourney, setJourneyPosition, currentLeg, journeyMargin,
   encodeJourney, decodeJourney, removeJourneyStop, freeManifestLine, hydrateManifestLine,
   cleApresRetrait, reindexerRangsJambe, detacherLotsDeJambe,
-  stationTree,
+  stationTree, groupOverridesByTerminal,
 } from "./logic.mjs";
 
 // ---------- Temps de trajet ----------
@@ -3436,4 +3436,82 @@ test("stationTree : les stations d'une même zone sont CONTIGUËS une fois l'arb
   const plates = stationTree(TERMINAUX_ARBRE()).flatMap((s) => s.zones.flatMap((z) => z.stations));
   const cles = plates.map((s) => `${s.system} › ${s.zone}`);
   assert.deepEqual(cles, [...new Set(cles)].flatMap((c) => cles.filter((x) => x === c)));
+});
+
+// ---------- groupOverridesByTerminal : les corrections rangées par station (ADR-003) ----------
+// Ce qui alimente la bande de vignettes. Deux exigences se cachent derrière l'apparente simplicité :
+// n'accepter que les clés à TROIS segments (les relevés d'autoload en ont deux et vivent dans un
+// store à part), et PURGER les volumes périmés avant de compter — sans quoi le compteur d'une
+// station qu'on n'a pas ouverte surcompte des corrections déjà mortes.
+const OV = (o) => JSON.parse(JSON.stringify(o));
+
+test("groupOverridesByTerminal réunit les corrections d'une même station en UNE entrée", () => {
+  const g = groupOverridesByTerminal(OV({
+    "Laranite|GrimHEX|sell": { price: 31200, base: 100 },
+    "Agricium|GrimHEX|sell": { price: 27400, base: 100 },
+    "Gold|Levski|buy": { price: 5000, base: 100 },
+  }), null);
+  assert.equal(g.length, 2);
+  assert.deepEqual(g.map((e) => [e.terminal, e.corrections]), [["GrimHEX", 2], ["Levski", 1]]);
+});
+
+test("groupOverridesByTerminal épingle la station active en tête, même à zéro correction", () => {
+  const g = groupOverridesByTerminal(OV({
+    "Laranite|GrimHEX|sell": { price: 31200, base: 100 },
+    "Agricium|GrimHEX|sell": { price: 27400, base: 100 },
+  }), "Levski");
+  assert.equal(g[0].terminal, "Levski");
+  assert.equal(g[0].corrections, 0);
+  assert.equal(g[0].actif, true);
+  assert.equal(g[1].terminal, "GrimHEX");
+  assert.equal(g[1].actif, false);
+});
+
+test("groupOverridesByTerminal : la station active n'apparaît jamais deux fois", () => {
+  const g = groupOverridesByTerminal(OV({ "Laranite|GrimHEX|sell": { price: 31200, base: 100 } }), "GrimHEX");
+  assert.equal(g.length, 1);
+  assert.equal(g[0].corrections, 1);
+  assert.equal(g[0].actif, true);
+});
+
+test("groupOverridesByTerminal ignore les clés à DEUX segments (relevés d'autoload)", () => {
+  // Le store des relevés `autoload|<terminal>` est séparé, mais rien n'empêche un appelant de
+  // passer le mauvais objet : la frontière est structurelle, pas déclarative. Un test E2E exige
+  // d'ailleurs que le badge « ✎ Corrections » reste SANS compteur quand seul un relevé existe.
+  const g = groupOverridesByTerminal(OV({
+    "autoload|GrimHEX": { k: 1.4 },
+    "Laranite|Levski|sell": { price: 100, base: 1 },
+  }), null);
+  assert.deepEqual(g.map((e) => e.terminal), ["Levski"]);
+});
+
+test("groupOverridesByTerminal trie par corrections décroissantes, puis par nom", () => {
+  const g = groupOverridesByTerminal(OV({
+    "A|Zeta|buy": { price: 1, base: 1 },
+    "A|Alpha|buy": { price: 1, base: 1 },
+    "A|Beta|buy": { price: 1, base: 1 },
+    "B|Beta|buy": { price: 1, base: 1 },
+  }), null);
+  assert.deepEqual(g.map((e) => e.terminal), ["Beta", "Alpha", "Zeta"]);
+});
+
+test("groupOverridesByTerminal purge les volumes périmés AVANT de compter", () => {
+  // Un volume corrigé meurt au bout de DUREE_VOL (3 h). La purge est un effet de bord d'effFromStore,
+  // déclenché par le rendu de la SEULE station affichée : les autres ne sont jamais interrogées.
+  // Sans purge ici, leur compteur annoncerait des corrections déjà mortes jusqu'au prochain clic.
+  const store = OV({
+    "Vieux|Levski|buy": { vol: 12, base: 1, pris: 0 },              // volume seul, périmé -> la clé part
+    "Prix|Levski|sell": { price: 900, base: 1 },                     // un prix ne périme jamais
+    "Mixte|GrimHEX|buy": { price: 50, vol: 7, base: 1, pris: 0 },    // le volume part, le prix reste
+  });
+  const g = groupOverridesByTerminal(store, null, 10 * 3600); // « maintenant » = 10 h après la saisie
+  assert.deepEqual(g.map((e) => [e.terminal, e.corrections]).sort(), [["GrimHEX", 1], ["Levski", 1]]);
+  assert.equal(store["Vieux|Levski|buy"], undefined, "la clé sans rien de vivant doit disparaître");
+  assert.equal(store["Mixte|GrimHEX|buy"].vol, undefined, "le volume périmé doit partir");
+  assert.equal(store["Mixte|GrimHEX|buy"].price, 50, "le prix, lui, survit");
+});
+
+test("groupOverridesByTerminal : une station dont tout a péri sort de la bande", () => {
+  const store = OV({ "Vieux|Levski|buy": { vol: 12, base: 1, pris: 0 } });
+  assert.deepEqual(groupOverridesByTerminal(store, null, 10 * 3600), []);
 });

--- a/style.css
+++ b/style.css
@@ -861,6 +861,74 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 /* ---------- Vue Corrections ---------- */
 .corrections-wrap { margin: 20px 0 0; }
 .station-title { padding: 12px 2px; font-family: var(--display); font-weight: 600; color: #fff; }
+
+/* ---------- Bande des stations corrigées (ADR-003) ---------- */
+/* Elle passe naturellement à la ligne plutôt que de défiler : le nombre de STATIONS est petit par
+   construction — on corrige là où on s'amarre — et un défilement caché coûterait plus en
+   découvrabilité qu'il ne gagnerait en hauteur. */
+.stn-band { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 18px; }
+.stn-tile {
+  position: relative; display: grid; gap: 3px; justify-items: start; width: 132px; padding: 8px 10px 9px;
+  text-align: left; cursor: pointer; color: var(--muted); background: var(--panel-solid);
+  border: 1px solid transparent; border-left: 2px solid transparent; border-radius: 3px;
+  transition: color 0.12s, border-color 0.12s, background 0.12s;
+}
+.stn-tile:hover { color: var(--text); border-color: var(--line); }
+.stn-tile:disabled { cursor: not-allowed; opacity: 0.7; }
+/* Station affichée : même grammaire que .vbtn.active et .sort-modes button.active — c'est ainsi que
+   ce dépôt dit « actif », et il n'y a pas de raison d'en inventer une deuxième. */
+.stn-tile.active {
+  color: #fff; font-weight: 700;
+  border: 1px solid var(--line2); border-left: 2px solid var(--acc);
+  background: linear-gradient(180deg, rgba(255, 176, 32, 0.14), rgba(255, 176, 32, 0.02));
+  box-shadow: inset 0 0 22px rgba(255, 176, 32, 0.08);
+}
+/* Le focus clavier ne doit PAS se confondre avec la sélection. */
+.stn-tile:focus-visible { outline: 2px solid var(--acc-2); outline-offset: 1px; }
+.stn-tile-name { font-size: 12.5px; line-height: 1.2; }
+.stn-tile-meta { display: flex; align-items: center; gap: 6px; font-family: var(--mono); font-size: 10px; }
+/* « en cours » ÉCRIT, et pas seulement teinté : la règle maison veut qu'un état ne tienne jamais à
+   la seule couleur (cf. le commentaire de .scomm). */
+.stn-tile-flag {
+  font-family: var(--mono); font-size: 8.5px; letter-spacing: 1px; text-transform: uppercase; color: var(--acc);
+}
+/* Seule la PHOTO des tuiles inactives est estompée. Estomper la tuile entière ferait passer son
+   texte --muted (5,6:1 sur le fond) sous les 3:1, donc sous le seuil AA. */
+.stn-tile:not(.active) .stn-vign { opacity: 0.62; transition: opacity 0.12s; }
+.stn-tile:hover .stn-vign { opacity: 1; }
+.stn-tile .stn-vign { width: 100%; height: 42px; }
+@media (prefers-reduced-motion: reduce) { .stn-tile, .stn-tile .stn-vign { transition: none; } }
+
+/* ---------- Bandeau collant de la station affichée ---------- */
+/* Collant parce que .station-title sortait de l'écran au premier coup de molette : au milieu des
+   92 tuiles de GrimHEX, plus rien ne disait quelle station on éditait. */
+.stn-hero {
+  position: sticky; top: 0; z-index: 20; display: flex; align-items: center; gap: 12px;
+  padding: 8px 10px; margin-bottom: 14px;
+  background: var(--panel-solid); border: 1px solid var(--line); border-left: 2px solid var(--acc);
+}
+.stn-hero .stn-vign { width: 96px; height: 52px; }
+.stn-hero-txt { min-width: 0; flex: 1 1 auto; }
+.stn-hero-line { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; }
+.stn-hero-name { font-family: var(--display); font-size: 15px; font-weight: 600; color: #fff; }
+.stn-hero-zone { font-size: 11px; color: var(--muted); }
+.stn-hero-code { font-family: var(--mono); font-size: 10px; color: var(--muted); }
+.stn-hero-sub { display: flex; gap: 10px; margin-top: 2px; font-size: 11px; color: var(--muted); }
+.stn-hero-credit { font-size: 10px; opacity: 0.75; }
+.stn-hero .reset-ov { margin-left: 0; }
+
+/* Retour à la valeur UEX. Contrôle DÉDIÉ, hors du .editv qui porte déjà role="button" — et sur une
+   cible confortable, là où le ✎ ne fait que 9 × 9 px imbriqués dans un autre déclencheur. */
+.scomm-undos { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 2px; padding-left: 41px; }
+.scomm-undo {
+  padding: 1px 6px; border-radius: 3px; cursor: pointer;
+  font-family: var(--mono); font-size: 10px; line-height: 1.5;
+  color: var(--muted); background: rgba(255, 255, 255, 0.04); border: 1px solid var(--line);
+  transition: color 0.12s, border-color 0.12s;
+}
+.scomm-undo:hover { color: var(--acc); border-color: var(--acc); }
+.scomm-undo:focus-visible { outline: 2px solid var(--acc-2); outline-offset: 1px; }
+@media (prefers-reduced-motion: reduce) { .scomm-undo { transition: none; } }
 /* Les commodités d'une station : une GRILLE de tuiles, pas une colonne. GrimHEX en compte 92 —
    en liste, 4 546 px à parcourir pour corriger un chiffre, pendant que les trois colonnes du
    tableau faisaient 444 px chacune pour du contenu qui en demande 200. `auto-fill` rend cet espace

--- a/sw.js
+++ b/sw.js
@@ -5,7 +5,7 @@
 // recevrait encore l'ANCIEN index.html — sans CSP et avec son <script> inline — pendant toute une
 // visite, tandis que rail.js, lui, serait déjà là. `activate` purge tout cache au nom différent :
 // le bump garantit que la nouvelle page et son script arrivent ENSEMBLE.
-const CACHE = "best-hauling-v6";
+const CACHE = "best-hauling-v7";
 // Coquille précachée. Les woff2 (mêmes-origine depuis fonts/) sont mis en cache au premier
 // rendu par le gestionnaire fetch ci-dessous (stale-while-revalidate) -> hors-ligne complet.
 const SHELL = ["./", "./index.html", "./app.js", "./rail.js", "./logic.mjs", "./style.css", "./fonts/fonts.css", "./icon.svg", "./manifest.webmanifest"];


### PR DESCRIPTION
## Ce que ça change

La vue **Corrections** s'organise autour de la **station**, plus autour de la correction. Une bande
de vignettes en tête — une par station corrigée, avec sa photo et son compteur — remplace la liste
plate : vingt corrections y tiennent en une rangée là où elles faisaient vingt lignes. La station
affichée est épinglée en première position et marquée « en cours » ; un clic sur une vignette
recharge sa station. Un bandeau collant garde sous les yeux la photo du terminal, son système, sa
zone, son code UEX et le nombre de corrections qu'on y a faites. Chaque chiffre corrigé porte enfin
son propre `↺`, qui **annonce la valeur UEX** vers laquelle il ramène.

Et un relevé de tarif d'autoload en cours de saisie n'est plus effacé par un re-rendu.

## Pourquoi

**#38** — la liste plate coûtait une ligne par correction et les rangeait par commodité, donc jamais
côte à côte pour un même comptoir : les corrections d'une station y étaient éparpillées. La station
est pourtant l'unité naturelle — on corrige là où on s'amarre. Conception actée par
[ADR-003](docs/superpowers/specs/2026-08-13-refonte-vue-corrections-adr.md). La ligne de titre, elle,
sortait de l'écran au premier coup de molette : au milieu des 92 commodités de GrimHEX, plus rien ne
disait quelle station on éditait — d'où le bandeau collant.

**#24** — cause racine : `renderCorrections` (`app.js:2740`) réécrivait `#correctionsStation`
**inconditionnellement** à chaque rendu, et le panneau de frais vivait dedans. Tout re-rendu de la
vue — un filtre tapé, une correction ailleurs — repartait donc avec un `#alAmount` vide.

Il a fallu **deux gestes, pas un**, et c'est le point non évident : sortir le panneau dans son
propre conteneur `#correctionsFees` (`index.html:246`) ne suffisait pas, puisque `renderCorrections`
réécrivait ce nouveau conteneur tout aussi inconditionnellement. Le panneau ne dépend que de la
station affichée et du store des relevés : cette signature décide seule de le réécrire
(`app.js:2749-2753`).

Le champ de recherche de station reçoit le même garde (`app.js:2997-3003`) pour la même raison : son
rendu différé arrivait ~300 ms après celui du sélecteur et refaisait le même écran pour rien, en
détachant au passage l'éditeur d'un chiffre ouvert entre les deux.

**Effet de bord traité** — `groupOverridesByTerminal` (`logic.mjs:590`) **purge les volumes périmés
avant de compter**. La péremption à 3 h est un effet de bord du *rendu* de la seule station
affichée : les corrections des autres stations n'étaient donc jamais interrogées, donc jamais
purgées. Sans cette passe, leur compteur aurait annoncé des corrections déjà mortes jusqu'à ce qu'on
clique dessus. La bande promet un décompte juste ; c'est là qu'elle le tient.

## Vérification

- `node --test` → **380 tests, 380 pass, 0 fail** (174 ms). 7 nouveaux tests sur
  `groupOverridesByTerminal` : regroupement, épinglage de la station active même à zéro correction,
  pas de doublon, rejet des clés à deux segments (les relevés d'autoload ont leur propre store),
  tri, purge avant comptage, et disparition d'une station dont tout a péri.
- `npx playwright test` → **116 passed, 2 skipped, 0 failed** (58,8 s), 118 tests contre 108 sur
  `main` — 10 nouveaux, dont 3 estampillés #24.
- **Rouge avant, vert après, mesuré dans les deux sens.** En retirant le garde de signature, le test
  `corrections : un relevé d'autoload en cours de saisie survit à un re-rendu (#24)` échoue :
  ```
  Expected: "1159"
  Received: ""
    at e2e/smoke.pw.mjs:1911
  ```
  Garde remis : `1 passed (2.2 s)`.

## Ce qui n'est pas couvert

- **Les photos de terminaux ne sont pas mises en cache hors-ligne** : le service worker ignore
  volontairement le cross-origin. Hors ligne, le repli généré prend le relais — 97 des 114 terminaux
  ont une photo UEX, les 17 autres reçoivent une vignette teintée par système portant leur code.
- **La bande passe à la ligne plutôt que de défiler.** Le nombre de *stations* est petit par
  construction ; si quelqu'un accumulait des corrections sur cinquante stations, elle prendrait de
  la hauteur. Un défilement caché coûterait plus en découvrabilité qu'il ne gagnerait.
- **Une station disparue de `market.json`** garde sa vignette, désactivée : sa correction resterait
  sinon invisible **et** ineffaçable. On ne peut pas la rouvrir, seulement la balayer par « Tout
  réinitialiser ».
- **#27** (un montant tapé à côté donne k = 1000) n'est **pas** traité : c'est la validation du
  relevé, pas sa survie à un re-rendu. Issue distincte, toujours ouverte.
- Les autres issues de la vue restent ouvertes : **#19**, **#23**, **#28**.

Closes #38
Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)
