### PR TITLE
fix(autoload): un montant tapé à côté ne devient plus un tarif de station relevé

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,11 @@ quand UEX renvoie 0** : ce repli sous-estime les frais plutôt que de les invent
 D'où le **`≈` sur tout montant** : l'app donne un ordre de grandeur fiable, pas un chiffre exact. Si tu
 relèves le tarif réel d'une station, tu peux **l'enregistrer** (montant observé pour une quantité donnée →
 `k` déduit) : c'est **local**, comme les corrections, jamais partagé ni mis dans l'URL — seuls
-l'interrupteur et le `k` global entrent dans le permalien.
+l'interrupteur et le `k` global entrent dans le permalien. Un relevé qui donne un `k` hors de la plage
+plausible (**0,25 à 4**, soit ×4 et ÷4 autour de l'ancrage — dix fois l'écart entre les deux stations
+mesurées) **demande confirmation** avant d'être retenu : un zéro de trop dans le montant produit un
+coefficient d'apparence honnête, ensuite affiché « (relevé) » comme s'il avait été mesuré. La question
+ne refuse rien — un tarif vraiment surprenant reste enregistrable en un clic.
 
 Deux hypothèses complètent le modèle, faute de mesures : le **nombre de caisses est fixé au chargement**
 (au déchargement on sort les caisses qu'on a, seul le tarif change) et **une transaction par commodité**

--- a/app.js
+++ b/app.js
@@ -4,7 +4,7 @@
 import {
   tripMinutes, ageDays, pairAge,
   normalizeScores, bySort, addableUnits, scuBoxes, cargoBoxes, bestChain,
-  AUTOLOAD, autoloadFee, autoloadPoint, haulFee, lineHaulFee, lineNet,
+  AUTOLOAD, autoloadFee, autoloadPoint, haulFee, lineHaulFee, lineNet, kFromReading, kPlausible,
   ovKey, effFromStore, setInStore, DUREE_VOL, groupOverridesByTerminal, safeKey, encodeState, decodeState,
   routePasses, loopPasses,
   routeMetrics, loopMetrics, enRouteDeals, bestManifest, buildChainAdjacency, suggestionsFrom, netMarginRoi,
@@ -231,15 +231,6 @@ function saveAutoloadK() { try { localStorage.setItem(AUTOLOAD_KEY, JSON.stringi
 const globalK = () => { const v = Number($("alk").value); return v > 0 ? v : K_DEFAULT; };
 const kFor = (terminal) => { const o = AUTOLOAD_K[alKey(terminal)]; return o && o.k > 0 ? o.k : globalK(); };
 
-// Déduit k d'un montant observé en jeu : personne ne lit un coefficient à l'écran, on lit une
-// facture. k = montant payé / montant que la formule prédirait au tarif d'ancrage (k = 1).
-// null quand la mesure ne dit rien (quantité nulle, montant absurde).
-function kFromReading(amount, scu, maxBox) {
-  const ref = autoloadFee(scu, maxBox, 1);
-  if (!(ref > 0) || !(amount > 0)) return null;
-  return Math.round((amount / ref) * 1000) / 1000;
-}
-
 // Ce qu'UNE extrémité facture. `point` est ce que consomme logic.mjs ; les autres champs servent à
 // EXPLIQUER le chiffre à l'écran — « cette station ne propose pas l'autoload » et « UEX ne nous a
 // pas dit si elle le propose » aboutissent au même 0 mais ne se racontent pas pareil, et aucun des
@@ -277,7 +268,8 @@ const feeResolver = (f) => (f.autoload ? (t) => autoloadPoint(t, kFor(t && t.nam
 // relevés à 2,8 % près, et `k` varie de 40 % entre les deux seules stations mesurées. Le « ≈ » le
 // dit, partout où le chiffre a été amputé.
 const fmtFee = (n, fees) => (fees > 0 ? "≈ " + fmt(n) : fmt(n));
-const kText = (e) => `×${e.k.toLocaleString("fr-FR", { maximumFractionDigits: 3 })} ${e.measured ? "(relevé)" : "(k global)"}`;
+const kFmt = (k) => k.toLocaleString("fr-FR", { maximumFractionDigits: 3 });
+const kText = (e) => `×${kFmt(e.k)} ${e.measured ? "(relevé)" : "(k global)"}`;
 function feeEndText(e) {
   if (!e.known) return `${e.name} : autoload inconnu (donnée UEX absente) — rien facturé`;
   if (!e.available) return `${e.name} : pas d'autoload — rien facturé`;
@@ -2551,6 +2543,16 @@ function saveStationReading() {
   const scu = Math.floor(Number($("alScu").value));
   const k = kFromReading(amount, scu, t.maxBox);
   if (k == null) { showToast("⚠ Relevé inutilisable — indique le montant payé et la quantité chargée"); return; }
+  // Un montant tapé à côté (un zéro de trop) donne un k d'apparence honnête, qu'on persiste et
+  // qu'on réaffiche « (relevé) » — il se lit alors comme une mesure fiable tout en multipliant les
+  // frais de cette station dans toutes les vues. Hors des bornes plausibles on DEMANDE, on ne
+  // refuse pas : un relevé surprenant reste une mesure, et c'est l'utilisateur qui l'a faite.
+  // Le message montre le montant tel qu'il a été compris et le compare aux deux tarifs connus :
+  // sans ce repère, « k = 1 413 » ne dit pas à quel point c'est absurde.
+  if (!kPlausible(k) && !confirm(
+    `${fmt(amount)} aUEC pour ${fmt(scu)} SCU à ${t.name}, c'est ×${kFmt(k)} le tarif d'Endgame.\n` +
+    `Les deux seules stations mesurées valent ×1 et ×1,4. Un zéro de trop ?\n\nEnregistrer ce relevé quand même ?`
+  )) return;
   AUTOLOAD_K[alKey(t.name)] = { k, amount, scu };
   saveAutoloadK();
   refresh();
@@ -2585,7 +2587,7 @@ function stationFeeHTML(S) {
   const rec = AUTOLOAD_K[alKey(t.name)];
   const k = kFor(t.name);
   const scu = rec ? rec.scu : 32;
-  const note = `<div class="fee-note">Tarif retenu : <b>k = ${k.toLocaleString("fr-FR", { maximumFractionDigits: 3 })}</b> ${rec ? "(ton relevé)" : "(k global)"} — soit ≈ <b>${fmt(autoloadFee(scu, t.maxBox, k))}</b> aUEC pour ${fmt(scu)} SCU${t.maxBox ? `, caisses de ${fmt(t.maxBox)} SCU max` : ""}.</div>`;
+  const note = `<div class="fee-note">Tarif retenu : <b>k = ${kFmt(k)}</b> ${rec ? "(ton relevé)" : "(k global)"} — soit ≈ <b>${fmt(autoloadFee(scu, t.maxBox, k))}</b> aUEC pour ${fmt(scu)} SCU${t.maxBox ? `, caisses de ${fmt(t.maxBox)} SCU max` : ""}.</div>`;
   return wrap(
     `<div class="fee-row">
        <span>Montant observé</span>
@@ -2728,7 +2730,7 @@ function autoloadListHTML() {
   const items = keys.sort().map((key) => {
     const o = AUTOLOAD_K[key];
     const terminal = key.slice(key.indexOf("|") + 1);
-    return `<div class="corr-item autoload"><div><b>${esc(terminal)}</b> <span class="corr-side">autoload</span><div class="loc-sub">k = <b>${o.k.toLocaleString("fr-FR", { maximumFractionDigits: 3 })}</b> · ${fmt(o.amount)} aUEC observés pour ${fmt(o.scu)} SCU</div></div><button class="corr-del al-del" data-key="${esc(key)}" title="Oublier ce relevé">✕</button></div>`;
+    return `<div class="corr-item autoload"><div><b>${esc(terminal)}</b> <span class="corr-side">autoload</span><div class="loc-sub">k = <b>${kFmt(o.k)}</b> · ${fmt(o.amount)} aUEC observés pour ${fmt(o.scu)} SCU</div></div><button class="corr-del al-del" data-key="${esc(key)}" title="Oublier ce relevé">✕</button></div>`;
   }).join("");
   return `<div class="corr-list-head"><span>${keys.length} relevé${keys.length > 1 ? "s" : ""} d'autoload</span><button id="resetAllK" class="reset-ov">Tout oublier</button></div>${items}`;
 }

--- a/docs/superpowers/specs/2026-08-10-frais-autoload-design.md
+++ b/docs/superpowers/specs/2026-08-10-frais-autoload-design.md
@@ -127,6 +127,17 @@ pour 32 SCU à Ruin → k = 1 159 / 820 = 1,41.
 Les stations non mesurées prennent le **k global**, réglable, **défaut 1,2** (milieu des deux
 mesures connues).
 
+**Plage plausible du relevé** (ajout du 2026-08-14, issue #27) : `k` accepté sans question de
+**0,25 à 4**, confirmation demandée au-delà. Ces bornes ne prétendent pas connaître le tarif des 159
+terminaux jamais mesurés — elles écartent le **décalage de virgule**, seule faute de saisie qui
+produise un coefficient d'apparence honnête : un zéro de trop (1 159 000 pour 1 159) multiplie `k`
+par dix, un dernier chiffre oublié le divise par dix. Depuis la plage mesurée, le plus petit
+décalage possible donne 10 d'un côté et 0,14 de l'autre ; toute borne située entre les deux les
+attrape. ×4 / ÷4 autour de l'ancrage laisse dix fois l'écart réellement observé entre les deux
+stations, et plus du double de marge avant le premier décalage. **On confirme, on ne refuse pas** :
+une borne qui perdrait un relevé véritablement surprenant serait pire que le tarif faux qu'elle
+corrige — et c'est parce qu'elle ne coûte qu'un clic qu'on peut la serrer autant.
+
 ### Application dans le moteur
 
 Les frais s'appliquent **deux fois par trajet** — chargement à l'achat, déchargement à la vente —

--- a/e2e/autoload.pw.mjs
+++ b/e2e/autoload.pw.mjs
@@ -356,3 +356,27 @@ test("relevé de station : k déduit d'un montant observé, persistant, hors du 
   await page.locator("#station").dispatchEvent("input");
   await expect(page.locator(".corr-item.autoload")).toContainText("1,41"); // survit au rechargement
 });
+
+test("relevé de station : un zéro de trop se fait confirmer avant d'être retenu (#27)", async ({ page }) => {
+  await enrichMarket(page, "all", 32); // mêmes caisses de 32 SCU que le relevé de Ruin ci-dessus
+  await page.goto("/index.html");
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+  await page.click("#viewCorrections");
+  const label = await page.locator("#stationList option").first().getAttribute("value");
+  await page.fill("#station", label);
+  await page.locator("#station").dispatchEvent("input");
+  await expect(page.locator("#alAmount")).toBeVisible();
+
+  // 1 159 000 au lieu de 1 159 : k = 1 413, mille fois le tarif d'ancrage. Playwright REFUSE tout
+  // dialogue tant qu'aucun écouteur n'est posé — c'est donc ici l'utilisateur qui dit « non ».
+  await page.fill("#alAmount", "1159000");
+  await page.fill("#alScu", "32");
+  await page.click("#alSave");
+  await expect(page.locator(".corr-item.autoload")).toHaveCount(0); // rien de persisté
+  await expect(page.locator(".fee-note")).toContainText("(k global)"); // ni annoncé comme relevé
+
+  // Confirmé, le relevé surprenant reste enregistrable : la borne coûte un clic, pas une mesure.
+  page.on("dialog", (d) => d.accept());
+  await page.click("#alSave");
+  await expect(page.locator(".corr-item.autoload")).toContainText("413,415");
+});

--- a/logic.mjs
+++ b/logic.mjs
@@ -417,6 +417,30 @@ export function autoloadFee(scu, maxBox, k) {
   return Math.round(k * (AUTOLOAD.base + AUTOLOAD.perBox * boxes + AUTOLOAD.perScu * units));
 }
 
+// ---------- Relevé de station : du montant payé au coefficient ----------
+// Déduit `k` d'un montant observé en jeu : personne ne lit un coefficient à l'écran, on lit une
+// facture. k = montant payé / montant que la formule prédirait à l'ancrage (k = 1), au plafond de
+// caisse du terminal. null quand la mesure ne dit rien : sans quantité il n'y a pas de référence à
+// diviser, sans montant il n'y a rien de mesuré (un champ vide donne Number("") = 0, un texte NaN).
+export function kFromReading(amount, scu, maxBox) {
+  const ref = autoloadFee(scu, maxBox, 1);
+  if (!(ref > 0) || !(amount > 0)) return null;
+  return Math.round((amount / ref) * 1000) / 1000;
+}
+
+// Ce k est-il celui d'une station, ou d'une faute de frappe ? Ces bornes ne prétendent PAS connaître
+// le tarif des 159 terminaux jamais mesurés — elles écartent le DÉCALAGE DE VIRGULE, seule erreur de
+// saisie qui produise un coefficient d'apparence honnête : un zéro de trop (1 159 000 pour 1 159)
+// multiplie k par dix, un dernier chiffre oublié le divise par dix. Depuis la plage mesurée (1,0 à
+// Endgame, 1,4 à Ruin), le plus petit décalage possible donne 10 d'un côté, 0,14 de l'autre ; toute
+// borne entre ces deux valeurs les attrape. On prend ×4 et ÷4 autour de l'ancrage : dix fois l'écart
+// réellement observé entre les deux stations, et il reste plus du double de marge avant le premier
+// décalage. Hors bornes, l'appelant fait CONFIRMER, il ne refuse pas — une borne qui perdrait un
+// relevé véritablement surprenant serait pire que le tarif faux qu'elle corrige, et c'est justement
+// parce qu'elle ne coûte qu'un clic qu'on peut la serrer autant.
+export const K_PLAUSIBLE = { min: 0.25, max: 4 };
+export const kPlausible = (k) => k >= K_PLAUSIBLE.min && k <= K_PLAUSIBLE.max;
+
 // ---------- Contexte de frais : un point par terminal, une paire par chargement ----------
 // Tout le moteur reçoit ce contexte en PARAMÈTRE OPTIONNEL, et son absence (null) est le chemin
 // par défaut : sans lui, chaque fonction rend exactement les valeurs brutes qu'elle rendait avant

--- a/logic.test.mjs
+++ b/logic.test.mjs
@@ -6,7 +6,7 @@ import { readFileSync } from "node:fs";
 import {
   tripMinutes, loopMinutes, ageDays, pairAge, freshnessFactor, availabilityFactor, tighterVolume,
   normalizeScores, bySort, computeUnits, effValue, fillCargo, addableUnits, scuBoxes, cargoBoxes, bestChain,
-  AUTOLOAD, autoloadFee, autoloadPoint, haulFee, lineHaulFee, lineNet,
+  AUTOLOAD, autoloadFee, autoloadPoint, haulFee, lineHaulFee, lineNet, kFromReading, kPlausible, K_PLAUSIBLE,
   manifestTotals, freeAddUnits, manifestLine, stationLabel, parseStationLabel,
   ovKey, effFromStore, setInStore, safeKey, encodeState, decodeState,
   profitPerHour, rawScoreOf, routePasses, loopPasses,
@@ -623,6 +623,45 @@ test("autoloadFee : à taille de caisse constante, le coût croît avec le volum
     prec = f;
   }
   assert.ok(autoloadFee(31, 32, 1) > autoloadFee(32, 32, 1), "31 SCU en 4 caisses > 32 SCU en 1");
+});
+
+// ---------- Relevé de station : du montant payé au coefficient ----------
+test("kFromReading : le relevé de Ruin redonne son coefficient", () => {
+  // La spec : 1 159 aUEC pour 32 SCU en une caisse de 32 -> 1 159 / 820 = 1,413.
+  assert.equal(autoloadFee(32, 32, 1), 820);
+  assert.equal(kFromReading(1159, 32, 32), 1.413);
+  // Le plafond de caisse du terminal compte : à 16, les mêmes 32 SCU font deux caisses (850 à k=1).
+  assert.equal(kFromReading(1159, 32, 16), 1.364);
+});
+
+test("kFromReading : une mesure qui ne dit rien ne rend pas un coefficient", () => {
+  assert.equal(kFromReading(1159, 0, 32), null);    // sans quantité, aucune référence
+  assert.equal(kFromReading(0, 32, 32), null);      // sans montant, aucune mesure
+  assert.equal(kFromReading(-500, 32, 32), null);
+  assert.equal(kFromReading(NaN, 32, 32), null);    // champ vide -> Number("") vaut 0, texte -> NaN
+});
+
+test("kPlausible : les deux stations mesurées passent, le décalage de virgule non (#27)", () => {
+  // Les seuls coefficients jamais mesurés : Endgame (l'ancrage) et Ruin.
+  assert.ok(kPlausible(1));
+  assert.ok(kPlausible(1.4));
+  assert.ok(kPlausible(kFromReading(1159, 32, 32)));
+  // Le bug : un zéro de trop dans le montant, et k passe à mille sans que rien ne le signale.
+  assert.equal(kFromReading(1159000, 32, 32), 1413.415);
+  assert.ok(!kPlausible(1413.415), "1 159 000 aUEC pour 32 SCU n'est pas un tarif de station");
+  // Ce que les bornes doivent attraper, exactement : le plus PETIT décalage de virgule possible
+  // depuis la plage mesurée — un zéro de trop sur la station la moins chère (1,0 -> 10), un dernier
+  // chiffre oublié sur la plus chère (1,4 -> 0,14). Toute borne entre les deux les rejette.
+  assert.ok(!kPlausible(10));
+  assert.ok(!kPlausible(0.14));
+  assert.ok(K_PLAUSIBLE.max < 10 && K_PLAUSIBLE.min > 0.14);
+  // Et elles restent larges : ×4 et ÷4 autour de l'ancrage, soit dix fois l'écart réellement
+  // observé entre les deux stations. Une plage resserrée sur [1 ; 1,4] ferait confirmer la moitié
+  // des relevés honnêtes, à commencer par le k global par défaut.
+  assert.equal(K_PLAUSIBLE.min * K_PLAUSIBLE.max, 1);
+  assert.ok(kPlausible(K_PLAUSIBLE.min) && kPlausible(K_PLAUSIBLE.max));
+  assert.ok(kPlausible(1.2), "le k global par défaut doit rester au-dessus de tout soupçon");
+  assert.ok(!kPlausible(null)); // une mesure inutilisable n'est pas un coefficient plausible
 });
 
 // ---------- addableUnits (suggestions) ----------


### PR DESCRIPTION
## Ce que ça change

Un relevé de tarif d'autoload dont le montant a été tapé à côté — 1 159 000 aUEC au lieu de 1 159 —
ne s'enregistre plus en silence. L'app annonce le coefficient qu'elle vient de comprendre
(« ×1 413,415 le tarif d'Endgame »), le compare aux deux seules stations mesurées (×1 et ×1,4) et
**demande confirmation**. Répondre « non » n'écrit rien. Répondre « oui » enregistre quand même : un
tarif surprenant reste une mesure, et c'est l'utilisateur qui l'a faite.

## Pourquoi

`kFromReading` (avant ce correctif `app.js:237`) promettait dans son propre commentaire « null quand
la mesure ne dit rien (quantité nulle, **montant absurde**) » mais ne testait que `amount > 0`. Un
zéro de trop donnait donc `k = 1 413`, **accepté et persisté** par `saveStationReading`
(`app.js:2547`) dans `best-hauling-autoload`, puis réaffiché « ×1 413 **(relevé)** » — la mention
même qui distingue une mesure d'une estimation — tout en multipliant par mille les frais estimés de
cette station dans les six vues.

La règle est pure : elle part donc dans `logic.mjs` (`kFromReading`, `kPlausible`, `K_PLAUSIBLE`,
juste après `autoloadFee` dont elle est l'inverse), où `node --test` l'atteint — au lieu de n'être
vérifiable qu'en e2e.

**La borne, et pourquoi celle-là.** Elle ne prétend pas connaître le tarif des 159 terminaux jamais
mesurés : elle écarte le **décalage de virgule**, seule faute de saisie qui produise un coefficient
d'apparence honnête — un zéro de trop multiplie `k` par dix, un dernier chiffre oublié le divise par
dix. Depuis la plage mesurée (1,0 à Endgame, 1,4 à Ruin), le plus petit décalage possible donne
**10** d'un côté et **0,14** de l'autre ; toute borne située entre ces deux valeurs les attrape. On
prend **×4 et ÷4 autour de l'ancrage** (`k` de 0,25 à 4) : dix fois l'écart réellement observé entre
les deux stations, et plus du double de marge avant le premier décalage. Et on **confirme au lieu de
refuser** : une borne qui perdrait un relevé véritablement surprenant serait pire que le tarif faux
qu'elle corrige — c'est justement parce qu'elle ne coûte qu'un clic qu'on peut la serrer autant. Le
raisonnement vit dans le commentaire de `logic.mjs`, dans le README et dans l'ADR d'origine.

## Vérification

Une mise en garde d'abord : le port 4173 de `playwright.config.mjs` était occupé par le serveur d'un
AUTRE plan de travail, et `reuseExistingServer` le réemployait — le premier passage complet mesurait
un `app.js` qui n'était pas celui de cette branche. Tout ce qui suit tourne sur un serveur dédié à ce
worktree (`reuseExistingServer: false`, port privé). La machine porte plusieurs plans de travail en
parallèle (16 cœurs à 100 %, plus de 60 processus node) : à 8 workers, 27 tests dépassaient les 30 s
sans qu'aucune assertion ne tombe. Relancés seuls, ils passent en 2 à 10 s — c'était de la
contention, pas des régressions. Le passage complet ci-dessous est fait à **3 workers, timeout 90 s**.

**Rouge AVANT** — le test e2e neuf, sur le code d'avant le correctif :

```
✘  1 [chromium] › e2e\autoload.pw.mjs:360:1 › relevé de station : un zéro de trop se fait confirmer avant d'être retenu (#27)
    Error: expect(locator).toHaveCount(expected) failed
    Locator:  locator('.corr-item.autoload')
    Expected: 0
    Received: 1
      375 |   await page.click("#alSave");
    > 376 |   await expect(page.locator(".corr-item.autoload")).toHaveCount(0); // rien de persisté
  1 failed
```

Le relevé à 1 159 000 était bel et bien écrit, sans qu'aucune question ne soit posée. Côté unitaire,
le rouge est celui d'une API qui n'existe pas encore :
`SyntaxError: The requested module './logic.mjs' does not provide an export named 'K_PLAUSIBLE'`.

**Vert APRÈS** :

```
$ node --test
ℹ tests 383
ℹ pass 383
ℹ fail 0
ℹ duration_ms 11582.4002

$ npx playwright test
  ✓  10 [chromium] › e2e\autoload.pw.mjs:323:1 › relevé de station : k déduit d'un montant observé, persistant, hors du lien (25.9s)
  ✓  11 [chromium] › e2e\autoload.pw.mjs:360:1 › relevé de station : un zéro de trop se fait confirmer avant d'être retenu (#27) (17.8s)
  …
  1 failed
    [chromium] › e2e\smoke.pw.mjs:1400:1 › les filtres à saisie libre sont débouncés : un mot tapé ne re-rend qu'une fois
  2 skipped
  116 passed (10.3m)
```

L'unique rouge est une **attente de 5 s** codée en dur dans le test
(`await expect(page).toHaveURL(/search=Laranite/)`, smoke.pw.mjs:1408) : le debounce plus le rendu
ont dépassé cette limite pendant que la machine était saturée. Relancé seul, il passe :

```
$ npx playwright test smoke.pw.mjs:1400
  ✓  1 [chromium] › e2e\smoke.pw.mjs:1400:1 › les filtres à saisie libre sont débouncés : un mot tapé ne re-rend qu'une fois (13.8s)
  1 passed
```

Il ne touche ni l'autoload ni le panneau de relevé, et rien de ce diff n'entre dans son chemin.

## Ce qui n'est pas couvert

- **Les relevés déjà enregistrés ne sont pas purgés** : un `k` absurde stocké avant ce correctif
  reste en place. Le purger au chargement effacerait aussi, sans le dire, un relevé surprenant que
  l'utilisateur aura confirmé ; il l'ôte avec le ✕ du relevé, ou « Tout oublier ».
- **Le `k` global** (`#alk`) n'est pas borné. Il reste visible, réglable et réversible à l'écran, et
  s'affiche « (k global) » — jamais « (relevé) » : il ne se fait pas passer pour une mesure.
- Un montant si petit que `k` **s'arrondit à 0** (moins de 0,0005 fois le tarif d'ancrage) passe
  désormais par la confirmation, mais reste persistable si on confirme : `kFor` traite alors ce 0
  comme « pas de relevé » et retombe sur le `k` global, tout en affichant « (relevé) ». Défaut
  distinct, hors du périmètre de cette issue.
- L'instabilité e2e de la famille « relevé de station » (#28) n'est pas traitée : le test neuf
  partage le même contexte et peut l'hériter.
- Aucun `data/*.json` touché.

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)
