### PR TITLE
fix(trajets): une route déficitaire affiche une barre de score vide, pas pleine

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@
 // Fonctions de calcul pures (testées par logic.test.mjs).
 import {
   tripMinutes, ageDays, pairAge,
-  normalizeScores, bySort, addableUnits, scuBoxes, cargoBoxes, bestChain,
+  normalizeScores, scoreBarWidth, bySort, addableUnits, scuBoxes, cargoBoxes, bestChain,
   AUTOLOAD, autoloadFee, autoloadPoint, haulFee, lineHaulFee, lineNet,
   ovKey, effFromStore, setInStore, DUREE_VOL, groupOverridesByTerminal, safeKey, encodeState, decodeState,
   routePasses, loopPasses,
@@ -405,10 +405,11 @@ function evaluate(r, f) {
   return { ...r, buy, sell, buyPrice: buy.price, sellPrice: sell.price, feeInfo, ...metrics, ...net };
 }
 
-// Cellule visuelle du score : mini-barre + valeur.
+// Cellule visuelle du score : mini-barre + valeur. La barre est bornée à [0, 100] (scoreBarWidth),
+// le nombre affiché reste le score réel — y compris négatif, qui dit « cette route perd de l'argent ».
 function scoreCell(score) {
   const tier = score >= 70 ? "s-good" : score >= 40 ? "s-ok" : "s-low";
-  return `<div class="score-cell"><span class="scorebar ${tier}"><i style="width:${score}%"></i></span><b>${score}</b></div>`;
+  return `<div class="score-cell"><span class="scorebar ${tier}"><i style="width:${scoreBarWidth(score)}%"></i></span><b>${score}</b></div>`;
 }
 
 // Valeur éditable (clic pour corriger localement). side = "buy"|"sell", field = "price"|"vol".

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -1910,3 +1910,38 @@ test("corrections : un relevé d'autoload en cours de saisie survit à un re-ren
   await page.waitForTimeout(500); // le debounce du filtre est retombé
   await expect(montant).toHaveValue("1159"); // la saisie n'a pas été effacée
 });
+
+test("score : une barre de score négatif est vide, jamais pleine (#39)", async ({ page }) => {
+  // Cause racine de #39 : `.scorebar i` n'avait aucune `width` par défaut. Une largeur négative
+  // (`width:-1441%`, ce que scoreCell écrivait pour une route qui perd de l'argent) est une
+  // déclaration CSS INVALIDE, donc ignorée — l'élément retombait en `width:auto`, et un bloc en
+  // auto remplit son parent. La pire ligne du tableau portait donc la plus grosse barre.
+  // On mesure la règle CSS elle-même : aucune donnée de l'amorce ne garantit qu'une route soit
+  // déficitaire aujourd'hui, et ce test ne doit pas dépendre du relevé du jour.
+  const largeurs = await page.evaluate(() => {
+    const hote = document.createElement("div");
+    // Le gabarit exact de scoreCell, pour les trois largeurs qui ont pu s'écrire dans le style.
+    hote.innerHTML = `
+      <span class="scorebar s-low" id="t-neg"><i style="width:-1441%"></i></span>
+      <span class="scorebar s-low" id="t-vide"><i></i></span>
+      <span class="scorebar s-good" id="t-plein"><i style="width:100%"></i></span>`;
+    document.body.append(hote);
+    const large = (id) => document.querySelector(`#${id} i`).getBoundingClientRect().width;
+    const mesures = { negatif: large("t-neg"), sansLargeur: large("t-vide"), plein: large("t-plein") };
+    hote.remove();
+    return mesures;
+  });
+
+  expect(largeurs.plein).toBeGreaterThan(40);   // une barre pleine occupe bien les 46 px du parent
+  expect(largeurs.negatif).toBe(0);             // 46 px avant le correctif : le bug
+  expect(largeurs.sansLargeur).toBe(0);         // la ceinture : plus aucun repli sur `auto`
+});
+
+test("score : le tableau n'écrit jamais une largeur hors [0, 100] (#39)", async ({ page }) => {
+  // Le correctif porte sur le RENDU : scoreCell borne la largeur, le chiffre garde son signe.
+  const styles = await page.locator("#rows .scorebar i").evaluateAll((els) =>
+    els.map((e) => e.getAttribute("style") || ""));
+  expect(styles.length).toBeGreaterThan(50);
+  const horsBornes = styles.filter((s) => !/^width:\s*(100|\d{1,2})%;?$/.test(s.trim()));
+  expect(horsBornes).toEqual([]);
+});

