### PR TITLE
fix(manifeste): remplir toute la soute quand une ligne est laissée au sol

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,17 @@ plus loin (« vend ailleurs ») n'est pas déchargé à l'arrivée, celui déjà
 butin, minage, salvage) n'a pas été chargé au départ. Un terminal qu'UEX déclare sans autoload
 (`is_auto_load`) n'est jamais facturé.
 
+Parce que la base se paie **par ligne**, une commodité peut coûter au manifeste plus qu'elle ne lui
+rapporte : ses 335 aUEC de marge sur l'unique SCU en stock ne couvrent pas les 400 de manutention,
+ou bien son SCU vaudrait davantage rempli de la commodité suivante. Le manifeste optimal la **laisse
+au sol et rend sa place au remplissage** — il ne garde une ligne que s'il vaut plus avec elle que
+sans, et il rebâtit le chargement à chaque retrait plutôt que de laisser la soute entamée. Garantie
+qui en découle, **quand la soute est la seule contrainte** : un manifeste ne rapporte jamais moins
+que sa meilleure commodité chargée seule sur le même trajet — vérifié sur les 167 434 arcs des
+40 combinaisons soute × tarif de l'instantané. Sous **budget bornant**, c'est un sac à dos à deux
+contraintes : le remplissage reste glouton et 16 arcs sur 499 772 y restent en deçà (contre 4 166
+avant), écart maximal 12 %.
+
 Les relevés bruts et le raisonnement complet sont dans
 [`docs/superpowers/specs/2026-08-10-frais-autoload-design.md`](docs/superpowers/specs/2026-08-10-frais-autoload-design.md).
 

