### PR TITLE
fix(soute): vider la soute ne recharge plus la jambe, et annuler ne rend que ce qu'on a pris

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,8 +268,16 @@ Trois règles à connaître :
 **correction locale** comme une autre, ancrée à la date UEX du point, donc périmée dès qu'UEX
 republie. Sans elle, la station continuait d'annoncer un stock déjà emporté et le manifeste suivant
 le reproposait. Si tu as pris **plus** que le stock publié, le rayon tombe à **0** et jamais en
-négatif : le relevé était faux, c'est tout ce qu'on en sait. Annuler le chargement rend exactement
-ce qui avait été retiré — le lot porte la valeur d'avant.
+négatif : le relevé était faux, c'est tout ce qu'on en sait. Annuler un chargement rend au rayon
+**ce que cette jambe-là y a pris**, et rien de plus : sur un aller-retour où deux jambes achètent au
+même point, se raviser sur la première laisse la seconde déduite. Lui rendre le stock d'avant
+reproposerait une cargaison qui est toujours à bord.
+
+**Une jambe chargée le reste tant que tu ne l'annules pas.** Vendre, déposer, vider la soute par son
+✕ : tous ces gestes sortent le fret, aucun ne le remet en rayon. Le bouton reste donc `⬢ à bord` et
+la déduction reste posée — `⬢ à bord` est le seul chemin de retour, et il rend toujours exactement ce
+qui avait été pris. Sans ça, une soute vidée autrement qu'en annulant rendait la jambe rechargeable,
+et le rayon était déduit une seconde fois depuis un chiffre déjà amputé.
 
 **Vendre, déposer, repartir.** Un bouton par commodité ouvre un champ prérempli au total :
 valider vend tout, réduire vend partiellement. Ce que le comptoir n'a pas pris est marqué

--- a/app.js
+++ b/app.js
@@ -19,6 +19,7 @@ import {
   journeyConnects, addToJourney, setJourneyPosition, currentLeg, journeyMargin,
   removeJourneyStop as removeStopPure,
   reindexerRangsJambe, detacherLotsDeJambe,
+  soldeDuPoint, poserChargement, retirerChargement, migrerChargements,
   encodeJourney, decodeJourney,
 } from "./logic.mjs";
 
@@ -1225,6 +1226,23 @@ function loadSoute() {
 }
 function saveSoute() { try { localStorage.setItem(HOLD_KEY, JSON.stringify(SOUTE)); } catch {} }
 
+// Le REGISTRE des chargements (logic.mjs) : quelle jambe est engagée, et ce qu'elle a pris à quel
+// rayon. Store à part de la soute, et c'est tout le point : la soute se vide par son ✕, par une
+// vente, par la vente implicite du départ — aucun de ces chemins ne rend rien à la station, donc
+// aucun ne décharge la jambe. Le fret peut partir, ce qu'on doit au rayon reste dû.
+const CHARGES_KEY = "best-hauling-jambes-chargees";
+let CHARGEMENTS = {};
+// À appeler APRÈS loadSoute : la migration lit les lots pour reconstruire le registre d'une soute
+// écrite avant lui (l'état vivait alors dans la présence des lots, et le stock d'avant dans `avant`).
+function loadChargements() {
+  try { CHARGEMENTS = JSON.parse(localStorage.getItem(CHARGES_KEY)) || {}; } catch { CHARGEMENTS = {}; }
+  if (!CHARGEMENTS || typeof CHARGEMENTS !== "object" || Array.isArray(CHARGEMENTS)) CHARGEMENTS = {};
+  const m = migrerChargements(CHARGEMENTS, SOUTE);
+  CHARGEMENTS = m.chargements;
+  if (m.change) { SOUTE = m.lots; saveSoute(); saveChargements(); }
+}
+function saveChargements() { try { localStorage.setItem(CHARGES_KEY, JSON.stringify(CHARGEMENTS)); } catch {} }
+
 // Charge le manifeste d'une jambe dans la soute, au prix que l'app venait d'afficher. Les lots
 // portent la clé de la jambe : c'est ce qui permet d'annuler un chargement sans deviner.
 // Le point d'achat d'une commodité à un terminal, avec son stock EFFECTIF (corrections comprises)
@@ -1239,18 +1257,32 @@ function pointAchat(nomCommodite, nomTerminal) {
   return { commodite: c.name, stock: e.vol, base: b[3] };
 }
 
