### PR TITLE
fix(ci): chaque copie de travail teste son propre code, sur son propre port

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ npm run serve        # sert le dossier sur http://127.0.0.1:4173 (serveur maison
 # puis ouvre http://127.0.0.1:4173/index.html — l'écoute est volontairement limitée à la boucle locale
 ```
 
+> **Plusieurs copies de travail sur la même machine ?** Le serveur de `npm run serve` reste sur 4173,
+> mais celui des tests Playwright prend un port **dérivé du chemin de la copie**
+> (`scripts/port.mjs`, plage 30000-39999). Sans quoi, `reuseExistingServer` étant actif hors CI, une
+> suite lancée depuis un worktree testait le code d'un autre — verte, et sans rien vérifier. Rien à
+> configurer : `npx playwright test` trouve son port tout seul.
+
 Les `data/*.json` versionnés servent d'**amorce** pour le dev local. Pour les régénérer depuis UEX :
 
 ```bash

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,8 +1,18 @@
 import { defineConfig, devices } from "@playwright/test";
+import { portDuDepot } from "./scripts/port.mjs";
 
 // Tests E2E de fumée (non-régression des bugs passés). Le site est servi par le
 // serveur statique maison (aucune dépendance runtime). Fichiers : e2e/*.pw.mjs
 // (le suffixe .pw évite que `node --test` ne les ramasse — ils passent par Playwright).
+
+// Le port est DÉRIVÉ de la copie de travail, jamais écrit ici (#70). Avec un port fixe et
+// `reuseExistingServer`, une suite lancée depuis un second worktree testait le code du premier :
+// verte, et sans rien vérifier. Un seul littéral suffisait à ramener le défaut, d'où l'unique
+// source ci-dessous — et un test de lecture de source qui interdit d'en réécrire un
+// (scripts/port.test.mjs).
+const PORT = portDuDepot(process.cwd());
+const ORIGINE = `http://127.0.0.1:${PORT}`;
+
 export default defineConfig({
   testDir: "./e2e",
   testMatch: "**/*.pw.mjs",