--- a/logic.mjs
+++ b/logic.mjs
@@ -794,15 +794,66 @@ export function manifestsFrom(market, origin, destSystem, f, resolve, destTermin
     // un chiffre qui n'est pas celui qui classe le manifeste : les frais grossissent avec le volume,
     // donc le remplissage le plus chargé n'est pas toujours le plus rentable une fois déduits.
     // Une ligne dont les frais dépassent la marge fait perdre de l'argent : la charger quand même
-    // classerait ce manifeste sous un autre qui, lui, l'aurait laissée au sol. La place libérée ne
-    // se recycle pas — les candidates suivantes sont moins rentables, par construction du tri.
-    const evalue = (rempli) => {
-      const kept = fee ? rempli.lines.filter((l) => l.units * l.margin > lineHaulFee(l.units, l, fee)) : rempli.lines;
-      return { lines: kept, profit: fee ? manifestTotals(kept, fee).profit : rempli.profit };
+    // classerait ce manifeste sous un autre qui, lui, l'aurait laissée au sol. Mais une ligne ne se
+    // juge PAS seule, et c'est ce que faisait le filtre `units * margin > lineHaulFee` appliqué
+    // après coup (#41) : il ratait les deux moitiés de la question.
+    //   - La place de la ligne écartée n'était rendue à personne. Le tri classe sur la marge au SCU,
+    //     le filtre coupait sur la marge TOTALE, et les deux ne sont pas monotones l'un dans
+    //     l'autre : une petite ligne à très forte marge préempte de la place en tête de tri, puis se
+    //     fait écarter faute de couvrir la base de frais — 1 SCU de soute restait vide devant
+    //     1 337 SCU à quai.
+    //   - Une ligne rentable SEULE peut coûter au manifeste plus qu'elle ne rapporte : 1 SCU de
+    //     Methane gagne 667 net, mais prend sa place aux 739 du Nitrogen et paie une base de frais
+    //     de plus. Rentable, et pourtant à laisser au sol.
+    // D'où le seul critère juste : une ligne reste si le manifeste vaut plus AVEC elle que sans, ce
+    // qui suppose de rebâtir le chargement à chaque retrait — la place libérée retourne alors
+    // d'elle-même aux candidates suivantes. Le tour qui n'améliore rien s'arrête, et une candidate
+    // retirée ne revient jamais : la boucle est bornée par le nombre de candidates.
+    // Ça ne rend pas `fillCargo` optimal — le sac à dos à deux contraintes reste hors de portée.
+    // Ce qui est acquis : soute seule contrainte, un manifeste ne rapporte jamais moins que sa
+    // meilleure commodité seule (0 contre-exemple sur les 167 434 arcs de l'instantané). Sous
+    // budget bornant, c'est le budget qui joue la seconde contrainte et il en reste 16 sur 499 772.
+
+    // Remplit, puis retire les lignes qui ne couvrent même pas leurs propres frais (lineNet <= 0) —
+    // et recommence, parce que le retrait rend de la place et que les suivantes chargent davantage,
+    // ce qui peut à son tour rendre déficitaire une ligne qui tenait à plus petit volume.
+    // Ce verdict-là ne vaut QUE pour le chargement qui vient d'être bâti : il dépend du volume
+    // attribué, donc de qui d'autre est à bord. 126 SCU de Human Food Bars perdent 60 aUEC là où
+    // 128 en gagnent 200 — deux SCU de moins et la cargaison ne tient plus en caisses de 32. Le
+    // rejet reste donc LOCAL à cet appel, et `evalue` repart toujours des candidates au complet.
+    const remplir = (liste) => {
+      let restantes = liste;
+      for (;;) {
+        const rempli = fillCargo(restantes, f.cargo, budget);
+        const jetees = new Set();
+        const lines = rempli.lines.filter((l) => {
+          if (lineNet(l.units, l, fee) > 0) return true;
+          jetees.add(l.name);
+          return false;
+        });
+        if (!jetees.size) return { lines, profit: manifestTotals(lines, fee).profit };
+        restantes = restantes.filter((c) => !jetees.has(c.name));
+      }
     };
-    let meilleur = evalue(fillCargo([...items].sort(parMarge), f.cargo, budget));
+    const evalue = (ordre) => {
+      const candidates = [...items].sort(ordre);
+      if (!fee) return fillCargo(candidates, f.cargo, budget);
+      const laissees = new Set();                       // écartées pour de bon : une par tour, jamais reprises
+      let retenu = remplir(candidates);
+      for (;;) {
+        let mieux = null, sacrifiee = null;
+        for (const l of retenu.lines) {
+          const essai = remplir(candidates.filter((c) => c.name !== l.name && !laissees.has(c.name)));
+          if (!mieux || essai.profit > mieux.profit) { mieux = essai; sacrifiee = l.name; }
+        }
+        if (!mieux || mieux.profit <= retenu.profit) return retenu;
+        laissees.add(sacrifiee);
+        retenu = mieux;
+      }
+    };
+    let meilleur = evalue(parMarge);
     if (isFinite(budget)) {
-      const alt = evalue(fillCargo([...items].sort(parRendement), f.cargo, budget));
+      const alt = evalue(parRendement);
       if (alt.profit > meilleur.profit) meilleur = alt;
     }
     if (!meilleur.lines.length) continue;

--- a/logic.test.mjs
+++ b/logic.test.mjs
@@ -3271,6 +3271,144 @@ test("manifestsFrom : une commodité dont les frais dépassent la marge reste au
   assert.ok(100 * 5 < 2 * OP1, `500 de marge devrait rester sous ${2 * OP1} de frais`);
 });
 
+// --- Une ligne laissée au sol ne laisse pas sa place vide (#41) ---
+// Le marché du bug, aux chiffres exacts de MIC-L5 -> Ruin Station : une commodité à très forte
+// marge dont il ne reste qu'1 SCU à quai, et une seconde à marge moindre mais en stock abondant.
+// À k = 1 et maxBox 32, un chargement d'1 SCU coûte 200 aUEC par opération, donc 400 pour les deux
+// — plus que les 335 que « Waste » rapporte. Elle se fait donc écarter, mais APRÈS avoir préempté
+// son SCU en tête de tri : c'est le SCU que la soute perdait.
+const MKT_41 = () => ({
+  terminals: [TERM_NET("MIC-L5"), TERM_NET("Ruin Station")],
+  commodities: [
+    { name: "Waste", kind: "scrap", illegal: false, buys: [[0, 100, 1, NOW, 5]], sells: [[1, 435, 999, NOW, 3]] },
+    { name: "Scrap", kind: "scrap", illegal: false, buys: [[0, 100, 1337, NOW, 5]], sells: [[1, 235, 9999, NOW, 3]] },
+  ],
+});
+const frais41 = (t) => autoloadPoint(t, 1);
+
+test("manifestsFrom : la place d'une ligne écartée pour cause de frais retourne au remplissage", () => {
+  const f = F({ useCargo: true, cargo: 96 });
+  // Non vacuisant : « Waste » est bien écartée à bon droit, et c'est bien elle qui part en tête.
+  assert.equal(lineNet(1, { margin: 335 }, { buy: PT_A, sell: PT_A }), 335 - 2 * autoloadFee(1, 32, 1));
+  assert.ok(lineNet(1, { margin: 335 }, { buy: PT_A, sell: PT_A }) < 0, "la fixture doit rendre Waste déficitaire");
+  assert.deepEqual(manifestsFrom(MKT_41(), 0, "", f, idResolve)[0].lines.map((l) => [l.name, l.units]),
+    [["Waste", 1], ["Scrap", 95]]);                     // sans frais, elle est rentable et se charge
+  // Avec frais : « Waste » reste au sol, et son SCU revient au « Scrap » au lieu de rester vide.
+  const [t] = manifestsFrom(MKT_41(), 0, "", f, idResolve, null, frais41);
+  assert.deepEqual(t.lines.map((l) => [l.name, l.units]), [["Scrap", 96]]);  // 95 avant le correctif
+  assert.equal(t.lines.reduce((a, l) => a + l.units, 0), 96, "la soute repartait entamée d'1 SCU");
+  assert.equal(t.profit, 96 * 135 - 2 * autoloadFee(96, 32, 1));
+  assert.equal(t.profit, 8_640);                                             // 8 365 avant le correctif
+  // Et il y avait bien de quoi remplir : 1 337 SCU de Scrap attendaient à quai.
+  assert.ok(t.lines[0].stock > 96, "fixture sans stock de rechange : le test ne prouverait rien");
+});
+
+test("manifestsFrom : une ligne rentable SEULE mais qui prend sa place aux autres reste au sol", () => {
+  // L'autre moitié du même défaut, aux chiffres de CRU-L1 -> ARC-L1. « Methane » gagne 667 nets sur
+  // son unique SCU : jugée seule, elle mérite la soute. Mais ce SCU vaut 739 au « Nitrogen », et la
+  // charger coûte une base de frais de plus — le manifeste perd 212 aUEC à l'emporter.
+  const mkt = () => ({
+    terminals: [TERM_NET("CRU-L1"), TERM_NET("ARC-L1")],
+    commodities: [
+      { name: "Methane", kind: "gas", illegal: false, buys: [[0, 100, 1, NOW, 5]], sells: [[1, 1167, 999, NOW, 3]] },
+      { name: "Nitrogen", kind: "gas", illegal: false, buys: [[0, 100, 639, NOW, 5]], sells: [[1, 839, 9999, NOW, 3]] },
+    ],
+  });
+  const f = F({ useCargo: true, cargo: 96 });
+  // Non vacuisant : prise isolément, la ligne est bénéficiaire — ce n'est PAS le filtre déficitaire
+  // qui doit la retirer, et l'ancien code la gardait pour cette raison.
+  assert.equal(lineNet(1, { margin: 1067 }, { buy: PT_A, sell: PT_A }), 667);
+  const [t] = manifestsFrom(mkt(), 0, "", f, idResolve, null, frais41);
+  assert.deepEqual(t.lines.map((l) => [l.name, l.units]), [["Nitrogen", 96]]);
+  assert.equal(t.profit, 96 * 739 - 2 * autoloadFee(96, 32, 1));
+  assert.equal(t.profit, 66_624);                       // 66 412 avant : Methane 1 + Nitrogen 95
+  assert.ok(t.profit > 667 + 95 * 739 - 2 * autoloadFee(95, 32, 1), "le chargement à deux lignes devait perdre");
+});
+
+test("manifestsFrom : une ligne déficitaire à 126 SCU redevient éligible à 128, et le manifeste la reprend", () => {
+  // Aux chiffres de Rat's Nest -> Port Tressler, k = 2. Le verdict « cette ligne ne couvre pas ses
+  // frais » dépend du VOLUME qu'on lui a donné, donc de qui d'autre est à bord : « Human Food Bars »
+  // perd 60 aUEC sur 126 SCU et en gagne 200 sur 128, parce que 126 SCU ne tiennent plus en caisses
+  // de 32. Un rejet retenu d'un tour sur l'autre condamnait la meilleure option de l'arc : la soute
+  // repartait avec les 2 SCU de Fluorine et 146 aUEC.
+  const mkt = () => ({
+    terminals: [TERM_NET("Rat's Nest"), TERM_NET("Port Tressler")],
+    commodities: [
+      { name: "Fluorine", kind: "gas", illegal: false, buys: [[0, 100, 2, NOW, 5]], sells: [[1, 613, 999, NOW, 3]] },
+      { name: "Human Food Bars", kind: "food", illegal: false, buys: [[0, 100, 6000, NOW, 5]], sells: [[1, 190, 9999, NOW, 3]] },
+    ],
+  });
+  const f = F({ useCargo: true, cargo: 128 });
+  const frais2 = (t) => autoloadPoint(t, 2);
+  // Non vacuisant : c'est bien le passage de 128 à 126 SCU qui renverse le signe, par les caisses.
+  assert.equal(lineNet(128, { margin: 90 }, { buy: PT_A, sell: PT_A }) > 0, true);
+  assert.equal(126 * 90 - 2 * autoloadFee(126, 32, 2), -60);
+  assert.equal(128 * 90 - 2 * autoloadFee(128, 32, 2), 200);
+  const [t] = manifestsFrom(mkt(), 0, "", f, idResolve, null, frais2);
+  assert.deepEqual(t.lines.map((l) => [l.name, l.units]), [["Human Food Bars", 128]]);
+  assert.equal(t.profit, 200);                          // 146 avant : Fluorine 2 SCU, seule à bord
+});
+
+test("manifestsFrom : sans frais, le chargement des 4 284 arcs réels est inchangé au SCU près", () => {
+  // Garde-fou : la reprise du remplissage ne vit QUE dans la branche à frais. Interrupteur éteint,
+  // `fillCargo` doit rendre exactement ce qu'il rendait — un seul appel, aucun retrait, aucun tri
+  // de plus. C'est ce total figé qui le dit.
+  const f = F({ useCargo: true, cargo: 96 });
+  let arcs = 0, scu = 0, profit = 0;
+  for (let o = 0; o < REAL.terminals.length; o++) {
+    for (const t of manifestsFrom(REAL, o, "", f, idResolve)) {
+      arcs++; profit += t.profit;
+      scu += t.lines.reduce((a, l) => a + l.units, 0);
+    }
+  }
+  assert.deepEqual({ arcs, scu, profit }, { arcs: 4_284, scu: 344_101, profit: 392_892_971 });
+});
+
+test("manifestsFrom : frais actifs, aucun manifeste réel ne rapporte moins que sa meilleure commodité seule", () => {
+  // La non-régression MESURÉE, sur l'instantané entier : pour chaque arc, on chiffre la meilleure
+  // commodité chargée SEULE (le repli que le joueur a toujours sous la main) et on exige que le
+  // manifeste fasse au moins aussi bien. C'est l'invariant que le SCU perdu cassait : 20 arcs sur
+  // 4 219 y échouaient, jusqu'à −3,2 % (MIC-L5 -> Ruin Station, 8 365 contre 8 640).
+  const f = F({ useCargo: true, cargo: 96 });
+  const frais = (t) => autoloadPoint(t, 1);
+  let arcs = 0, multi = 0;
+  const echecs = [];
+  for (let o = 0; o < REAL.terminals.length; o++) {
+    for (const t of manifestsFrom(REAL, o, "", f, idResolve, null, frais)) {
+      arcs++;
+      if (t.lines.length > 1) multi++;
+      // Zéro plancher : ne rien charger reste une option, donc un manifeste ne perd jamais d'argent.
+      let mono = 0;
+      for (const it of suggestionsFrom(REAL, { lines: [], originIdx: t.originIdx, destIdx: t.destIdx, origin: t.origin, dest: t.dest, f }, idResolve)) {
+        let u = Math.min(f.cargo, it.stock);
+        if (it.demand != null || it.demandKnown) u = Math.min(u, it.demand);
+        if (u > 0) mono = Math.max(mono, u * it.margin - lineHaulFee(u, it, t.fee));
+      }
+      if (t.profit < mono) echecs.push(`${t.origin.name} -> ${t.dest.name} : ${t.profit} < ${mono}`);
+    }
+  }
+  assert.equal(arcs, 4_219, "l'instantané a changé : le compte d'arcs n'est plus celui qui a mesuré le défaut");
+  assert.deepEqual(echecs, []);
+  // Non vacuisant : l'invariant serait trivialement vrai si le correctif avait ramené tout le monde
+  // à une seule commodité. Le remplissage multi-commodité doit rester la règle, pas l'exception.
+  assert.ok(multi > 700, `chargements multi-commodité tombés à ${multi} : le correctif a trop coupé`);
+});
+
+test("manifestsFrom : le remplissage relancé s'arrête même quand TOUTES les candidates sont déficitaires", () => {
+  // La borne de la boucle : chaque tour retire au moins une candidate et une candidate retirée ne
+  // revient jamais, donc le pire des cas — tout jeter — termine sur un manifeste vide, pas en rond.
+  const mkt = () => ({
+    terminals: [TERM_NET("Depart"), TERM_NET("Sobre")],
+    commodities: Array.from({ length: 12 }, (_, i) => ({
+      name: `Miette${i}`, kind: "metal", illegal: false,
+      buys: [[0, 100, 1, NOW, 5]], sells: [[1, 100 + 12 - i, 999, NOW, 3]],   // marge 12 -> 1, stock 1
+    })),
+  });
+  const f = F({ useCargo: true, cargo: 96 });
+  assert.equal(manifestsFrom(mkt(), 0, "", f, idResolve)[0].lines.length, 12); // sans frais, on prend tout
+  assert.deepEqual(manifestsFrom(mkt(), 0, "", f, idResolve, null, frais41), []);
+});
+
 test("buildChainAdjacency : estampille sur chaque saut les frais de ses DEUX terminaux", () => {
   const f = { legalOnly: false, noOutpost: false };
   const sans = buildChainAdjacency(MKT_NET(), f, idResolve);


### PR DESCRIPTION
## Ce que ça change

Frais d'autoload actifs, « En route 🧭 » ne laisse plus un bout de soute vide derrière une commodité
qu'il a écartée. MIC-L5 → Ruin Station charge **96 SCU et rapporte 8 640 aUEC**, au lieu de 95 SCU
et 8 365 — alors que 1 337 SCU de Scrap attendaient à quai. Conséquence visible pour le joueur :
soute seule contrainte, un manifeste ne rapporte **jamais moins que sa meilleure commodité chargée
seule** sur le même trajet, ce qui n'était pas garanti.

## Pourquoi

Cause racine : **`logic.mjs:800`** (sur `main`), le filtre de `evalue()` dans `manifestsFrom` —

```js
const kept = fee ? rempli.lines.filter((l) => l.units * l.margin > lineHaulFee(l.units, l, fee)) : rempli.lines;
```

Il s'applique **après** `fillCargo`, donc après que la place a été allouée, et il juge chaque ligne
**seule**. C'était faux de trois façons :

1. **La place de la ligne écartée n'était rendue à personne.** Le tri classe sur la marge au SCU, le
   filtre coupe sur la marge *totale*, et les deux ne sont pas monotones l'un dans l'autre : une
   petite ligne à très forte marge passe en tête de tri, préempte son SCU, puis se fait écarter faute
   de couvrir la base de frais. Le SCU restait vide.
2. **Une ligne rentable seule peut coûter au manifeste plus qu'elle ne rapporte.** 1 SCU de Methane
   gagne 667 aUEC nets, mais ce SCU vaut 739 au Nitrogen et la charger paie une base de frais de
   plus. Le filtre la gardait, à juste titre selon son propre critère — lequel était le mauvais.
3. **Le verdict dépend du volume attribué,** donc de qui d'autre est à bord : 126 SCU de Human Food
   Bars perdent 60 aUEC là où 128 en gagnent 200, faute de tenir en caisses de 32. Un rejet retenu
   d'un tour sur l'autre condamnait la meilleure option de l'arc.

Le commentaire de `logic.mjs:796-798` assumait explicitement le choix (« *la place libérée ne se
recycle pas — les candidates suivantes sont moins rentables, par construction du tri* ») : c'est
précisément cette prémisse qui est fausse, et le commentaire a été réécrit avec le correctif.

Le correctif retient le seul critère juste — **une ligne reste si le manifeste vaut plus avec elle
que sans** — et rebâtit le chargement à chaque retrait, si bien que la place libérée retourne
d'elle-même aux candidates suivantes. La boucle est bornée : un tour qui n'améliore rien s'arrête,
et une candidate sacrifiée ne revient jamais.

## Vérification

### Le rouge d'abord

Les tests ajoutés, appliqués **seuls** sur `origin/main` (7454a54, `logic.mjs` inchangé) :

```
ℹ tests 386
ℹ pass 382
ℹ fail 4
```

```
✖ manifestsFrom : la place d'une ligne écartée pour cause de frais retourne au remplissage
    actual: [ [ 'Scrap', 95 ] ]              expected: [ [ 'Scrap', 96 ] ]
✖ manifestsFrom : une ligne rentable SEULE mais qui prend sa place aux autres reste au sol
    actual: [ [ 'Methane', 1 ], [ 'Nitrogen', 95 ] ]   expected: [ [ 'Nitrogen', 96 ] ]
✖ manifestsFrom : une ligne déficitaire à 126 SCU redevient éligible à 128, et le manifeste la reprend
    actual: [ [ 'Fluorine', 2 ] ]            expected: [ [ 'Human Food Bars', 128 ] ]
✖ manifestsFrom : frais actifs, aucun manifeste réel ne rapporte moins que sa meilleure commodité seule
    actual: [ 'Megumi -> Levski : 66480 < 66576', 'Shubin SAL-2 -> GrimHEX : 32300 < 32370',
              'Baijini Point -> Gaslight : 54827 < 55104', ... 20 arcs ...
              'MIC-L5 -> Ruin Station : 8365 < 8640', 'MIC-L5 -> TDD Orison : 8365 < 8640' ]
    expected: []
```

Les **20 arcs** listés sont exactement ceux qu'annonce l'issue #41. Les deux autres tests ajoutés
passent déjà sur `main`, et c'est voulu : ce sont des garde-fous (« sans frais, rien ne bouge » et
« la boucle relancée termine »), pas des reproductions du défaut.

### Le vert

`node --test` sur la branche :

```
ℹ tests 386
ℹ pass 386
ℹ fail 0
ℹ duration_ms 205.888
```

`npx playwright test` : **116 passed, 2 skipped** (118 au total, 1,0 min).

⚠️ Servi sur un **port dédié 4400**, pas le 4173 par défaut : quatre autres copies de travail
écoutaient déjà 4199, 4211, 4291 et 4293 pendant ce run (c'est l'issue #70). Le port a été contrôlé
avant la suite — `curl http://127.0.0.1:4400/logic.mjs` renvoie bien `const remplir = (liste) =>`
et `laissees.add(sacrifiee)`, donc la suite a mesuré le code de CETTE branche.

### Les mesures du message de commit

Reproduites, sur `data/market.json` du dépôt :

| Mesure | Avant (`main`) | Après | Reproduit ? |
|---|---|---|---|
| Soute 96, k = 1 : arcs sous le mono-commodité | **20** sur 4 219 | **0** | ✅ exact |
| Écart maximal sur ces 20 arcs | −3,2 % (MIC-L5 → Ruin, 8 365 vs 8 640) | — | ✅ exact |
| Balayage 8 soutes × 5 tarifs (k = 1…5), 163 117 arcs | **1 080** | **0** | ✅ direction |
| Sous budget bornant, 120 combinaisons, ~382 000 arcs | **5 205** | **21** | ✅ direction |
| Sans frais : arcs / SCU / profit | 4 284 / 344 101 / 392 892 971 | identique | ✅ figé par un test |

**Deux bases de mesure, et une seule est vérifiable — à trancher.** L'issue #41 annonce « 20 arcs
sur 4 219 » : c'est **une** configuration (soute 96 SCU, k = 1). Le message de commit et le README
annoncent « 771 sur 167 434 » et « 16 sur 499 772 » : ce sont des **balayages** de 40 combinaisons
soute × tarif. Les deux ne se contredisent donc pas — elles ne comptent pas la même chose.

Mais la seconde n'est **pas reproductible** : ni le commit ni le README ne disent quelles soutes ni
quels tarifs composent les 40 combinaisons, et j'ai vérifié qu'on ne peut pas la retrouver par
recoupement — en balayant une table (soute, tarif) et en cherchant les grilles dont le total fait
exactement 167 434, **plusieurs grilles sans rapport y arrivent** (`[8, 16, 192, 256, 384, 512, 696,
1152] × [0,5 ; 1 ; 1,4 ; 2 ; 3]`, `[8, 32, 48, 64, 96, 256, 384, 2016] × …`, et d'autres). Un chiffre
que n'importe quelle grille peut produire ne prouve rien.

**La base à retenir est donc celle de l'issue #41 : 20 arcs sur 4 219, soute 96, k = 1** — c'est la
seule qu'un test du dépôt exécute et fait échouer avant le correctif. Les balayages restent utiles
comme ordre de grandeur (1 080 → 0 et 5 205 → 21 sur mes propres grilles, mêmes arcs de part et
d'autre), pas comme chiffres à citer.

## Ce qui n'est pas couvert

- **Le README garde le chiffre non reproductible.** La ligne ajoutée annonce « vérifié sur les
  167 434 arcs des 40 combinaisons soute × tarif » et « 16 arcs sur 499 772 » sans dire lesquelles.
  Je n'ai pas retouché le commit (mission de vérification, pas de reprise) : **à corriger avant
  merge** pour citer la base que le test tient — 4 219 arcs, soute 96, k = 1.
- **`fillCargo` n'est toujours pas optimal.** Sous budget bornant, c'est un sac à dos à deux
  contraintes et le remplissage reste glouton : un résidu d'arcs sous le mono-commodité subsiste
  (21 sur ~382 000 dans mon balayage, écart maximal 4,6 %). Le correctif ne prétend pas le supprimer.
- **Coût en temps non mesuré.** La reprise du remplissage rebâtit le chargement à chaque retrait
  (boucle bornée par le nombre de candidates) ; aucun chiffre de performance n'accompagne la PR.
  `node --test` reste à ~206 ms, ce qui suggère que ça ne se voit pas, mais ce n'est pas un banc.
- La branche ne touche que la branche **à frais** : interrupteur éteint, un test fige le total des
  4 284 arcs au SCU près.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)