--- a/logic.mjs
+++ b/logic.mjs
@@ -69,6 +69,17 @@ export function normalizeScores(rows) {
   return rows;
 }
 
+// Largeur de la mini-barre d'un score, en pourcentage. On borne le DESSIN, jamais la MESURE :
+// un score négatif (route dont les frais d'autoload dépassent la marge) est une information vraie
+// dont le tri se sert pour classer « perd un peu » avant « perd beaucoup ». Seul son rendu était
+// faux — et spectaculairement : `width:-1441%` est une déclaration CSS invalide, donc ignorée,
+// donc l'élément retombait en `width:auto`, qui remplit son parent. La pire ligne du tableau
+// portait ainsi la plus grosse barre. Un score absent vaut 0 plutôt qu'un `width:NaN%`, qui
+// serait invalide de la même façon.
+export function scoreBarWidth(score) {
+  return Number.isFinite(score) ? Math.min(100, Math.max(0, score)) : 0;
+}
+
 // ---------- Tri (valeurs nulles en bas ; chaînes sensibles à la locale) ----------
 export function bySort(key, dir) {
   return (a, b) => {

--- a/logic.test.mjs
+++ b/logic.test.mjs
@@ -5,7 +5,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import {
   tripMinutes, loopMinutes, ageDays, pairAge, freshnessFactor, availabilityFactor, tighterVolume,
-  normalizeScores, bySort, computeUnits, effValue, fillCargo, addableUnits, scuBoxes, cargoBoxes, bestChain,
+  normalizeScores, scoreBarWidth, bySort, computeUnits, effValue, fillCargo, addableUnits, scuBoxes, cargoBoxes, bestChain,
   AUTOLOAD, autoloadFee, autoloadPoint, haulFee, lineHaulFee, lineNet,
   manifestTotals, freeAddUnits, manifestLine, stationLabel, parseStationLabel,
   ovKey, effFromStore, setInStore, safeKey, encodeState, decodeState,
@@ -136,6 +136,57 @@ test("normalizeScores : tout à 0 si aucun score positif", () => {
   const rows = [{ rawScore: 0 }, {}];
   normalizeScores(rows);
   assert.deepEqual(rows.map((r) => r.score), [0, 0]);
+});
+
+// Prémisse du bug de la barre pleine : un score négatif n'est pas une hypothèse d'école, il sort
+// du calcul dès que les frais d'autoload mangent la marge. On l'établit sur les fonctions pures
+// avant de parler de rendu, sinon on borne une largeur pour un cas qui n'arrive jamais.
+test("rawScore négatif : une marge trop mince pour les frais d'autoload", () => {
+  const f = { cargo: 96, budget: 0, capStock: true, useCargo: true, useBudget: false };
+  const m = {
+    buyPrice: 250, buyStock: 400, sellDemand: 400, margin: 12,
+    distance: 30, sameSystem: true, buyUpdated: 1, sellUpdated: 1,
+  };
+  const station = { maxBox: 32, k: 1 };
+
+  // Sans frais la route est rentable : 96 SCU × 12 aUEC = 1152 aUEC de marge.
+  const brut = routeMetrics(m, f, null);
+  assert.equal(brut.profit, 1152);
+  assert.ok(brut.rawScore > 0);
+
+  // Les mêmes 96 SCU coûtent 4320 aUEC de manutention aux deux bouts : le trajet fait perdre
+  // de l'argent, donc profit/heure négatif, donc rawScore négatif (les deux facteurs sont positifs).
+  const net = routeMetrics(m, f, { buy: station, sell: station });
+  assert.equal(net.fees, 4320);
+  assert.equal(net.profit, -3168);
+  assert.ok(net.profitHour < 0, "profit/heure négatif");
+  assert.ok(net.rawScore < 0, "rawScore négatif");
+});
+
+// On borne le DESSIN, pas la MESURE : le score garde son signe pour tous ses consommateurs —
+// dont le tri, qui doit pouvoir classer « perd un peu » avant « perd beaucoup ».
+test("normalizeScores : un rawScore négatif garde son signe, et descend sous -100", () => {
+  const rows = [{ rawScore: 400 }, { rawScore: -80 }, { rawScore: -5763 }];
+  normalizeScores(rows);
+  assert.deepEqual(rows.map((r) => r.score), [100, -20, -1441]);
+  // Le tri décroissant range bien la pire route en dernier.
+  assert.deepEqual([...rows].sort(bySort("score", -1)).map((r) => r.score), [100, -20, -1441]);
+});
+
+test("scoreBarWidth : la largeur de la barre reste dans [0, 100]", () => {
+  // Le cœur du bug : `width:-1441%` est une déclaration CSS invalide, donc ignorée, donc
+  // l'élément retombe en `width:auto` — et un bloc en auto remplit son parent. Une largeur
+  // négative ne dessinait pas une barre vide, elle dessinait la barre la plus PLEINE du tableau.
+  assert.equal(scoreBarWidth(-1441), 0);
+  assert.equal(scoreBarWidth(-20), 0);
+  assert.equal(scoreBarWidth(0), 0);
+  assert.equal(scoreBarWidth(42), 42);
+  assert.equal(scoreBarWidth(100), 100);
+  assert.equal(scoreBarWidth(160), 100);
+  // Un score absent ne doit pas écrire `width:NaN%`, qui retomberait dans le même piège.
+  assert.equal(scoreBarWidth(null), 0);
+  assert.equal(scoreBarWidth(undefined), 0);
+  assert.equal(scoreBarWidth(NaN), 0);
 });
 
 // ---------- Tri ----------

--- a/style.css
+++ b/style.css
@@ -757,7 +757,10 @@ input.editv-input { width: 80px; min-width: 0; padding: 2px 5px; font-size: 12px
 .score-cell { display: flex; align-items: center; justify-content: center; gap: 8px; white-space: nowrap; }
 .score-cell b { font-family: var(--mono); font-variant-numeric: tabular-nums; min-width: 22px; text-align: right; }
 .scorebar { display: inline-block; width: 46px; height: 6px; flex-shrink: 0; background: rgba(255, 255, 255, 0.07); border: 1px solid var(--line); overflow: hidden; }
-.scorebar i { display: block; height: 100%; }
+/* `width: 0` par défaut : sans elle, une largeur invalide (négative, NaN) est ignorée et l'élément
+   retombe en `width: auto`, qui REMPLIT le parent — une barre hors bornes se lisait « meilleure du
+   tableau ». La borne vit dans scoreBarWidth ; ceci est la ceinture qui la double. */
+.scorebar i { display: block; height: 100%; width: 0; }
 .scorebar.s-good i { background: linear-gradient(90deg, rgba(70,229,160,.5), var(--good)); }
 .score-cell.has b, .scorebar.s-good + b { color: var(--good); }
 .scorebar.s-good ~ b { color: var(--good); }


### PR DESCRIPTION
## Ce que ça change

Une ligne dont le profit/heure est négatif — les frais d'autoload dépassent la marge — affiche
désormais une mini-barre **vide**. Elle s'affichait **pleine**, exactement comme la meilleure ligne
du tableau : la pire route du classement portait la plus grosse barre. Le chiffre à côté ne change
pas, il reste le score réel, signe compris.

## Pourquoi

La cause racine tient en deux temps, et c'est le second qui **inverse** le sens de la barre.

- `app.js:411` (avant correctif) — `scoreCell` écrivait `style="width:${score}%"` sans garde.
  `normalizeScores` (`logic.mjs:66-70`) ne borne que le HAUT (100 = meilleur de la liste) : un
  `rawScore` négatif ressort en pourcentage négatif, et pas de peu — **-1441 %** sur une liste
  réaliste (mesuré par le test ajouté).
- `style.css:759` (avant correctif) — `.scorebar i { display: block; height: 100% }`, **sans aucune
  `width`**. `width:-1441%` est une déclaration CSS invalide, donc ignorée ; l'élément retombait sur
  `width: auto`, et un bloc en auto occupe TOUTE la largeur de son parent. Une largeur négative ne
  dessine pas une barre vide, elle dessine la barre la plus pleine du tableau.

Le score négatif n'est pas un cas d'école : à 12 aUEC/SCU de marge sur 96 SCU, les 4 320 aUEC de
manutention aux deux bouts font passer le trajet de **+1 152 à -3 168 aUEC**. C'est ce que le
premier test ajouté établit, sur les fonctions pures, avant qu'on parle de rendu.

**Où la garde est posée — et pourquoi là.** Dans le rendu (`scoreBarWidth`, appelée par `scoreCell`),
pas dans `normalizeScores`. C'est la recommandation de l'issue, et elle tient après vérification des
consommateurs de `score` : outre `scoreCell`, c'est la **clé de tri par défaut** des vues Trajets et
Boucles (`sortKey` / `loopSortKey`, `app.js:43,45`). Écraser les négatifs à 0 dans la mesure rendrait
« perd un peu » et « perd beaucoup » indiscernables au tri. On borne le dessin, jamais la mesure.

`.scorebar i` reçoit en plus une `width: 0` par défaut : la ceinture qui empêche qu'une future
largeur invalide (négative, `NaN`) se relise comme « plein ».

## Vérification

### Le rouge, d'abord

Le défaut est un défaut de **rendu** : la preuve qui compte est une mesure dans un vrai navigateur.
`npx playwright test -g "score :"`, avant correctif :

```
Error: expect(received).toBe(expected) // Object.is equality

Expected: 0
Received: 44

> 1936 |   expect(largeurs.negatif).toBe(0);   // 46 px avant le correctif : le bug
```

**44 px** : la barre d'un score à -1441 occupait toute la largeur intérieure de son parent (46 px
moins les deux bordures). La barre la plus pleine du tableau, pour la pire route.

Côté unitaire, `scoreBarWidth` n'existait pas :

```
ReferenceError: scoreBarWidth is not defined
```

Les **deux tests de prémisse passaient déjà** avant le correctif — ils n'établissent pas le défaut,
ils établissent qu'il est atteignable, ce qui devait être prouvé avant de borner quoi que ce soit :

```
✔ rawScore négatif : une marge trop mince pour les frais d'autoload
✔ normalizeScores : un rawScore négatif garde son signe, et descend sous -100
```

### Le vert, après

`node --test` :

```
ℹ tests 383
ℹ pass 383
ℹ fail 0
```

`npx playwright test` (lancé par fichiers, cf. la note ci-dessous) :

```
e2e/autoload.pw.mjs + e2e/injection.pw.mjs :  12 passed,             1 flaky  (3.0m)
e2e/smoke.pw.mjs                           : 103 passed, 2 skipped,  2 flaky  (7.0m)
```

Et la CI de cette PR, qui n'a ni contention ni port squatté — c'est le verdict propre :

```
e2e   pass  3m59s
unit  pass  12s
```

Aucun échec. Les 3 « flaky » locaux (« navigation entre les cinq vues », « le vaisseau ET sa carte », et
« manifeste : une ligne vend ailleurs ») passent à la reprise, sont **sans rapport** avec le score,
et se reproduisent à l'identique sur `origin/main` **sans** ce correctif : c'est de la contention
locale, pas une régression. La CI est verte sur `main`.

> **Piège rencontré, à savoir pour qui relance ces tests localement.**
> `playwright.config.mjs` fixe le port 4173 avec `reuseExistingServer: !process.env.CI`. Un serveur
> laissé tourner par un AUTRE worktree occupe ce port, et Playwright le réutilise **silencieusement** :
> la suite s'exécute alors contre le code d'un autre répertoire. C'est arrivé ici — le premier
> « rouge » comme le premier « vert » ont été mesurés contre des fichiers étrangers, et la suite
> affichait 19 échecs sans rapport. Tous les chiffres ci-dessus ont été relancés sur un port dédié,
> `cwd` pointé sur ce worktree.

## Ce qui n'est pas couvert

- **La pertinence de la formule de score** reste entière : ce correctif ne touche pas au calcul, il
  l'empêche seulement d'être dessiné à l'envers. C'est le sujet de #51, qui demande un ADR.
- **Les seuils de couleur** `s-good` / `s-ok` / `s-low` sont inchangés : un score négatif tombe dans
  `s-low`, ce qui reste juste.
- **Aucun test ne fait produire un score négatif à l'application par les données réelles** : rien ne
  garantit qu'une route de l'amorce soit déficitaire un jour donné, et l'e2e ne doit pas dépendre du
  relevé du jour. La négativité est donc prouvée sur les fonctions pures (`node --test`), et le rendu
  est vérifié sur la règle CSS elle-même plus sur l'absence de largeur hors bornes dans le tableau.
- **`normalizeScores` peut encore produire `NaN`** pour une ligne sans `rawScore` dès qu'une autre
  ligne est positive (`undefined / max`). La barre, elle, est désormais sûre des deux côtés
  (`scoreBarWidth` → 0, et la `width: 0` par défaut), mais le nombre affiché s'écrirait `NaN`. Aucun
  appelant réel n'y mène aujourd'hui — `routeMetrics` et `tripMetrics` renseignent toujours le champ —
  et le corriger sortirait du périmètre de cette issue.

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)
