### PR TITLE
test(carte): rendre au filet « même système » de la Chaîne le pouvoir d'attraper une régression

### DIFF
--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -252,11 +252,16 @@ test("Chaîne : le filtre « même système » contraint la chaîne (régression
   const origin = await page.locator("#originList option").first().getAttribute("value");
   await page.fill("#chainOrigin", origin);
   await expect(page.locator("#chainOut .chain-leg").first()).toBeVisible();
-  // Avec « même système », tous les badges système de la chaîne doivent être identiques.
+  // Avec « même système », tous les badges système de la chaîne doivent être identiques. Ils sont
+  // posés sur le fil d'Ariane `.chain-path` (un badge par étape), jamais dans les `.chain-leg`.
   await page.check("#sameSystem");
   await expect(page.locator("#chainOut .chain-leg").first()).toBeVisible();
-  const systems = await page.locator("#chainOut .chain-leg .sys").allInnerTexts();
-  expect(new Set(systems.map((s) => s.trim())).size).toBeLessThanOrEqual(1);
+  const systems = (await page.locator("#chainOut .chain-path .sys").allInnerTexts()).map((s) => s.trim());
+  // Compter les badges AVANT de les comparer : `allInnerTexts()` n'attend rien et rend `[]` sur un
+  // sélecteur mort, et `new Set([]).size` vaut 0 — donc toute assertion d'unicité seule reste verte
+  // quand la classe visée est renommée. C'est cette garde qui empêche le test de redevenir creux.
+  expect(systems.length).toBeGreaterThan(0);
+  expect(new Set(systems).size).toBe(1);
 });
 
 // Pose la vue « En route » sur le premier terminal de départ proposé et rend la carte Manifeste.


### PR DESCRIPTION
## Ce que ça change

Rien à l'écran : c'est le filet de sécurité qui change. Le test de régression du filtre « même
système » de la vue Chaîne surveille enfin ce qu'il prétend surveiller. Si ce filtre cesse de
contraindre la chaîne à un seul système, la CI le dira — jusqu'ici elle serait restée verte.

## Pourquoi

`e2e/smoke.pw.mjs:258` (avant correctif) visait `#chainOut .chain-leg .sys`.

**Cause racine :** les badges système ne sont pas dans les jambes. `app.js:1178` compose une
`.chain-leg` avec `.chain-step`, `.chain-leg-main` et `.chain-leg-profit` — aucun `.sys` à
l'intérieur. Les badges sont posés une seule fois, sur le fil d'Ariane : `app.js:1171` les fabrique
(`sysBadge`) et `app.js:1186` les dépose dans `<span class="chain-path">`. `style.css:850` le
confirme — `.chain-path .sys` est la seule règle qui associe les deux classes, il n'existe pas de
`.chain-leg .sys`.

Conséquence : `allInnerTexts()` n'attend rien et rend `[]` sur un sélecteur qui ne matche rien, donc
`new Set([]).size` vaut `0`, et `0 <= 1` passait quelle que soit la réalité du filtre.

Deux corrections, donc, et pas une :

1. viser `#chainOut .chain-path .sys` ;
2. **exiger une liste non vide** avant de vérifier l'unicité. C'est cette ligne qui empêche la même
   panne silencieuse de revenir au prochain renommage de classe.

## Vérification

**1. L'ancien test ne mordait pas.** Filtre `sameOnly` de `buildChainAdjacency` (`logic.mjs:960`)
volontairement INVERSÉ (`bt.system === st.system`, ce qui force des chaînes inter-systèmes), test
d'origine inchangé :

```
Running 1 test using 1 worker
  ✓  1 [chromium] › e2e\smoke.pw.mjs:249:1 › Chaîne : le filtre « même système » contraint la chaîne (régression) (966ms)
  1 passed (1.7s)
```

Vert, avec le filtre entièrement retourné : la démonstration que l'assertion ne portait sur rien.

**2. Le test corrigé mord.** Même filtre inversé, assertion corrigée :

```
  ✘  1 [chromium] › e2e\smoke.pw.mjs:249:1 › Chaîne : le filtre « même système » contraint la chaîne (régression) (1.3s)

    Error: expect(received).toBe(expected) // Object.is equality

    Expected: 1
    Received: 3

      263 |   expect(systems.length).toBeGreaterThan(0);
    > 264 |   expect(new Set(systems).size).toBe(1);
  1 failed
```

**3. La garde « liste non vide » mord aussi.** Filtre rétabli, mais sélecteur remis volontairement
sur le conteneur mort `.chain-leg .sys` :

```
    Error: expect(received).toBeGreaterThan(expected)

    Expected: > 0
    Received:   0

    > 263 |   expect(systems.length).toBeGreaterThan(0);
  1 failed
```

C'est la mesure directe du bug de #40 : l'ancien sélecteur rend bien 0 élément.

**4. Filtre rétabli (`git diff logic.mjs` vide), test au vert :**

```
  ✓  1 [chromium] › e2e\smoke.pw.mjs:249:1 › Chaîne : le filtre « même système » contraint la chaîne (régression) (1.0s)
  1 passed (1.7s)
```

**5. Suites entières.**

```
node --test
ℹ tests 380
ℹ suites 0
ℹ pass 380
ℹ fail 0
```

```
npx playwright test
Running 118 tests using 2 workers
  2 skipped
  116 passed (16.1m)
```

Note sur cette dernière commande : la machine faisait tourner plusieurs suites Playwright en
parallèle, et la config du dépôt fixe le port 4173 avec `reuseExistingServer` — le premier serveur
lancé sert alors SES fichiers à toutes les suites. La suite complète a donc été passée sur un port
privé et sans réemploi (`--workers=2`), pour que le vert ci-dessus porte bien sur ce worktree. Aucun
fichier de configuration n'est modifié par la PR.

## Ce qui n'est pas couvert

- **La logique du filtre** n'est pas touchée : `logic.mjs:960` est correct, c'est sa surveillance qui
  manquait. Les deux inversions ci-dessus ont été rétablies (le diff de la PR ne porte que sur
  `e2e/smoke.pw.mjs`).
- **Balayage des autres `allInnerTexts()` / `.count()` du fichier** : aucun second sélecteur mort.
  Les autres sont adossés à un `toBeVisible()`, un `toHaveCount(n>0)` ou une égalité avec un
  compteur déjà prouvé non nul. Un cas reste toutefois **édenté sans être mort**, et n'est PAS
  corrigé ici (hors périmètre de #40) : `e2e/smoke.pw.mjs:233-236`, le volet « Boucles » du test des
  filtres, compte `#loopRows tr` sans attendre le rendu, puis n'assère que
  `loopsLegal <= loopsAll`. Le sélecteur est bien vivant (mesuré : 160 → 127 lignes), mais
  l'assertion passerait aussi bien sur `0 <= 0` que si le filtre ne faisait strictement rien.
- La refonte multi-commodités de la carte Chaîne (#56) restructurera `.chain-leg` ; ce correctif
  passe avant, exprès, pour qu'elle hérite d'un filet déjà vu mordre.

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)
