### PR TITLE
fix(front): trois vues cessent d'afficher un état qui n'est plus vrai (#23, #25, #26)

### DIFF
--- a/app.js
+++ b/app.js
@@ -488,7 +488,17 @@ function renderMulti(f) {
     empty.textContent = "Active la soute (SCU) pour calculer des trajets multi-commodité.";
     return;
   }
-  if (!MARKET) { withMarket(refresh); return; } // graphe requis
+  // Graphe requis. On vide comme le fait la branche « soute inactive » juste au-dessus : laisser les
+  // trajets à UNE commodité sous un mode qui promet des chargements combinés, c'est un tableau qui
+  // ne correspond plus à `shownMulti` — ▶ et 📦 y lisaient un index vide et ne faisaient RIEN.
+  // #empty reste masqué : le tableau n'est pas vide à cause des filtres, le marché n'est pas là.
+  if (!MARKET) {
+    shownMulti = [];
+    $("rows").innerHTML = "";
+    empty.hidden = true;
+    withMarket(refresh);
+    return;
+  }
   // Le contexte de frais descend DANS multiTrips (et non après coup) : c'est lui qui trie puis
   // TRONQUE à 300 trajets, un trajet meilleur en net serait donc coupé avant d'atteindre le tableau.
   const trips = multiTrips(MARKET, f, effVals, 300, f.multiAll ? 1 : 2, feeResolver(f))
@@ -1111,7 +1121,12 @@ function renderManifest(origin, destSystem, f, destTerminal) {
 }
 
 function renderEnRoute() {
-  if (!MARKET) { withMarket(refresh); return; }
+  // #empty est PARTAGÉ avec Trajets / Boucles, et cette vue n'a encore rien de VRAI à y écrire :
+  // ce n'est pas un filtre qui vide le tableau, c'est le marché qui manque. Symétrie du
+  // EMPTY_DEFAULT posé en tête de render() / renderLoops() (#55), qui manquait ici parce que le
+  // retour anticipé précède toute écriture — et withMarket ne re-rend PAS en cas d'échec, donc le
+  // message de la vue quittée y serait resté pour de bon, sous le toast « Marché indisponible ».
+  if (!MARKET) { $("empty").hidden = true; withMarket(refresh); return; }
   if (!enrouteReady) setupEnRoute();
   resolveOrigin(); // re-résout depuis le champ (peut avoir été posé par le parcours, sans événement input)
   resolveDest();
@@ -1628,7 +1643,11 @@ function clearJourney() {
   SOUTE = detacherLotsDeJambe(SOUTE); saveSoute();
   journeyExpandedLeg = -1;
   renderJourney();
-  saveState();
+  // Comme tous les autres mutateurs du parcours : la carte Voyage n'est pas la seule à lire JOURNEY.
+  // Les Boucles hissent en tête celles qui partent de la fin du parcours (.from-here) et le board
+  // Commodités marque d'un ◆ ce qu'on transporte — sans ce rendu, les deux gardaient l'état d'AVANT
+  // l'effacement jusqu'au geste suivant. `refresh` finit par `saveState`, inutile de le doubler.
+  refresh();
 }
 // Ensemble des commodités transportées au moins une fois sur le parcours (union des manifestes).
 function journeyCarriedCommodities() {

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -349,6 +349,23 @@ test("Compagnon de voyage : pré-remplit Chaîne + remonte les boucles depuis l'
   await expect(page.locator("#loopRows tr").first()).toHaveClass(/from-here/); // pertinentes en tête
 });
 
+test("Compagnon de voyage : effacer le parcours repeint la vue courante (#23)", async ({ page }) => {
+  // clearJourney rendait la carte Voyage et sauvegardait, mais ne rappelait pas refresh() comme le
+  // font tous les autres mutateurs du parcours. Les vues qui lisent JOURNEY à leur rendu gardaient
+  // donc l'état d'avant : boucles hissées en tête avec le fond `.from-here`, tuiles « transportée »
+  // encore ◆. L'état SAUVÉ, lui, était déjà correct — d'où l'invisibilité à tout test de persistance.
+  await page.click("#viewLoops");
+  await expect(page.locator("#loopRows tr").first()).toBeVisible();
+  // Une boucle est un cycle A→B→A : la prendre place la fin du parcours sur SON propre terminal A,
+  // elle se marque donc « from-here » sans dépendre d'une intersection dans le jeu de données.
+  await page.locator("#loopRows tr").first().locator(".journey-pick").click();
+  await expect(page.locator("#loopRows tr.from-here").first()).toBeVisible();
+
+  await page.locator("#journeyClear").click();
+  await expect(page.locator("#journeyStartBtn")).toBeVisible(); // le parcours est bien effacé…
+  await expect(page.locator("#loopRows tr.from-here")).toHaveCount(0); // …et la vue le sait
+});
+
 test("Compagnon de voyage : cliquer une étape recale En route (position interactive)", async ({ page }) => {
   const row = page.locator("#rows tr").first();
   const buyTerminal = (await row.locator(".term-name").nth(0).innerText()).trim();
@@ -1336,6 +1353,50 @@ test.describe("chargement du marché", () => {
     await expect(page.locator("#empty")).toBeHidden(); // et non « Choisis un terminal de départ… »
     await expect(page.locator("#manifest")).toBeHidden();
     await expect(page.locator("#routes")).toBeVisible();
+  });
+
+  test("marché lent : « En route » n'affiche pas le message vide d'une autre vue (#26)", async ({ page }) => {
+    // Symétrie exacte de #55, laissée dans un seul sens : render() et renderLoops() remettent
+    // #empty à sa valeur d'index.html en tête de rendu, mais renderEnRoute sortait AVANT toute
+    // écriture quand le marché manquait. Le message de la vue qu'on quitte restait donc sous un
+    // tableau « En route » vide — et si le fetch échoue, withMarket ne re-rend pas : il y reste.
+    // 2,5 s : le test observe un état TRANSITOIRE, il faut que la fenêtre survive à un runner chargé.
+    await page.route("**/data/market.json", async (route) => {
+      await new Promise((r) => setTimeout(r, 2500)); // le marché arrive bien après le changement de vue
+      return route.continue();
+    });
+
+    // On ATTEND que le filtre ait vidé le tableau : le rendu est débouncé, et changer de vue avant
+    // qu'il ne parte laisserait #empty masqué — le test passerait alors sans rien prouver.
+    await page.fill("#search", "zzz"); // aucune route -> #empty affiche le message des Trajets
+    await expect(page.locator("#rows tr")).toHaveCount(0);
+    await expect(page.locator("#empty")).toBeVisible();
+    await expect(page.locator("#empty")).toHaveText("Aucune route ne correspond aux filtres.");
+
+    await page.click("#viewEnroute");
+    await expect(page.locator("#enroute")).toBeVisible();
+    await expect(page.locator("#empty")).toBeHidden(); // sans marché, cette vue n'a rien de vrai à dire
+    // À l'arrivée du marché seulement, elle dit ce qui lui manque VRAIMENT.
+    await expect(page.locator("#empty")).toHaveText(
+      "Choisis un terminal de départ pour voir le fret à emporter.", { timeout: 15000 });
+  });
+
+  test("marché lent : le mode multi n'affiche pas les lignes des trajets simples (#25)", async ({ page }) => {
+    // renderMulti sortait le temps du fetch sans toucher à #rows : l'écran gardait les trajets à UNE
+    // commodité sous un mode qui promet des chargements combinés, et ▶ comme 📦 indexaient alors
+    // `shownMulti`, resté vide — clic mort, sans le moindre message.
+    // 2,5 s : idem, l'état observé est transitoire (il dure le temps du fetch et pas plus).
+    await page.route("**/data/market.json", async (route) => {
+      await new Promise((r) => setTimeout(r, 2500));
+      return route.continue();
+    });
+
+    await expect(page.locator("#rows tr").first()).toBeVisible(); // trajets à une commodité
+    await page.check("#multiCommodity");
+    await expect(page.locator("#rows tr")).toHaveCount(0);  // le tableau suit son tableau de données
+    await expect(page.locator("#empty")).toBeHidden();      // et ne prétend pas que c'est un filtre
+    // Le mode finit par se remplir de VRAIS chargements combinés (plusieurs icônes par ligne).
+    await expect(page.locator("#rows .multi-icons").first()).toBeVisible({ timeout: 15000 });
   });
 });
 


### PR DESCRIPTION
## Ce que ça change

Trois écrans cessent de montrer un état qui n'est plus vrai. Effacer le parcours (✕) éteint
immédiatement les boucles hissées en tête et le ◆ « transportée » des tuiles Commodités, au lieu
d'attendre le geste suivant. Pendant que `market.json` se charge, « En route » n'affiche plus le
message vide de la vue Trajets, et « Multi commodité » n'affiche plus les trajets à une commodité
sous un mode qui promet des chargements combinés — avec un ▶ et un 📦 qui ne faisaient rien.

## Pourquoi

Trois défauts indépendants de la couche interface, groupés dans une PR comme le précédent
`11bd686`. Ils partagent une même forme : un état de rendu qui survit à ce qui l'a rendu faux, et
qu'aucun test de persistance ne peut voir — l'état SAUVÉ, lui, est déjà correct dans les trois cas.

**#23 — cause racine : `app.js:1633` (`clearJourney`).** La fonction appelait `renderJourney()` et
`saveState()`, mais jamais `refresh()`, alors que tous les autres mutateurs du parcours le font
(`pickJourney` app.js:1593, `setJourneyStop` app.js:1605, `beginJourney` app.js:1934,
`removeJourneyStop` app.js:1959, `chargerJambe` app.js:1257). Or la carte Voyage n'est pas seule à
lire `JOURNEY` au rendu : `renderLoops` remonte et colore les boucles qui partent de la fin du
parcours (`hereArrival` → `.from-here`, app.js:642, peint par `style.css:428`) et
`renderCommodities` marque d'un ◆ les commodités transportées (`commCarried`, app.js:2930). Après
le ✕, les deux gardaient le surlignage jusqu'au geste suivant. Le correctif remplace `saveState()`
par `refresh()`, qui finit lui-même par `saveState()` — pas de double écriture. Il couvre du même
coup le retrait du DERNIER arrêt, qui délègue à `clearJourney` (app.js:1972).

**#25 — cause racine : `app.js:481` (`renderMulti`).** Son
`if (!MARKET) { withMarket(refresh); return; }` sortait sans vider `#rows` ni `shownMulti`. Le
tableau affiché ne correspondait plus à son tableau de données : les délégués 📦 (app.js:3115) et
▶ (app.js:3167) lisent `shownMulti[i]` dès que `isMultiRoutes()`, y trouvaient `undefined`, et
sortaient sans rien faire ni rien dire. On vide désormais comme le fait déjà la branche « soute
inactive » de la même fonction (app.js:484-490). `#empty` reste masqué : le tableau n'est pas vide
à cause des filtres, le marché n'est pas là.

**#26 — cause racine : `app.js:1123` (`renderEnRoute`).** Le retour anticipé précède toute écriture
de `#empty`, `<p>` PARTAGÉ par Trajets / Boucles / En route (`index.html:332`). `switchView`
(app.js:2155) ne le neutralise que pour chain / corrections / commodities. Résultat : « En route »
affichait « Aucune route ne correspond aux filtres. » — le message de la vue quittée, et faux ici,
puisque aucun filtre n'est en cause : il manque juste un terminal de départ. C'est la symétrie
exacte de #55, traitée dans un seul sens — `render()` et `renderLoops()` remettent `#empty` à
`EMPTY_DEFAULT` en tête de rendu, `renderEnRoute` n'avait pas d'équivalent. Aggravant : `withMarket`
ne re-rend pas en cas d'échec (`catch` → `marketUnavailable` seul, app.js:745), donc hors ligne le
message étranger restait pour de bon sous le toast « ⚠ Marché indisponible ». Le correctif masque
`#empty` tant que le marché manque.

## Vérification

Une mise en garde d'abord : le port 4173 de `playwright.config.mjs` était occupé par le serveur
d'un AUTRE plan de travail, et `reuseExistingServer` le réemployait — les premiers résultats
portaient sur un `app.js` qui n'était pas celui de cette branche. Tout ce qui suit a été relancé
sur un serveur dédié rattaché à ce worktree (port 4877, `reuseExistingServer: false`), avec
`workers: 3` et `timeout: 90 s` : la machine porte plusieurs plans de travail en parallèle, et les
36 dépassements observés à 8 workers étaient de la contention, pas des régressions (le premier
d'entre eux, relancé seul, passait en 28,8 s).

**Rouge AVANT le correctif** — les trois tests, `app.js` remis à l'état d'`origin/main` :

```
  ✘ smoke.pw.mjs:352 › Compagnon de voyage : effacer le parcours repeint la vue courante (#23)
    Error: expect(locator).toHaveCount(expected) failed
    Locator:  locator('#loopRows tr.from-here')
    Expected: 0
    Received: 2

  ✘ smoke.pw.mjs:1358 › marché lent : « En route » n'affiche pas le message vide d'une autre vue (#26)
    Error: expect(locator).toBeHidden() failed
    Locator:  locator('#empty')
    Expected: hidden
    Received: visible
      - locator resolved to <p id="empty" class="empty">Aucune route ne correspond aux filtres.</p>

  ✘ smoke.pw.mjs:1383 › marché lent : le mode multi n'affiche pas les lignes des trajets simples (#25)
    Error: expect(locator).toHaveCount(expected) failed
    Locator:  locator('#rows tr')
    Expected: 0
    Received: 300

  3 failed
```

**Vert APRÈS**, mêmes trois tests :

```
  ✓ smoke.pw.mjs:1358 › marché lent : « En route » n'affiche pas le message vide d'une autre vue (#26) (5.9s)
  ✓ smoke.pw.mjs:352  › Compagnon de voyage : effacer le parcours repeint la vue courante (#23) (4.9s)
  ✓ smoke.pw.mjs:1383 › marché lent : le mode multi n'affiche pas les lignes des trajets simples (#25) (6.8s)

  3 passed (32.9s)
```

**Suites entières, après correctif :**

```
$ node --test
ℹ tests 380
ℹ pass 380
ℹ fail 0
ℹ duration_ms 4394.5575

$ npx playwright test
  2 skipped
  119 passed (10.3m)
```

Les deux `skipped` sont des gardes de DONNÉES déjà en place (`test.skip` sur « aucune commodité
rentable à suggérer », smoke.pw.mjs:1090 et 1133) : elles ne dépendent pas de ce correctif.

## Ce qui n'est pas couvert

- **`renderChain` a exactement le même trou que `renderMulti`, et n'est pas corrigé ici.** Les
  issues #25 et #26 affirment toutes deux que `renderChain` « vide `shownChain` » et protège déjà
  ce cas : c'est faux aujourd'hui. Son `if (!MARKET) { withMarket(refresh); return; }`
  (app.js:1210) précède le `shownChain = null` (app.js:1215), donc pendant le fetch la carte
  `#chainOut` et son bouton « ▶ Ajouter au voyage » restent ceux d'un calcul précédent. Le symptôme
  est moins visible — aucun tableau partagé avec un autre mode — mais c'est la même classe de
  défaut. Il mérite son issue, pas un élargissement discret de celle-ci.
- Pendant le chargement du marché, « En route » et « Multi commodité » sont désormais MUETS plutôt
  que menteurs : tableau vide, aucun message. Aucun libellé « Chargement… » n'a été inventé — il
  survivrait à un échec de fetch (`withMarket` ne re-rend pas) et deviendrait à son tour un message
  faux, soit exactement la classe de bug corrigée ici. L'échec, lui, reste signalé par le toast
  « ⚠ Marché indisponible ».
- **#23** n'est testé que par les boucles `.from-here`. Le second symptôme de l'issue — le ◆
  « transportée » des tuiles Commodités — passe par le même `refresh()` mais n'a pas son propre
  test : il exige un marché chargé ET un manifeste de jambe non vide, deux préconditions de données
  qui l'auraient rendu conditionnel.
- Les numéros de ligne des trois issues datent de plusieurs refontes et étaient tous décalés
  (`clearJourney` annoncé en 1497 est en 1633 ; `renderMulti` en 468 est en 481 ; `renderEnRoute` en
  1045 est en 1123 ; les délégués en 2817/2862 sont en 3115/3167). Le code a été retrouvé par nom.
- Aucune modification de `README.md` : ces trois correctifs rétablissent un comportement déjà
  décrit, ils n'en changent aucun. Aucun `data/*.json` touché.

Closes #23
Closes #25
Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)