@@ -15,13 +25,13 @@ export default defineConfig({
   // un runner n'a pas de navigateur à ouvrir, et le serveur du rapport bloquerait le job).
   reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "line",
   use: {
-    baseURL: "http://127.0.0.1:4173",
+    baseURL: ORIGINE,
     trace: "on-first-retry",
   },
   projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
   webServer: {
-    command: "node scripts/serve.mjs 4173",
-    url: "http://127.0.0.1:4173/index.html",
+    command: `node scripts/serve.mjs ${PORT}`,
+    url: `${ORIGINE}/index.html`,
     reuseExistingServer: !process.env.CI,
     timeout: 30_000,
   },

--- a/scripts/port.mjs
+++ b/scripts/port.mjs
@@ -1,0 +1,32 @@
+// Le port du serveur de test, DÉRIVÉ de la copie de travail au lieu d'être fixé.
+//
+// Pourquoi : `playwright.config.mjs` pose `reuseExistingServer` hors CI. Avec un port fixe, une
+// suite lancée depuis une seconde copie (worktree, ou simplement un second clone) trouvait le port
+// occupé, considérait que le serveur était le sien, et lui envoyait ses tests — alors que
+// `scripts/serve.mjs` sert le répertoire depuis lequel IL a été lancé, c'est-à-dire l'autre copie.
+// La suite passait, verte, en ayant mesuré le code du voisin. C'est la pire forme de faux vert :
+// celle qui ressemble exactement à un vrai (#70).
+//
+// Le repli n'existe pas : il n'y a pas de « port par défaut » qu'on pourrait oublier de surcharger.
+// Un port dérivé protège sans discipline, une variable d'environnement demande qu'on y pense — donc
+// on n'y penserait pas le jour où ça compte.
+import { createHash } from "node:crypto";
+import { resolve } from "node:path";
+
+// Plage retenue : 30000-39999. Au-dessus des ports d'applications courants, et SOUS la plage
+// dynamique de Windows (49152-65535) où le système attribue les ports éphémères — s'y poser
+// exposerait à un conflit intermittent avec n'importe quelle connexion sortante, c'est-à-dire au
+// test instable qu'on cherche précisément à supprimer.
+export const PORT_BASE = 30000;
+export const PORT_PLAGE = 10000;
+
+export function portDuDepot(racine) {
+  // `resolve` normalise séparateurs et `..` : deux façons d'écrire le même chemin doivent rendre le
+  // même port, sinon deux terminaux sur la MÊME copie démarreraient deux serveurs.
+  let cle = resolve(racine);
+  // Les chemins Windows sont insensibles à la casse — `C:\Projets` et `c:\projets` sont la même
+  // copie. Ailleurs, non : deux répertoires ne différant que par la casse sont bien distincts, et
+  // les confondre les ferait se partager un serveur, soit le défaut d'origine à l'envers.
+  if (process.platform === "win32") cle = cle.toLowerCase();
+  return PORT_BASE + (createHash("sha1").update(cle).digest().readUInt32BE(0) % PORT_PLAGE);
+}

--- a/scripts/port.test.mjs
+++ b/scripts/port.test.mjs
@@ -1,0 +1,67 @@
+// Le port du serveur de test. Un port FIXE partagé par plusieurs copies de travail est le pire
+// défaut d'outillage possible : la suite reste verte en testant le code du voisin (#70). Ces tests
+// verrouillent les deux propriétés qui l'empêchent — un port par copie, et aucun port en dur dans
+// la configuration.
+// Lancer : `node --test`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { portDuDepot, PORT_BASE, PORT_PLAGE } from "./port.mjs";
+
+const RACINE = join(dirname(fileURLToPath(import.meta.url)), "..");
+const lire = (...p) => readFileSync(join(RACINE, ...p), "utf8").replace(/\r\n/g, "\n");
+
+test("portDuDepot : deux copies de travail ne partagent jamais leur serveur", () => {
+  // Le scénario exact de #70 : le dépôt et un worktree posé dessous.
+  const depot = portDuDepot("C:/Projets/best-hauling");
+  const worktree = portDuDepot("C:/Projets/best-hauling/.claude/worktrees/wf-1");
+  assert.notEqual(depot, worktree);
+
+  // Et sur un échantillon large : aucune collision entre vingt copies plausibles. Une collision
+  // ramènerait exactement le défaut, en plus rare donc en plus difficile à croire.
+  const ports = new Set();
+  for (let i = 0; i < 20; i++) ports.add(portDuDepot(`/home/x/best-hauling-${i}`));
+  assert.equal(ports.size, 20);
+});
+
+test("portDuDepot : la même copie rend TOUJOURS le même port", () => {
+  // Sans quoi `reuseExistingServer` ne servirait plus à rien : chaque relance dans la même copie
+  // repaierait le démarrage du serveur.
+  const a = portDuDepot("/home/x/best-hauling");
+  assert.equal(portDuDepot("/home/x/best-hauling"), a);
+  // Un chemin non normalisé désigne la même copie, donc le même port.
+  assert.equal(portDuDepot("/home/x/./autre/../best-hauling"), a);
+});
+
+test("portDuDepot : le port tombe dans une plage sûre", () => {
+  // Hors de la plage dynamique de Windows (49152-65535), où le système attribue les ports
+  // éphémères : s'y poser exposerait à un conflit intermittent avec n'importe quelle connexion
+  // sortante — c'est-à-dire à un test instable, ce qu'on cherche justement à supprimer.
+  for (const p of ["/a", "C:/b", "/very/long/path/to/a/checkout", RACINE]) {
+    const port = portDuDepot(p);
+    assert.ok(Number.isInteger(port), `${p} rend un entier`);
+    assert.ok(port >= PORT_BASE && port < PORT_BASE + PORT_PLAGE, `${p} -> ${port} dans la plage`);
+    assert.ok(port < 49152, `${p} -> ${port} hors de la plage dynamique Windows`);
+  }
+});
+
+test("portDuDepot : sous Windows, la casse du chemin ne change pas le port", () => {
+  // Les chemins Windows sont insensibles à la casse : deux terminaux ouverts sur `C:\Projets` et
+  // `c:\projets` sont la MÊME copie et doivent partager leur serveur, pas en démarrer deux.
+  const attendu = process.platform === "win32";
+  const memePort = portDuDepot("C:/Projets/best-hauling") === portDuDepot("c:/projets/best-hauling");
+  assert.equal(memePort, attendu);
+});
+
+// LECTURE DE SOURCE. C'est LE test qui échoue avant le correctif : la configuration écrivait 4173
+// à trois endroits (`baseURL`, la commande du serveur, l'URL de sonde). Un seul oubli et deux
+// copies se repartagent un serveur — sans que rien ne le signale, puisque la suite reste verte.
+test("playwright.config.mjs ne fixe aucun port en dur", () => {
+  const conf = lire("playwright.config.mjs")
+    .split("\n").filter((l) => !l.trim().startsWith("//")).join("\n");
+  const enDur = conf.match(/\b(?:127\.0\.0\.1|localhost):(\d{4,5})|serve\.mjs (\d{4,5})/g) || [];
+  assert.deepEqual(enDur, [], "le port doit venir de portDuDepot(), jamais d'un littéral");
+  assert.match(conf, /portDuDepot/, "ancre : la configuration dérive bien son port de la copie");
+});


### PR DESCRIPTION
## Ce que ça change

Une suite de tests lancée depuis une copie de travail teste **le code de cette copie**. Jusqu'ici, avec deux copies sur la même machine (worktree, second clone, ou simplement deux terminaux sur deux branches), la seconde envoyait ses tests au serveur de la première — et passait au vert en n'ayant rien vérifié.

Rien à configurer : `npx playwright test` trouve son port tout seul.

## Pourquoi

Cause racine — `playwright.config.mjs` écrivait `4173` **à trois endroits** (`:18` `baseURL`, `:23` la commande du serveur, `:24` l'URL de sonde) avec `reuseExistingServer: !process.env.CI`, donc actif en local. Le second lancement trouvait le port occupé, tenait le serveur pour le sien, et lui envoyait ses tests. Or `scripts/serve.mjs` sert le répertoire depuis lequel **il** a été lancé, c'est-à-dire l'autre copie.

C'est la pire forme de faux vert : celle qui ressemble exactement à un vrai. Le défaut est **strictement local** — en CI, `reuseExistingServer` est faux et chaque job a sa machine — ce qui explique sa survie jusqu'ici.

Le port vient désormais d'un hachage SHA-1 du chemin résolu de la copie (`scripts/port.mjs`), projeté dans la plage **30000-39999** : au-dessus des ports d'applications courants, et **sous** la plage dynamique de Windows (49152-65535) où le système attribue les ports éphémères — s'y poser aurait échangé un faux vert contre un test instable.

`reuseExistingServer` garde tout son intérêt : deux lancements dans la **même** copie partagent leur serveur, deux copies différentes ne se voient plus.

## Vérification

**Le rouge, mesuré sur le scénario réel** — un serveur étranger posé sur 4173, servant un autre contenu, puis la suite lancée depuis le dépôt avec la configuration de `main` :

```
> 78 |   await expect(page.locator("#rows tr").first()).toBeVisible();
       at e2e/autoload.pw.mjs:78:50
  1 failed
```

La suite est bien allée taper sur le serveur étranger. **Nuance qui compte** : ici l'échec est visible parce que le squatteur sert une page franchement différente. Dans le cas réel — deux copies du *même* dépôt — la suite serait passée au **vert** contre le mauvais code. C'est ce cas-là, invisible, que le correctif supprime.

**Le vert, squatteur toujours en place sur 4173** :

```
2 skipped
129 passed (52.8s)
```

La suite l'a complètement ignoré, et le squatteur répondait encore après coup (vérifié par `curl`).

**Le test qui échoue avant, côté unitaire** — lecture de source sur la configuration :

```
✖ playwright.config.mjs ne fixe aucun port en dur
  actual: [ '127.0.0.1:4173', 'serve.mjs 4173', '127.0.0.1:4173' ]
  expected: []
```

Les trois littéraux, listés par le test lui-même. Après correctif : `5 pass, 0 fail`.

**Suites complètes** — `node --test` → **407 tests, 407 pass, 0 fail** (402 avant, +5). `npx playwright test` → **129 passed, 2 skipped, 0 failed**.

Les quatre autres tests unitaires couvrent les propriétés qui font tenir le dispositif : deux copies ne collisionnent jamais (dont le cas exact d'un worktree posé sous le dépôt, plus un échantillon de vingt chemins), la même copie rend toujours le même port (y compris depuis un chemin non normalisé — sinon `reuseExistingServer` ne servirait plus), le port reste dans la plage sûre, et sous Windows la casse du chemin ne change pas le port (deux terminaux sur `C:\Projets` et `c:\projets` sont la même copie et doivent partager leur serveur).

## Ce qui n'est pas couvert

- **`npm run serve` reste sur 4173**, inchangé et documenté : c'est le serveur qu'on ouvre à la main, il n'a pas de raison de bouger. Il ne peut plus être confondu avec celui des tests, puisqu'ils ne partagent plus de port.
- **Aucune protection contre une collision fortuite** entre deux copies dont les chemins hacheraient sur le même port. La probabilité est de 1/10000 par paire, le test couvre vingt chemins plausibles, et la conséquence serait le défaut d'origine. Un bail effectif du port serait la vraie réponse, et c'est disproportionné ici.
- **#28** (le test de relevé instable) est un mécanisme distinct — partage de `localStorage` entre tests parallèles — et a été corrigé séparément par #74. Les deux se ressemblent, aucun n'est la cause de l'autre.
- **La CI n'est pas modifiée** : `ci.yml` se contente de `npx playwright test`, et le comportement y est identique.

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)
