### PR TITLE
fix(autoload): le test du relevé de station ne s'arme plus le rendu qui l'efface

### DIFF
--- a/e2e/autoload.pw.mjs
+++ b/e2e/autoload.pw.mjs
@@ -330,9 +330,11 @@ test("relevé de station : k déduit d'un montant observé, persistant, hors du 
   await expect(page.locator("#correctionsControls")).toBeVisible();
 
   // On sélectionne une station par son libellé exact (la datalist n'est peuplée qu'après market.json).
+  // UN SEUL événement `input` : `fill` en émet déjà un, et le second qu'on envoyait ici arrivait
+  // parfois après le debounce de 150 ms du champ — il valait alors un rendu différé de plus, dont
+  // l'instabilité de ce test était le symptôme (#28).
   const label = await page.locator("#stationList option").first().getAttribute("value");
   await page.fill("#station", label);
-  await page.locator("#station").dispatchEvent("input");
   await expect(page.locator("#alAmount")).toBeVisible();
 
   // 1 159 aUEC observés pour 32 SCU -> autoloadFee(32, 32, 1) = 820 -> k ≈ 1,413 (le relevé de Ruin).
@@ -353,6 +355,35 @@ test("relevé de station : k déduit d'un montant observé, persistant, hors du 
   await expect(page.locator("#correctionsControls")).toBeVisible();
   await expect(page.locator("#stationList option").first()).toBeAttached(); // marché rechargé
   await page.fill("#station", label);
-  await page.locator("#station").dispatchEvent("input");
   await expect(page.locator(".corr-item.autoload")).toContainText("1,41"); // survit au rechargement
+});
+
+// #28 : le test ci-dessus échouait une fois sur N, toujours vert à la relance, et le rapport ne
+// désignait que sa ligne de déclaration — de quoi le faire passer pour un caprice de la machine.
+// C'était #24, armé par le test lui-même : son second `input` sur #station, quand la latence du
+// protocole dépassait le debounce de 150 ms, comptait pour une frappe de plus. Un SECOND rendu
+// différé partait, tombait entre la saisie du montant et le clic sur « Enregistrer », et réécrivait
+// le panneau — `saveStationReading` lisait alors un champ vide, ne persistait rien, et la liste des
+// relevés restait introuvable. Ici on ne subit plus l'aléa, on le PROVOQUE : deux `input` séparés
+// par plus que le debounce, puis on laisse le rendu différé passer avant d'enregistrer.
+test("relevé de station : un rendu différé n'efface pas le montant déjà saisi (#28, #24)", async ({ page }) => {
+  await enrichMarket(page, "all", 32);
+  await page.goto("/index.html");
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+  await page.click("#viewCorrections");
+  await expect(page.locator("#stationList option").first()).toBeAttached({ timeout: 15000 });
+
+  const label = await page.locator("#stationList option").first().getAttribute("value");
+  await page.fill("#station", label);
+  await expect(page.locator("#alAmount")).toBeVisible();
+  await page.waitForTimeout(300); // le premier rendu est fait, le debounce retombé
+  await page.locator("#station").dispatchEvent("input"); // en arme un SECOND, gratuit
+
+  await page.fill("#alAmount", "1159");
+  await page.fill("#alScu", "32");
+  await page.waitForTimeout(300); // largement plus que le debounce : le rendu différé est passé
+  await expect(page.locator("#alAmount")).toHaveValue("1159"); // il n'a pas emporté la saisie
+
+  await page.click("#alSave");
+  await expect(page.locator(".corr-item.autoload")).toContainText("1,41");
 });


### PR DESCRIPTION
## Ce que ça change

Le test e2e « relevé de station » n'échoue plus une fois sur N sans raison lisible : il n'émet plus
lui-même l'événement qui armait le rendu différé capable de l'invalider. Un test dédié provoque
désormais ce rendu à chaque passage, pour que la propriété tienne au lieu de dépendre de la charge
machine.

## Pourquoi

Enquête, pas intuition. Le rapport ne désignait que la ligne de déclaration du test (`:315:1`),
donc aucune assertion précise.

**Ce que la reproduction a établi.** 15 passages de la suite ENTIÈRE (118 tests, 8 workers,
`retries: 0`, port dédié) sur la branche : **3 passages en échec, mais jamais ce test-là** — il est
passé 15 fois sur 15. Les deux pistes de l'issue sont écartées :

- *« `fullyParallel` et plusieurs tests écrivent le même `localStorage` »* — faux. Sonde dédiée :
  un test pose une marque dans `best-hauling-autoload` et la garde 1,5 s pendant que dix autres
  lisent en parallèle, douze fois chacun. **11 passed**, 120 observations, aucune contamination :
  Playwright donne un `BrowserContext` par test, donc un `localStorage` par test.
- *« un rendu que le `refreshDebounced` n'a pas encore produit »* — écarté sous cette forme :
  chaque attente du test est un `expect()` auto-attendant. Chronométrées sur 12 passages, toutes
  retombent entre 2 et 75 ms (sauf le chargement de page, 330–930 ms, et `#alAmount`, 166–707 ms
  dont 150 ms de debounce) — contre un budget de 5 000 ms.