+// Réécrit la correction de stock d'un point d'achat DEPUIS LE REGISTRE : sa référence, moins tout ce
+// que les jambes encore chargées y prennent. Chargement et annulation posent la même question, et
+// une seule réponse les empêche de diverger — c'est ce qui manquait quand deux jambes achetaient au
+// même point. `prise.ref` sert de repli quand plus aucune jambe ne tient le rayon : on lui rend
+// alors exactement ce qu'il annonçait avant qu'on y touche.
+// Renvoie le solde appliqué, ou null si le point a disparu d'UEX (rien à corriger).
+function ecrireStockDuPoint(prise) {
+  const p = pointAchat(prise.name, prise.terminal);
+  if (!p) return null;
+  const s = soldeDuPoint(CHARGEMENTS, prise.name, prise.terminal);
+  const ref = s.ref != null ? s.ref : prise.ref;
+  setOverride(prise.name, prise.terminal, "buy", "vol", stockApres(ref, s.pris), p.base);
+  return { ref, pris: s.pris };
+}
+
 function chargerJambe(i) {
   const leg = JOURNEY && JOURNEY.legs[i];
   if (!leg || !MARKET) return;
   const k = legKey(leg, i);
-  if (SOUTE.some((l) => l.leg === k)) {
-    // Annulation : on rend à la station ce qu'on lui avait retiré. La valeur d'AVANT est portée par
-    // le lot, donc on restaure exactement — et non « stock + units », qui gonflerait un rayon qu'on
-    // avait vidé au-delà de ce qu'il annonçait.
-    for (const l of SOUTE.filter((x) => x.leg === k && x.avant != null)) {
-      const p = pointAchat(l.name, l.from);
-      if (p) setOverride(l.name, l.from, "buy", "vol", l.avant, p.base);
-    }
+  if (CHARGEMENTS[k]) {
+    // Annulation : on rend au rayon ce que CETTE jambe y a pris, et rien de plus. Les lots peuvent
+    // avoir quitté la soute entre-temps (vendus, déposés, débarqués) : c'est le registre, pas eux,
+    // qui sait ce qu'on doit.
+    const prises = CHARGEMENTS[k];
+    CHARGEMENTS = retirerChargement(CHARGEMENTS, k);
+    for (const pr of prises) ecrireStockDuPoint(pr);
     SOUTE = SOUTE.filter((l) => l.leg !== k);
     updateOvBadge();
   } else {
@@ -1259,27 +1291,36 @@ function chargerJambe(i) {
     const lots = loadHold([], lignes, leg.from, nowSec()).map((l) => ({ ...l, leg: k }));
     // Charger, c'est vider le rayon d'autant. On fige d'abord les jambes qui achetaient ce point
     // (même règle qu'une correction de volume saisie à la main), puis on écrit la déduction.
-    const vides = [];
+    const prises = [];
     for (const l of lots) {
       const p = pointAchat(l.name, l.from);
-      if (!p || p.stock == null) continue;
-      l.avant = p.stock;
+      if (!p || p.stock == null) continue; // stock inconnu : rien à déduire, la jambe reste chargée
+      // La référence est celle qu'une AUTRE jambe a déjà retenue pour ce rayon. Relire le stock
+      // effectif ici, ce serait relire notre propre déduction et la compter une seconde fois.
+      const s = soldeDuPoint(CHARGEMENTS, l.name, l.from);
+      prises.push({ name: l.name, terminal: l.from, ref: s.ref != null ? s.ref : p.stock, units: l.units });
       pinLegsForVolume(l.name, l.from, "buy");
-      const reste = stockApres(p.stock, l.units);
-      setOverride(l.name, l.from, "buy", "vol", reste, p.base);
-      if (p.stock < l.units) vides.push(l.name); // le relevé annonçait moins que ce qu'on a pris
+    }
+    CHARGEMENTS = poserChargement(CHARGEMENTS, k, prises);
+    const vides = [];
+    for (const pr of prises) {
+      const s = ecrireStockDuPoint(pr);
+      if (s && s.pris > s.ref) vides.push(pr.name); // la station en annonçait moins qu'on n'en a pris
     }
     SOUTE = SOUTE.concat(lots);
     updateOvBadge();
     if (vides.length) {
-      showToast(`✓ Chargé — stock mis à 0 pour ${vides.join(", ")} : le relevé UEX en annonçait moins que ce que tu as pris`);
+      showToast(`✓ Chargé — stock mis à 0 pour ${vides.join(", ")} : la station en annonçait moins que ce que tu as pris`);
     }
   }
-  saveSoute();
+  saveSoute(); saveChargements();
   renderJourney();
   refresh();
 }
-const jambeChargee = (leg, i) => SOUTE.some((l) => l.leg === legKey(leg, i));
+// L'état « chargée » est PORTÉ par le registre, jamais déduit des lots : la soute se vide par
+// d'autres chemins que « annuler », et aucun ne défait le chargement — le fret est parti, il n'est
+// pas revenu au rayon.
+const jambeChargee = (leg, i) => !!CHARGEMENTS[legKey(leg, i)];
 
 // « Où suis-je ? » — l'étape courante du voyage, ou à défaut le terminal de départ d'« En route ».
 // C'est ce terminal qui fixe le prix d'une vente et qui porte le marqueur « refusé ici ».
@@ -1426,6 +1467,9 @@ function ecoulerHTML() {
   return `<div class="hold-ecouler"><div class="ec-head">Où écouler — classé par ce que ça rapporte, prix d'achat déduit</div>${lignes}</div>`;
 }
 
+// Débarquer le fret n'est pas le remettre en rayon : le registre des chargements n'est pas touché,
+// donc les jambes restent chargées (🔒 « ⬢ à bord ») et leur déduction reste posée. C'est ce qui
+// garde le chemin « annuler » atteignable — le seul qui rende vraiment son stock à la station.
 function viderSoute() { SOUTE = []; saveSoute(); renderSoute(); refresh(); }
 function retirerLot(i) { SOUTE = SOUTE.filter((_, j) => j !== i); saveSoute(); renderSoute(); refresh(); }
 
@@ -1626,6 +1670,10 @@ function clearJourney() {
   // ultérieur dont la jambe 0 relie les deux mêmes terminaux s'affichait « ⬢ à bord », et le clic
   // déchargeait les lots de l'ancien voyage en restaurant leurs stocks.
   SOUTE = detacherLotsDeJambe(SOUTE); saveSoute();
+  // Quatrième porteur du rang : le registre des chargements. Plus aucune jambe n'existe, donc plus
+  // rien à décharger — les déductions déjà posées sur les rayons, elles, restent : le fret est bien
+  // parti avec. Comme pour les lots qu'on vient de délier, elles ne sont simplement plus annulables.
+  CHARGEMENTS = {}; saveChargements();
   journeyExpandedLeg = -1;
   renderJourney();
   saveState();
@@ -1926,14 +1974,15 @@ function beginJourney(label) {
 }
 
 // Réindexe tout ce qui est indexé par le RANG des jambes après une modification du parcours. Les
-// TROIS porteurs — manifeste édité, 🔒, étiquette `leg` des lots de la soute — passent par le même
-// appel pur : les décaler séparément les ferait diverger, et c'est d'en avoir oublié un que venait
-// le double chargement (la jambe renumérotée se croyait vide alors que son fret était à bord).
+// QUATRE porteurs — manifeste édité, 🔒, étiquette `leg` des lots de la soute, entrée du registre
+// des chargements — passent par le même appel pur : les décaler séparément les ferait diverger, et
+// c'est d'en avoir oublié un que venait le double chargement (la jambe renumérotée se croyait vide
+// alors que son fret était à bord).
 function reindexerApresRetrait(retrait) {
-  const r = reindexerRangsJambe({ edits: JOURNEY_EDITS, pins: JOURNEY_PINS, lots: SOUTE }, retrait);
-  JOURNEY_EDITS = r.edits; JOURNEY_PINS = r.pins; SOUTE = r.lots;
+  const r = reindexerRangsJambe({ edits: JOURNEY_EDITS, pins: JOURNEY_PINS, lots: SOUTE, chargements: CHARGEMENTS }, retrait);
+  JOURNEY_EDITS = r.edits; JOURNEY_PINS = r.pins; SOUTE = r.lots; CHARGEMENTS = r.chargements;
   if (journeyExpandedLeg >= retrait.removedFrom) journeyExpandedLeg = -1; // le panneau déplié n'existe plus
-  saveJourneyEdits(); saveJourneyPins(); saveSoute();
+  saveJourneyEdits(); saveJourneyPins(); saveSoute(); saveChargements();
 }
 
 // Retire un arrêt (index de station) et RECONNECTE les voisins (recalcule la jambe A->C).
@@ -3240,6 +3289,7 @@ async function init() {
   loadJourneyEdits();
   loadJourneyPins();
   loadSoute();
+  loadChargements(); // après loadSoute : la migration reconstruit le registre depuis les lots
   loadDepots();
   updateOvBadge();
   syncToggles();

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -455,6 +455,15 @@ test("Multi commodité : « avec les simples » remet les trajets à une commodi
 // Les lots de la soute, tels que persistés — la source de vérité, plus lisible qu'un texte de panneau.
 const lots = (page) => page.evaluate(() => JSON.parse(localStorage.getItem("best-hauling-hold") || "[]"));
 const holdScuDe = (ls) => ls.reduce((s, l) => s + l.units, 0);
+// Le stock EFFECTIF d'un point d'achat, lu là où l'app l'affiche : la vue Corrections. C'est le seul
+// endroit qui montre ce que la station annonce APRÈS déduction — donc le seul juge des chargements.
+async function stockAchat(page, station, nom) {
+  await page.click("#viewCorrections");
+  await page.fill("#station", station);
+  const c = page.locator(`#correctionsStation .editv[data-c="${nom}"][data-s="buy"][data-f="vol"]`).first();
+  await expect(c).toBeVisible({ timeout: 8000 });
+  return Number(await c.getAttribute("data-v"));
+}
 
 async function jambeChargeable(page) {
   await manifesteDepuis(page, "Megumi — Pyro");
@@ -621,6 +630,128 @@ test("Soute : retirer un arrêt AVANT une jambe chargée ne la rend pas recharge
   // Et re-cliquer ANNULE le chargement, au lieu d'en ajouter un second exemplaire.
   await page.locator("#journeyCard .jleg-load").first().click();
   expect(holdScuDe(await lots(page))).toBe(0);
+});
+
+test("Soute : vider la soute ne rend pas la jambe rechargeable, le rayon n'est pas déduit deux fois (#21)", async ({ page }) => {
+  // « Cette jambe est chargée » se DÉDUISAIT de la présence de ses lots. Le ✕ de la soute — comme
+  // une vente — les faisait disparaître sans rien rendre à la station : le bouton repassait à
+  // « ✓ chargé », le clic suivant redéduisait le rayon DEPUIS le stock déjà amputé (100 → 40 → 0),
+  // et la valeur d'origine était perdue pour de bon.
+  await manifesteDepuis(page, "Megumi — Pyro");
+  const nom = await page.locator("#manifest .mline-del").first().getAttribute("data-name");
+  const pris = Number(await page.locator("#manifest .mline", { hasText: nom }).first().locator(".mqty-input").inputValue());
+  expect(pris).toBeGreaterThan(0);
+  const avant = await stockAchat(page, "Megumi — Pyro", nom);
+
+  await manifesteDepuis(page, "Megumi — Pyro");
+  await page.click("#manifestToJourney");
+  await page.locator("#journeyCard .jleg-load").first().click();
+  await expect(page.locator("#holdCard")).toBeVisible();
+  expect(await stockAchat(page, "Megumi — Pyro", nom)).toBe(Math.max(0, avant - pris));
+
+  // Le ✕ débarque le fret ; il ne DÉCHARGE pas la jambe — rien n'est revenu au rayon.
+  await page.click("#viewEnroute");
+  await page.locator("#holdClear").click();
+  await expect(page.locator("#holdCard")).toBeHidden();
+  await expect(page.locator("#journeyCard .jleg-load").first()).toHaveText(/à bord/i);
+  expect(await stockAchat(page, "Megumi — Pyro", nom)).toBe(Math.max(0, avant - pris));
+
+  // Le clic suivant ANNULE, il ne recharge pas : le rayon retrouve exactement sa valeur d'origine.
+  await page.click("#viewEnroute");
+  await page.locator("#journeyCard .jleg-load").first().click();
+  await expect(page.locator("#journeyCard .jleg-load").first()).toHaveText(/chargé/i);
+  expect(await stockAchat(page, "Megumi — Pyro", nom)).toBe(avant);
+});
+
+test("Soute : annuler une jambe ne rend au rayon que CE QU'ELLE y a pris (#22)", async ({ page }) => {
+  // Parcours A→B→A→C : les jambes 0 et 2 achètent la MÊME commodité au MÊME point. Annuler la
+  // première réécrivait un instantané ABSOLU du stock d'avant, effaçant la déduction de la seconde
+  // — la station reproposait aussitôt un stock fantôme, toujours à bord.
+  const plan = await page.evaluate(async () => {
+    const m = await (await fetch("data/market.json")).json();
+    const a = m.terminals.findIndex((t) => t.name === "Megumi");
+    if (a < 0) return null;
+    for (const c of m.commodities) {
+      const b = c.buys.find((x) => x[0] === a);
+      if (!b || !(b[2] >= 30)) continue;                                  // du stock, et de quoi le partager
+      const u = Math.floor(b[2] / 3);
+      // Une capacité de vente trop petite plafonnerait la ligne du manifeste, pas la prise.
+      const dest = c.sells.filter((x) => x[0] !== a && (x[2] == null || x[2] >= u)).slice(0, 2);
+      if (dest.length < 2) continue;
+      const nomSys = (i) => [m.terminals[i].name, m.terminals[i].system];
+      return { nom: c.name, units: u, a: nomSys(a), b: nomSys(dest[0][0]), d: nomSys(dest[1][0]) };
+    }
+    return null;
+  });
+  test.skip(!plan, "aucune commodité de Megumi n'a du stock à partager entre deux débouchés");
+
+  const [A, As] = plan.a, [B, Bs] = plan.b, [D, Ds] = plan.d;
+  // Le parcours passe par le lien partageable ; les manifestes des jambes 0 et 2 sont IMPOSÉS, sinon
+  // rien ne garantit qu'elles choisiraient la même commodité au même point.
+  await page.evaluate(({ A, B, D, nom, units }) => {
+    localStorage.setItem("best-hauling-journey-edits-v2", JSON.stringify({
+      [`0|${A}|${B}`]: [{ name: nom, units }],
+      [`1|${B}|${A}`]: [],
+      [`2|${A}|${D}`]: [{ name: nom, units }],
+    }));
+  }, { A, B, D, nom: plan.nom, units: plan.units });
+
+  const j = JSON.stringify({ c: 0, l: [[A, As, B, Bs], [B, Bs, A, As], [A, As, D, Ds]].map(([f, fs, t, ts]) => [f, fs, t, ts, plan.nom, 0, 0, 0]) });
+  await page.goto("/index.html#" + new URLSearchParams({ v: "enroute", cargo: "5000", useCargo: "1", j }).toString());
+  await page.reload(); // un `goto` qui ne change que le fragment ne relit pas l'état au démarrage
+  await expect(page.locator("#journeyCard .jstep")).toHaveCount(4, { timeout: 8000 });
+  await expect(page.locator("#journeyCard .jleg-load")).toHaveCount(2); // la jambe 1 ne charge rien
+
+  const station = `${A} — ${As}`;
+  const ref = await stockAchat(page, station, plan.nom);
+  expect(ref).toBeGreaterThanOrEqual(plan.units * 2);
+
+  await page.click("#viewEnroute");
+  await page.locator("#journeyCard .jleg-load").nth(0).click(); // jambe 0 : A→B
+  expect(await stockAchat(page, station, plan.nom)).toBe(ref - plan.units);
+  await page.click("#viewEnroute");
+  await page.locator("#journeyCard .jleg-load").nth(1).click(); // jambe 2 : A→C, même rayon
+  expect(await stockAchat(page, station, plan.nom)).toBe(ref - plan.units * 2);
+
+  // On se ravise sur la jambe 0 : le rayon ne récupère QUE ses SCU. Ceux de la jambe 2 sont
+  // toujours à bord, prise chez lui — les lui rendre inventerait du stock.
+  await page.click("#viewEnroute");
+  await page.locator("#journeyCard .jleg-load").nth(0).click();
+  expect(await stockAchat(page, station, plan.nom)).toBe(ref - plan.units);
+});
+
+test("Soute : une soute écrite AVANT le registre des chargements reste chargée et annulable", async ({ page }) => {
+  // Garde-fou de migration : chez qui a déjà du fret à bord, l'état « chargée » vit sur les lots
+  // (`leg`) et le stock d'avant dans `avant`. Sans reprise, la jambe repasserait à « ✓ chargé » au
+  // premier rechargement — le bug #21 servi à froid, sans que l'utilisateur ait rien touché.
+  await manifesteDepuis(page, "Megumi — Pyro");
+  const nom = await page.locator("#manifest .mline-del").first().getAttribute("data-name");
+  const avant = await stockAchat(page, "Megumi — Pyro", nom);
+  await manifesteDepuis(page, "Megumi — Pyro");
+  await page.click("#manifestToJourney");
+  await page.locator("#journeyCard .jleg-load").first().click();
+  await expect(page.locator("#holdCard")).toBeVisible();
+  const apresCharge = await stockAchat(page, "Megumi — Pyro", nom);
+  expect(apresCharge).toBeLessThan(avant);
+  await page.click("#viewEnroute");
+
+  // On rétrograde le stockage au format d'avant : le registre disparaît, `avant` revient sur les lots.
+  await page.evaluate(() => {
+    const reg = JSON.parse(localStorage.getItem("best-hauling-jambes-chargees") || "{}");
+    const refs = new Map();
+    for (const prises of Object.values(reg)) for (const p of prises) refs.set(`${p.name}|${p.terminal}`, p.ref);
+    const vieux = JSON.parse(localStorage.getItem("best-hauling-hold") || "[]")
+      .map((l) => (refs.has(`${l.name}|${l.from}`) ? { ...l, avant: refs.get(`${l.name}|${l.from}`) } : l));
+    localStorage.setItem("best-hauling-hold", JSON.stringify(vieux));
+    localStorage.removeItem("best-hauling-jambes-chargees");
+  });
+  await page.reload();
+  await expect(page.locator("#journeyCard .jleg-load").first()).toHaveText(/à bord/i, { timeout: 8000 });
+  expect(await stockAchat(page, "Megumi — Pyro", nom)).toBe(apresCharge); // la correction n'a pas bougé
+
+  await page.click("#viewEnroute");
+  await page.locator("#journeyCard .jleg-load").first().click();
+  expect(await stockAchat(page, "Megumi — Pyro", nom)).toBe(avant); // annuler rend toujours exactement
 });
 
 test("Soute : recharger la même commodité crée un SECOND lot, sans fondre les prix", async ({ page }) => {

--- a/logic.mjs
+++ b/logic.mjs
@@ -1358,11 +1358,12 @@ export function removeJourneyStop(journey, stopIndex, bridge) {
   };
 }
 
-// ---------- Le RANG d'une jambe, et ses TROIS porteurs ----------
-// Trois choses sont indexées par le rang d'une jambe : le manifeste ÉDITÉ, le 🔒 qui dit pourquoi
-// il l'est, et l'étiquette `leg` que le chargement pose sur les lots de la soute. Retirer un arrêt
-// renumérote les jambes : n'en décaler que deux les fait diverger. C'est le troisième, oublié, qui
-// rendait « ✓ chargé » une jambe dont le fret était déjà à bord — et un second clic la doublait.
+// ---------- Le RANG d'une jambe, et ses QUATRE porteurs ----------
+// Quatre choses sont indexées par le rang d'une jambe : le manifeste ÉDITÉ, le 🔒 qui dit pourquoi
+// il l'est, l'étiquette `leg` que le chargement pose sur les lots de la soute, et l'entrée du
+// REGISTRE des chargements (plus bas). Retirer un arrêt renumérote les jambes : n'en décaler que
+// trois les fait diverger. C'est d'en avoir oublié un que venait le double chargement — la jambe
+// renumérotée se croyait vide alors que son fret était à bord.
 
 // Nouvelle clé d'une jambe après un retrait d'arrêt : la même, renumérotée — ou `null` si la jambe
 // a disparu du parcours. Une clé illisible ressort INTACTE : on ne renumérote pas ce qu'on n'a pas
@@ -1379,13 +1380,16 @@ export function cleApresRetrait(cle, { removedFrom, removedCount, insertedCount 
 
 const sansEtiquette = (lot) => { const { leg, ...reste } = lot; return reste; };
 
-// Réindexe LES TROIS PORTEURS d'un seul appel — c'est tout l'intérêt : ils ne peuvent plus
+// Réindexe LES QUATRE PORTEURS d'un seul appel — c'est tout l'intérêt : ils ne peuvent plus
 // diverger, et un appelant ne peut plus en oublier un. Les STORES perdent l'entrée d'une jambe
 // disparue (le plan qu'elle portait n'existe plus) ; les LOTS, jamais : le fret est réellement à
 // bord. On leur retire seulement leur étiquette — ils restent en soute, visibles, vendables, mais
 // rattachés à aucune jambe. Les recoller au pont A→C serait pire : sa cargaison est RECALCULÉE, le
 // voyage prétendrait l'avoir chargée, et son vrai chargement deviendrait impossible.
-export function reindexerRangsJambe({ edits = {}, pins = {}, lots = [] }, retrait) {
+// Le registre suit la même règle que les stores : la déduction d'une jambe disparue reste posée sur
+// le rayon — le fret est parti avec, il n'est pas revenu — mais plus rien ne peut l'annuler, comme
+// pour les lots qu'on vient de délier.
+export function reindexerRangsJambe({ edits = {}, pins = {}, lots = [], chargements = {} }, retrait) {
   const decale = (store) => {
     const suivant = {};
     for (const [k, v] of Object.entries(store)) {
@@ -1397,6 +1401,7 @@ export function reindexerRangsJambe({ edits = {}, pins = {}, lots = [] }, retrai
   return {
     edits: decale(edits),
     pins: decale(pins),
+    chargements: decale(chargements),
     lots: lots.map((l) => {
       if (l.leg == null) return l;
       const n = cleApresRetrait(l.leg, retrait);
@@ -1411,6 +1416,83 @@ export function reindexerRangsJambe({ edits = {}, pins = {}, lots = [] }, retrai
 // corrigée pour les manifestes édités, à laquelle les étiquettes avaient échappé.
 export function detacherLotsDeJambe(lots) {
   return lots.map((l) => (l.leg == null ? l : sansEtiquette(l)));
+}
+
+// ---------- Le REGISTRE des chargements : quelle jambe a pris quoi, et où ----------
+// « Cette jambe est chargée » se DÉDUISAIT de la présence de ses lots en soute. Or la soute se vide
+// par bien d'autres chemins que « annuler » — son ✕, une vente, la vente implicite du départ — et
+// aucun ne rend quoi que ce soit au rayon. La jambe repassait donc à « ✓ chargé », le clic suivant
+// redéduisait, et la valeur d'origine du rayon partait avec les lots qui la portaient (100 → 40 → 0).
+// Le registre porte l'état EXPLICITEMENT, et il survit au fret : le fret peut quitter la soute, ce
+// qu'on doit au rayon reste dû.
+//
+//   { "<rang>|<from>|<to>": [ { name, terminal, ref, units }, … ] }
+//
+// Une entrée = une jambe chargée, même avec zéro prise (rayon au stock inconnu : rien à déduire,
+// mais la jambe est bel et bien engagée).
+//
+// `ref` est le stock du rayon AVANT toute déduction de jambe. C'est la TROISIÈME forme, la seule qui
+// tienne avec DEUX chargements au même point :
+//   - l'instantané absolu (« annuler rend les 100 d'avant ») efface la prise de l'autre jambe, et la
+//     station reproprose un stock fantôme qui est toujours à bord ;
+//   - le relatif (« stock effectif + units ») repart d'un chiffre que stockApres a pu écrêter à 0,
+//     et rend alors au rayon plus qu'il n'a jamais annoncé ;
+//   - la référence MOINS la somme des prises encore en cours tient dans les deux cas.
+
+// Ce qu'un point d'achat doit annoncer : sa `ref` (null si plus aucune jambe n'y prend rien) et le
+// total `pris` par les jambes encore chargées. `sauf` exclut une jambe — celle qu'on annule.
+// La `ref` retenue est la PLUS GRANDE : deux prises au même point la partagent par construction,
+// sauf après migration d'une soute ancienne où chaque lot portait le stock déjà amputé qu'il avait
+// lu. La plus grande est alors la plus ancienne, donc ce que la station annonçait vraiment.
+export function soldeDuPoint(chargements, name, terminal, sauf = null) {
+  let ref = null, pris = 0;
+  for (const [cle, prises] of Object.entries(chargements || {})) {
+    if (cle === sauf || !Array.isArray(prises)) continue;
+    for (const p of prises) {
+      if (p.name !== name || p.terminal !== terminal || p.ref == null) continue;
+      if (ref == null || p.ref > ref) ref = p.ref;
+      pris += Math.max(0, Math.floor(p.units || 0));
+    }
+  }
+  return { ref, pris };
+}
+
+export function poserChargement(chargements, cle, prises) {
+  return {
+    ...chargements,
+    [cle]: (prises || []).map((p) => ({ name: p.name, terminal: p.terminal, ref: p.ref, units: p.units })),
+  };
+}
+
+export function retirerChargement(chargements, cle) {
+  const { [cle]: _parti, ...reste } = chargements || {};
+  return reste;
+}
+
+// Une soute écrite AVANT le registre : l'état vivait dans la présence des lots, et le stock d'avant
+// dans leur champ `avant`. On reconstruit le registre à partir d'eux — sans quoi une jambe déjà
+// chargée repasserait à « ✓ chargé » au premier rechargement de page, chez un utilisateur qui n'a
+// rien touché. Aucune correction n'est écrite : on ne fait que retrouver qui a pris quoi.
+// `avant` est ensuite retiré des lots — le registre le porte, et deux sources divergeraient.
+// Renvoie { chargements, lots, change } ; `change` faux = rien à persister.
+export function migrerChargements(chargements, lots) {
+  const connus = chargements || {};
+  const source = lots || [];
+  const ajout = {};
+  let vieux = false;
+  for (const l of source) {
+    if ("avant" in l) vieux = true;
+    if (l.leg == null || connus[l.leg]) continue; // le registre existant fait foi sur ses jambes
+    const prises = ajout[l.leg] || (ajout[l.leg] = []);
+    if (l.avant == null) continue;                // rien de déductible : la jambe est chargée, sans prise
+    prises.push({ name: l.name, terminal: l.from, ref: l.avant, units: l.units || 0 });
+  }
+  const suivant = Object.keys(ajout).length ? { ...connus, ...ajout } : connus;
+  return {
+    chargements: suivant,
+    lots: vieux ? source.map((l) => { const { avant: _a, ...reste } = l; return reste; }) : source,
+    change: vieux || suivant !== connus,
+  };
 }
 
 // Déplace la position courante (bornée à 0..legs.length).

--- a/logic.test.mjs
+++ b/logic.test.mjs
@@ -23,6 +23,7 @@ import {
   journeyConnects, addToJourney, setJourneyPosition, currentLeg, journeyMargin,
   encodeJourney, decodeJourney, removeJourneyStop, freeManifestLine, hydrateManifestLine,
   cleApresRetrait, reindexerRangsJambe, detacherLotsDeJambe,
+  soldeDuPoint, poserChargement, retirerChargement, migrerChargements,
   stationTree, groupOverridesByTerminal,
 } from "./logic.mjs";
 
@@ -2781,6 +2782,88 @@ test("detacherLotsDeJambe : effacer le voyage délie les lots sans les débarque
   assert.equal(r.length, 2);
   assert.equal("leg" in r[0], false);
   assert.equal(r[0].units, 100); // le fret payé survit à l'effacement du parcours (ADR-002)
+});
+
+// ---------- Le registre des chargements : quelle jambe a pris quoi, et où (#21, #22) ----------
+const prise = (nom, terminal, ref, units) => ({ name: nom, terminal, ref, units });
+
+test("soldeDuPoint : deux jambes au même point se partagent une seule référence", () => {
+  // A→B→A→C : les jambes 0 et 2 achètent toutes deux du Titanium à A, qui en annonçait 100.
+  let c = poserChargement({}, "0|A|B", [prise("Titanium", "A", 100, 60)]);
+  c = poserChargement(c, "2|A|C", [prise("Titanium", "A", 100, 40)]);
+  const plein = soldeDuPoint(c, "Titanium", "A");
+  assert.deepEqual(plein, { ref: 100, pris: 100 });
+  assert.equal(stockApres(plein.ref, plein.pris), 0);
+
+  // Annuler la PREMIÈRE ne rend que SES 60 : la jambe 2 tient toujours ses 40.
+  const s = soldeDuPoint(retirerChargement(c, "0|A|B"), "Titanium", "A");
+  assert.deepEqual(s, { ref: 100, pris: 40 });
+  assert.equal(stockApres(s.ref, s.pris), 60); // et surtout pas 100 : l'instantané absolu effaçait la jambe 2
+});
+
+test("soldeDuPoint : la référence survit à l'écrêtage à 0, que « stock + units » ne sait pas défaire", () => {
+  // La jambe 0 prend PLUS que le rayon n'annonçait : stockApres écrête à 0, et le stock effectif
+  // ne porte plus l'information « il y en avait 100 ».
+  let c = poserChargement({}, "0|A|B", [prise("Gold", "A", 100, 150)]);
+  c = poserChargement(c, "1|A|C", [prise("Gold", "A", 100, 20)]);
+  const plein = soldeDuPoint(c, "Gold", "A");
+  assert.equal(stockApres(plein.ref, plein.pris), 0);
+
+  const s = soldeDuPoint(retirerChargement(c, "0|A|B"), "Gold", "A");
+  assert.equal(stockApres(s.ref, s.pris), 80); // « 0 + 150 » aurait rendu 150 à un rayon qui n'en eut jamais que 100
+});
+
+test("soldeDuPoint : un point que plus aucune jambe ne tient n'a plus de référence", () => {
+  const c = poserChargement({}, "0|A|B", [prise("Gold", "A", 100, 60)]);
+  assert.deepEqual(soldeDuPoint(retirerChargement(c, "0|A|B"), "Gold", "A"), { ref: null, pris: 0 });
+  assert.deepEqual(soldeDuPoint(c, "Gold", "B"), { ref: null, pris: 0 }); // autre rayon, autre solde
+  assert.deepEqual(soldeDuPoint(c, "Gold", "A", "0|A|B"), { ref: null, pris: 0 }); // `sauf` exclut la jambe annulée
+});
+
+test("poserChargement : une jambe sans prise reste CHARGÉE — c'est l'état qui compte d'abord", () => {
+  // Rayon au stock inconnu : rien à déduire, mais la jambe est bel et bien engagée. Sans entrée,
+  // elle repasserait à « ✓ chargé » et doublerait la soute au clic suivant.
+  const c = poserChargement({}, "0|A|B", []);
+  assert.equal("0|A|B" in c, true);
+  assert.deepEqual(retirerChargement(c, "0|A|B"), {});
+});
+
+test("migrerChargements : une soute écrite AVANT le registre reste chargée et annulable", () => {
+  // Ancien format : l'état vivait dans la présence des lots, et le stock d'avant dans `avant`.
+  const lots = [
+    { name: "Titanium", units: 60, paid: 1000, from: "A", at: 1, leg: "0|A|B", avant: 100 },
+    { name: "Titanium", units: 40, paid: 1000, from: "A", at: 2, leg: "2|A|C", avant: 40 },
+    { name: "Gold", units: 10, paid: 5, from: "X", at: 3 }, // sans jambe : rien à reconstruire
+  ];
+  const r = migrerChargements({}, lots);
+  assert.equal(r.change, true);
+  assert.deepEqual(Object.keys(r.chargements).sort(), ["0|A|B", "2|A|C"]);
+  // La référence retenue est la PLUS GRANDE : l'`avant` de la seconde jambe lisait déjà un rayon
+  // amputé par la première, c'est la plus ancienne qui dit ce que la station annonçait.
+  assert.deepEqual(soldeDuPoint(r.chargements, "Titanium", "A"), { ref: 100, pris: 100 });
+  assert.equal(r.lots.length, 3);
+  assert.equal(r.lots.some((l) => "avant" in l), false); // `avant` est mort : le registre porte tout
+  assert.equal(r.lots[0].units, 60);                     // et le fret, lui, ne bouge pas d'un SCU
+});
+
+test("migrerChargements : le registre existant fait foi, une soute déjà migrée ne bouge pas", () => {
+  const lots = [{ name: "Titanium", units: 60, paid: 1000, from: "A", at: 1, leg: "0|A|B" }];
+  const deja = poserChargement({}, "0|A|B", [prise("Titanium", "A", 100, 60)]);
+  const r = migrerChargements(deja, lots);
+  assert.equal(r.change, false);
+  assert.equal(r.chargements, deja); // rien à réécrire : pas de sauvegarde inutile
+  assert.equal(r.lots, lots);
+});
+
+test("reindexerRangsJambe : le REGISTRE suit la renumérotation, comme le manifeste et les lots", () => {
+  // A→B→C, on retire l'arrêt A : la jambe A→B disparaît, B→C recule au rang 0.
+  const retrait = removeJourneyStop(parcours(["A", "B", "C"], 0), 0);
+  const r = reindexerRangsJambe({
+    edits: {}, pins: {}, lots: [lotDe("1|B|C")],
+    chargements: { "0|A|B": [prise("Gold", "A", 100, 10)], "1|B|C": [prise("Gold", "B", 50, 5)] },
+  }, retrait);
+  assert.deepEqual(Object.keys(r.chargements), ["0|B|C"]); // sans ça la jambe repassait à « ✓ chargé »
+  assert.deepEqual(soldeDuPoint(r.chargements, "Gold", "B"), { ref: 50, pris: 5 });
 });
 
 // ---------- Suggestions d'arrêts : mêmes filtres que la vue qui les affichera ----------


### PR DESCRIPTION
## Ce que ça change

Vider la soute par son ✕ (ou vendre, ou quitter une escale) ne fait plus repasser la jambe à
« ✓ chargé » : elle reste `⬢ à bord`, et son stock n'est plus déduit une seconde fois. Et sur un
aller-retour où deux jambes achètent au même point, se raviser sur la première ne rend au rayon que
**ce qu'elle y avait pris** — la déduction de la seconde, dont le fret est toujours à bord, tient.

## Pourquoi

**#21 — `app.js:1282` (`jambeChargee`), `app.js:1246`, `app.js:1429`/`1430` (`viderSoute`/`retirerLot`).**
`jambeChargee` DÉRIVAIT l'état « chargée » de la seule présence des lots :
`SOUTE.some((l) => l.leg === legKey(leg, i))`. Or la soute se vide par bien d'autres chemins que
« annuler » — son ✕, une vente, la vente implicite du départ — et aucun ne rend rien à la station.
La jambe redevenait donc rechargeable : `pointAchat` relisait le stock EFFECTIF (déjà amputé à 40),
`l.avant = 40`, `stockApres(40, 60)` écrivait 0, et la valeur d'origine (100) était perdue pour de
bon puisqu'elle ne vivait que dans les lots disparus. Le toast affirmait au passage « le relevé UEX
en annonçait moins que ce que tu as pris », alors qu'UEX en annonçait 100 : c'est notre propre
déduction qui avait été relue.

**#22 — `app.js:1250-1252` (branche annulation) et `app.js:1264-1269` (capture d'`avant`).**
Chaque chargement capturait `avant` comme un instantané **absolu**, et l'annulation le réécrivait tel
quel. A→B→A→C, jambes 0 et 3 achetant du Titanium à A (100 annoncés) : la jambe 0 pose `avant = 100`
et corrige à 40, la jambe 3 pose `avant = 40` et corrige à 0 ; annuler la jambe 0 remet **100** alors
que 40 SCU sont toujours à bord, pris chez elle par la jambe 3. Le commentaire justifiait l'absolu
contre un « stock + units » — et il avait raison de l'écarter : `stockApres` écrête à 0, donc
« stock + units » rend au rayon plus qu'il n'a jamais annoncé dès qu'une prise a dépassé le stock.
**Aucune des deux formes ne tient.**

**La troisième forme.** Un **registre des chargements** (`best-hauling-jambes-chargees`), store à
part de la soute : `{ "<rang>|<from>|<to>": [{ name, terminal, ref, units }] }`. `ref` est le stock
du rayon **avant toute déduction de jambe** — la référence, pas un instantané du moment. Le rayon
affiche alors `stockApres(ref, Σ prises encore en cours)`, ce qui répond aux deux cas : l'écrêtage
n'efface plus la référence, et annuler une jambe laisse les autres déduites. Une seule fonction
(`ecrireStockDuPoint`) sert au chargement **et** à l'annulation, pour qu'elles ne puissent plus
diverger. Le registre porte aussi l'état « chargée », et il survit au fret : le fret peut quitter la
soute, ce qu'on doit au rayon reste dû.

Les numéros de ligne des issues étaient périmés ; le code a été retrouvé par nom. Les écarts :
`jambeChargee` était en `app.js:1282` (issue : 1214), `chargerJambe` en `app.js:1242-1281` (issue :
1195-1202 et 1182-1184), `viderSoute`/`retirerLot` en `app.js:1429`/`1430` (issue : 1311/1312).

**Migration (garde-fou 1).** Une soute déjà écrite chez l'utilisateur porte l'état sur ses lots
(`leg`) et le stock d'avant dans `avant`. Sans reprise, la jambe repassait à « ✓ chargé » au premier
rechargement de page — le bug #21 servi à froid, sans que personne ait rien touché.
`migrerChargements` reconstruit le registre depuis ces lots et retire `avant` (deux sources
divergeraient). Quand deux lots d'un même point portent des `avant` différents, c'est **le plus
grand** qui fait référence : le second lisait déjà un rayon amputé par le premier. Couvert par un
test unitaire et par un e2e qui rétrograde le stockage au format d'avant avant de recharger la page.

Le **rang de jambe** a maintenant QUATRE porteurs (manifeste édité, 🔒, étiquette `leg` des lots,
entrée du registre) : `reindexerRangsJambe` les décale tous d'un seul appel, puisque c'est d'en avoir
oublié un que venait déjà le double chargement de #7.

## Vérification

`node --test` — **rouge d'abord**, puis vert :

```
SyntaxError: The requested module './logic.mjs' does not provide an export named 'migrerChargements'
ℹ tests 42 · pass 41 · fail 1
```
```
ℹ tests 387
ℹ pass 387
ℹ fail 0
```

346 → 387 avec les 8 tests ajoutés sur `soldeDuPoint`, `poserChargement`, `retirerChargement`,
`migrerChargements` et `reindexerRangsJambe`.

`npx playwright test` — les deux e2e nouveaux échouaient **avant** le correctif, chacun sur le
symptôme décrit dans son issue :

```
1) Soute : vider la soute ne rend pas la jambe rechargeable… (#21)
   Expected pattern: /à bord/i
   Received string:  "✓ chargé"
   <button data-leg="0" class="jleg-load" title="J'ai payé et chargé ce manifeste…">✓ chargé</button>

2) Soute : annuler une jambe ne rend au rayon que CE QU'ELLE y a pris (#22)
   expect(received).toBe(expected)
   Expected: 456      // 684 − 228, la prise de la jambe 2 toujours à bord
   Received: 684      // l'instantané absolu : un stock fantôme
```

Après correctif, suite entière :

```
2 skipped
119 passed (1.8m)
```

Et le sous-ensemble Soute, où vivent les trois nouveaux tests :

```
18 passed (24.2s)
```

Le port 4173 a été vérifié avant de conclure : `curl http://127.0.0.1:4173/app.js` contient
`best-hauling-jambes-chargees` et `/logic.mjs` contient `soldeDuPoint` — c'est bien ce worktree qui
a été testé, et pas un autre servi sur le même port.

## Ce qui n'est pas couvert

- **#20 n'est pas corrigé, et c'est délibéré — il demande un ADR, pas un correctif discret.** L'issue
  prescrit de comparer le vendu à la quantité **demandée** plutôt qu'au total à bord. Or
  `sellFromHold` rend toujours `vendu = min(demandé, à bord)` : la comparaison proposée ne serait
  jamais vraie, `refuseHere` deviendrait du code mort, et le reliquat d'une vente partielle serait
  soldé par la vente implicite à la première étape franchie. C'est exactement ce que la réserve
  d'ADR-002 interdit (« Avancer d'une étape vend tout, **sauf ce qu'une vente partielle a
  explicitement laissé à bord** … sans quoi le résidu serait effacé au moment exact où il devient le
  sujet »), ce que `README.md` répète, et ce que l'e2e « Soute : vente partielle — le reste est
  REFUSÉ ici et survit au départ » vérifie. Le défaut réel de #20 est le **libellé** : l'app ne sait
  pas distinguer « le comptoir a refusé » de « je garde le reste », et affirme le premier. Les
  séparer suppose un geste d'interface nouveau — à trancher en ADR, avec #49.
- **Vider la soute laisse la jambe `⬢ à bord` et sa déduction posée.** C'est le correctif, pas un
  oubli : rien n'est revenu au rayon. Conséquence assumée — la carte continue de placer le vaisseau
  entre les deux stations tant que la jambe n'est pas annulée.
- **Une jambe qui DISPARAÎT emporte son entrée du registre** (retrait d'arrêt, effacement du voyage),
  donc sa déduction reste posée sans plus être annulable — même règle que les lots qu'on délie sans
  les débarquer, et même limite que celle déjà documentée pour eux.
- **Une correction de stock saisie à la main ENTRE deux chargements au même point** est ignorée par
  le recalcul : la référence du registre fait foi. Cas non observé, mais réel.
- Aucun `data/*.json` n'a été touché.

Closes #21
Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)