**Cause racine.** Le test était le symptôme de **#24**, corrigé depuis (PR #59, close le
2026-08-14 — après les deux observations du 2026-08-13). Le mécanisme, `e2e/autoload.pw.mjs:335`
avant ce correctif :

```js
await page.fill("#station", label);                     // input #1 -> debounce armé
await page.locator("#station").dispatchEvent("input");  // input #2 -> un second, redondant
```

`fill` émet déjà `input`. Tant que les deux appels sont séparés de **moins** de 150 ms, le debounce
de `app.js:3001` les regroupe et un seul rendu part. Passé 150 ms — c'est-à-dire sous charge, quand
un aller-retour du protocole coûte plus que le debounce — il en part **deux**. Le second tombait
entre `fill("#alAmount", "1159")` et `click("#alSave")`, et `renderCorrections` réécrivait alors
`$("correctionsStation").innerHTML` (`app.js:2568` de l'arbre du 2026-08-13), qui portait encore le
panneau de frais. `saveStationReading` (`app.js:2550`) lisait un `#alAmount` vide → `kFromReading`
rend `null` → toast, rien de persisté, `.corr-item.autoload` jamais rendu → échec sur la dernière
assertion.

**Démonstration causale**, arbre du 2026-08-13 (`8f96d70`) servi sur un port à part, à côté de la
branche, la même sonde jouée contre les deux :

| arbre servi | latences injectées | résultat |
| --- | --- | --- |
| `8f96d70` (avant #24) | aucune | `6 passed` — d'où « toujours vert à la relance » |
| `8f96d70` (avant #24) | 200 ms / 200 ms | **`3 failed`** — `montant lu avant le clic = «  »` |
| branche (main du jour) | 200 ms / 200 ms | `6 passed` |

Et le bisect du correctif : rajouter au seul `8f96d70` le garde `if (stationSel !== avant) refresh()`
(`app.js:3004` aujourd'hui) suffit à faire repasser les 4 passages — c'est bien le **rendu différé
gratuit** qui tuait la saisie, et le déménagement du panneau vers `#correctionsFees` (#24) la met
désormais à l'abri une seconde fois.

Le correctif applicatif est donc déjà en place ; ce qui restait à corriger est le test, qui armait
son propre piège et n'avait rien pour dire pourquoi il tombait.

## Vérification

```
$ node --test
ℹ tests 380
ℹ pass 380
ℹ fail 0
```

**Rouge AVANT**, le nouveau test joué contre l'arbre qui portait le défaut (`8f96d70`, servi sur
4493) :

```
$ npx playwright test --config=pw.vieux.mjs e2e/autoload.pw.mjs -g "rendu différé"
  1) e2e\autoload.pw.mjs:369:1 › relevé de station : un rendu différé n'efface pas le montant déjà saisi (#28, #24)
    Error: expect(locator).toHaveValue(expected) failed
    Locator:  locator('#alAmount')
    Expected: "1159"
    Received: ""
  1 failed
```

Vert sur la branche :

```
$ npx playwright test            # suite entière, port 4173 vérifié comme servant CE worktree
  2 skipped
  117 passed (46.6s)

$ npx playwright test e2e/autoload.pw.mjs -g "relevé de station" --repeat-each=30 --workers=8
  60 passed (32.7s)

$ 15 passages de e2e/autoload.pw.mjs, 8 workers, retries 0
  TOTAL : 0 echec(s) sur 15 passages
```

Le port a été vérifié à chaque mesure (issue #70) : `GET /app.js` et `GET /e2e/autoload.pw.mjs`
comparés au fichier du worktree avant de lancer la suite.

## Ce qui n'est pas couvert

- **Le taux d'échec d'origine n'a pas été reproduit sur la branche** : 0 sur 15 passages de la suite
  entière, et 0 sur 15 passages du fichier seul. La cause est établie par la démonstration
  ci-dessus, pas par une occurrence spontanée — c'est cohérent avec un défaut corrigé entre-temps
  par #24.
- **Cinq AUTRES tests ont échoué** pendant ces 15 passages, tous pendant les passages où la machine
  était saturée (1,9–2,5 min au lieu de 48 s), aucun deux fois. Quatre sont des `Test timeout of
  30000ms exceeded` sur un fil principal bloqué (`smoke.pw.mjs:234` `page.check("#legalOnly")`,
  `smoke.pw.mjs:677` et `:616` sur `#journeyCard`, `smoke.pw.mjs:1244` `.mline.acquired`). Le
  cinquième est un vrai défaut d'ordre, pas une lenteur : `autoload.pw.mjs:232` (« dégradation :
  sans les champs UEX »), où l'ORDRE des profits change entre le relevé brut et le relevé après
  activation alors que les montants, eux, sont identiques (`353 115` remonte de deux rangs). Rien
  de tout cela n'est traité ici.
- Le nouveau test utilise deux `waitForTimeout(300)` : ils ne masquent pas une attente, ils
  PROVOQUENT le rendu différé qu'on veut voir échouer — même usage que `smoke.pw.mjs:1892` et
  `:1910`. La condition, elle, reste attendue (`toHaveValue`).
- Les budgets d'`expect()` restent à 5 s par défaut : sous une saturation qui pousse un rendu
  au-delà de 30 s, ce test tombera comme n'importe quel autre.

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)
