### PR TITLE
chore(ci): une seule source pour la version, et l'app dit enfin laquelle elle est

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,40 @@ Les relevés bruts et le raisonnement complet sont dans
   « même système » contraint la Chaîne). Playwright est une dépendance **de dev uniquement** — le site livré reste sans dépendance.
 - **CI** ([`ci.yml`](.github/workflows/ci.yml)) : unitaires + E2E sur chaque push/PR.
 
+## Versions et déploiement
+
+`main` **est** la production : un push y déclenche la reconstruction et le déploiement Pages. Il n'y
+a rien à télécharger — les *releases* GitHub ne servent donc pas à distribuer, seulement à donner un
+changelog liable et un point de retour nommé.
+
+La version vit dans **`package.json`**, et nulle part ailleurs. Elle redescend à trois endroits qui
+ne peuvent pas la lire eux-mêmes, via [`scripts/version.mjs`](scripts/version.mjs) :
+
+| Où | Comment |
+|---|---|
+| le nom du cache de [`sw.js`](sw.js) | écrit à la main, **vérifié par un test** |
+| `data/meta.json` | écrit au build, avec le commit court du runner |
+| le bas du rail | lu depuis ce `meta.json` |
+
+Le nom du cache n'est pas décoratif : la coquille est servie en *stale-while-revalidate*, donc sans
+changement de nom un visiteur déjà installé continue de recevoir l'**ancien** `index.html` pendant
+toute une visite. Le bump était manuel, donc oubliable ; `node --test` échoue désormais s'il ne suit
+pas la version.
+
+### Clôturer un jalon
+
+Quand toutes les issues d'un jalon sont fermées, trois commandes :
+
+```bash
+npm version 1.0.1 --no-git-tag-version   # bump package.json
+# bump le CACHE de sw.js pour qu'il suive — `node --test` refuse le contraire
+git commit -am "chore(release): v1.0.1" && git push
+gh release create v1.0.1 --generate-notes   # tag + changelog assemblé depuis les PR fusionnées
+```
+
+Les notes sont **générées** à partir des titres de PR : c'est pour ça qu'ils décrivent ce qui change
+pour l'utilisateur plutôt que le fichier qui a bougé.
+
 ## Personnalisation
 
 - Fréquence de mise à jour : le `cron` dans [`update-data.yml`](.github/workflows/update-data.yml).

--- a/app.js
+++ b/app.js
@@ -3470,6 +3470,16 @@ async function init() {
       if (rs) rs.innerHTML =
         `<div class="rs-updated">Dernière MàJ<br><b>${exact}</b></div>` +
         `<div class="rs-counts"><b>${meta.routes}</b> routes · <b>${meta.loops ?? LOOPS.length}</b> boucles · <b>${meta.commodities}</b> commodités</div>`;
+      // Version déployée, et le commit qui l'a produite. Sans ça, un rapport de bug n'est
+      // rattachable à rien : on ne sait pas si l'utilisateur regarde le `main` d'il y a dix minutes
+      // ou une coquille servie depuis son cache d'il y a trois semaines. Silencieux si l'estampille
+      // manque — l'amorce versionnée dans data/ ne la porte pas tant qu'un build n'est pas passé,
+      // et « v— » vaudrait moins que rien.
+      const rv = $("railVersion");
+      if (rv && meta.app_version) {
+        rv.textContent = `v${meta.app_version}${meta.commit ? ` · ${meta.commit}` : ""}`;
+        rv.title = `Version déployée${meta.commit ? ` — commit ${meta.commit}` : ""}. À citer dans un rapport de bug.`;
+      }
     }
     // Applique l'état restauré une fois le menu système peuplé, puis affiche la bonne vue.
     applyState(saved);

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -2244,3 +2244,47 @@ for (const { largeur, hauteur } of [{ largeur: 1920, hauteur: 1080 }, { largeur:
     expect(await debord("#enroute"), "En route").toBeLessThanOrEqual(1);
   });
 }
+
+// #75 : l'app n'affichait AUCUNE version. Un rapport de bug n'était rattachable à rien — on ne
+// savait pas si l'utilisateur regardait le `main` d'il y a dix minutes ou une coquille servie
+// depuis son cache d'il y a trois semaines. L'estampille vient de meta.json, écrite au build : on
+// l'injecte ici, parce que l'amorce versionnée dans data/ ne la porte pas tant qu'aucun build n'est
+// passé (même raison que l'enrichissement de market.json dans autoload.pw.mjs).
+test.describe("version déployée", () => {
+  // `serviceWorkers: "block"` est INDISPENSABLE, comme dans autoload.pw.mjs : le service worker sert
+  // data/meta.json depuis son cache (réseau d'abord, cache en repli), et page.route ne voit alors
+  // jamais passer la requête — l'interception ci-dessous serait silencieusement sans effet.
+  test.use({ serviceWorkers: "block" });
+
+  test("version : l'estampille du déploiement s'affiche dans le rail (#75)", async ({ page }) => {
+    await page.route("**/data/meta.json", async (route) => {
+      const res = await route.fetch();
+      const meta = await res.json();
+      await route.fulfill({ response: res, json: { ...meta, app_version: "9.9.9", commit: "abc1234" } });
+    });
+    await page.goto("/index.html");
+    await expect(page.locator("#rows tr").first()).toBeVisible();
+
+    const v = page.locator("#railVersion");
+    await expect(v).toHaveText("v9.9.9 · abc1234");
+    await expect(v).toHaveAttribute("title", /rapport de bug/);
+  });
+
+  test("version : sans estampille, le rail ne montre rien plutôt qu'un « v— » (#75)", async ({ page }) => {
+    // L'amorce du dépôt n'a pas encore d'app_version : c'est le cas nominal en local, il ne doit pas
+    // produire de trou dans le rail. `:empty { display: none }` s'en charge, encore faut-il que le
+    // code ne remplisse pas l'élément avec un repli.
+    await page.route("**/data/meta.json", async (route) => {
+      const res = await route.fetch();
+      const meta = await res.json();
+      delete meta.app_version;
+      delete meta.commit;
+      await route.fulfill({ response: res, json: meta });
+    });
+    await page.goto("/index.html");
+    await expect(page.locator("#rows tr").first()).toBeVisible();
+    await expect(page.locator("#railVersion")).toHaveText("");
+    await expect(page.locator("#railVersion")).toBeHidden(); // :empty le retire du flux
+  });
+});
+

--- a/index.html
+++ b/index.html
@@ -74,6 +74,11 @@
       <div class="rail-status">
         <div class="rail-status-head"><span class="live-dot"></span><span class="rl">Flux UEX</span></div>
         <div class="rail-status-body rl" id="railStatus"></div>
+        <!-- Version déployée. Ici et pas dans .brand : ce bloc est déjà la zone d'état du rail, et
+             la marque est convoitée par le retour à l'accueil (#61) et le bouton de tuto (#62).
+             Reste vide tant que meta.json ne porte pas l'estampille — en local, l'amorce versionnée
+             n'en a pas, et afficher « v— » vaudrait moins que ne rien afficher. -->
+        <div class="rail-version rl" id="railVersion"></div>
       </div>
     </nav>
 

--- a/scripts/build-data.mjs
+++ b/scripts/build-data.mjs
@@ -8,6 +8,7 @@
 import { writeFile, mkdir, appendFile } from "node:fs/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { dirname, join } from "node:path";
+import { VERSION, commitCourt } from "./version.mjs";
 
 const API = "https://api.uexcorp.uk/2.0";
 const OUT_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "data");
@@ -483,6 +484,12 @@ async function main() {
     loops: topLoops.length,
     systems,
     data_signature: signature, // pour le rebuild conditionnel du prochain run
+    // Estampille de déploiement. La version vient de package.json via la source unique
+    // (scripts/version.mjs) ; le commit vient du runner et reste VIDE en local, parce qu'une
+    // copie de travail n'a pas de commit « déployé ». C'est ce couple qui rend un rapport de
+    // bug rattachable à un état du code — l'app n'affichait jusqu'ici aucune version.
+    app_version: VERSION,
+    commit: commitCourt(),
   };
 
   // Vaisseaux avec soute (>= 1 SCU), hors véhicules terrestres. Pour le filtre "vaisseau".

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -1,0 +1,28 @@
+// LA source de vérité de la version : `package.json`, et rien d'autre.
+//
+// Elle doit redescendre à trois endroits qui ne peuvent pas la lire eux-mêmes :
+//   - le nom du cache du service worker (`sw.js` est servi tel quel au navigateur, il n'importe
+//     rien) — d'où un littéral là-bas, et un test ici qui refuse qu'il diverge ;
+//   - `data/meta.json`, écrit au build et déjà récupéré par l'app ;
+//   - l'écran, via ce meta.
+//
+// Le nom du cache n'est pas décoratif. `sw.js` sert la coquille en « stale-while-revalidate » :
+// sans changement de nom, un visiteur déjà installé continue de recevoir l'ANCIEN index.html
+// pendant toute une visite, pendant que les scripts, eux, sont à jour. Le bump était jusqu'ici
+// manuel, donc oubliable ; il suit maintenant la version, et un test le vérifie.
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const RACINE = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+export const VERSION = JSON.parse(readFileSync(join(RACINE, "package.json"), "utf8")).version;
+
+// Le nom du cache pour une version donnée. Une fonction plutôt qu'une constante : c'est elle que le
+// test applique à `package.json` pour la comparer à ce que `sw.js` écrit vraiment.
+export const nomDuCache = (version = VERSION) => `best-hauling-v${version}`;
+
+// Le commit déployé, court. Vient de l'environnement du runner ; vide en local, et c'est voulu —
+// une copie de travail n'a pas de commit « déployé », et afficher le HEAD local laisserait croire
+// que ce qu'on voit est en ligne.
+export const commitCourt = (env = process.env) => (env.GITHUB_SHA || "").slice(0, 7);

--- a/scripts/version.test.mjs
+++ b/scripts/version.test.mjs
@@ -1,0 +1,47 @@
+// La version ne doit exister qu'à un seul endroit. Ces tests remplacent la vigilance humaine sur
+// les deux recopies qu'on ne peut pas éviter — le nom du cache dans `sw.js`, et ce que le build
+// écrit dans `meta.json`. Sans eux, un bump de version oublié dans `sw.js` sert l'ancien index.html
+// à tous les visiteurs déjà installés, sans que rien ne le signale.
+// Lancer : `node --test`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { VERSION, nomDuCache, commitCourt } from "./version.mjs";
+
+const RACINE = join(dirname(fileURLToPath(import.meta.url)), "..");
+const lire = (...p) => readFileSync(join(RACINE, ...p), "utf8").replace(/\r\n/g, "\n");
+
+test("la version de package.json est un semver à trois nombres", () => {
+  // Les jalons du dépôt sont des versions (v1.0.1, v1.1.0…) : si celle-ci part en dérive, le lien
+  // entre un jalon et ce qui est déployé se casse en silence.
+  assert.match(VERSION, /^\d+\.\d+\.\d+$/);
+});
+
+test("le nom du cache de sw.js suit la version — le bump manuel n'est plus oubliable", () => {
+  // `sw.js` est servi tel quel au navigateur : il n'importe rien, donc il ÉCRIT la version. C'est
+  // la seule recopie inévitable, et ce test est ce qui la tient.
+  const cache = lire("sw.js").match(/const CACHE = "([^"]+)"/);
+  assert.ok(cache, "ancre : sw.js déclare toujours son cache sous ce nom");
+  assert.equal(cache[1], nomDuCache(),
+    "bump de version sans bump du cache : les visiteurs installés garderaient l'ancien index.html");
+});
+
+test("le build estampille meta.json avec la version et le commit", () => {
+  // Lecture de source : `build-data.mjs` fait des appels réseau, on ne le rejoue pas ici. Ce qu'on
+  // vérifie est qu'il tire sa version de la source unique au lieu d'en écrire une seconde.
+  // `assert.ok` et non `assert.match` : sur un fichier de 900 lignes, `match` déverse tout le
+  // contenu dans le rapport d'échec et noie le message.
+  const build = lire("scripts", "build-data.mjs");
+  assert.ok(/from "\.\/version\.mjs"/.test(build), "le build importe la source unique");
+  assert.ok(/app_version:\s*VERSION/.test(build), "meta.json porte la version");
+  assert.ok(/commit:\s*commitCourt\(\)/.test(build), "meta.json porte le commit déployé");
+});
+
+test("commitCourt : sept caractères en CI, rien en local", () => {
+  // Vide en local À DESSEIN : une copie de travail n'a pas de commit « déployé », et afficher le
+  // HEAD local laisserait croire que ce qu'on regarde est en ligne.
+  assert.equal(commitCourt({ GITHUB_SHA: "0123456789abcdef0123456789abcdef01234567" }), "0123456");
+  assert.equal(commitCourt({}), "");
+});

--- a/style.css
+++ b/style.css
@@ -193,6 +193,11 @@ h1 { margin: 0; font-family: var(--display); font-weight: 700; font-size: 26px; 
 .rs-updated b { color: var(--text); font-size: 11px; }
 .rs-counts { font-size: 10px; color: var(--muted); line-height: 1.65; }
 .rs-counts b { color: var(--acc); }
+/* Version déployée : présente, jamais bruyante. Plus discrète que les compteurs au-dessus — on la
+   cherche quand on rédige un rapport de bug, on ne la lit pas en travaillant. `:empty` la retire du
+   flux tant que l'estampille manque, sinon elle laisserait une marge orpheline. */
+.rail-version { margin-top: 9px; font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.5px; color: var(--muted); opacity: 0.65; }
+.rail-version:empty { display: none; }
 
 main { padding: 22px 30px 40px; }
 

--- a/sw.js
+++ b/sw.js
@@ -5,7 +5,7 @@
 // recevrait encore l'ANCIEN index.html — sans CSP et avec son <script> inline — pendant toute une
 // visite, tandis que rail.js, lui, serait déjà là. `activate` purge tout cache au nom différent :
 // le bump garantit que la nouvelle page et son script arrivent ENSEMBLE.
-const CACHE = "best-hauling-v7";
+const CACHE = "best-hauling-v1.0.0";
 // Coquille précachée. Les woff2 (mêmes-origine depuis fonts/) sont mis en cache au premier
 // rendu par le gestionnaire fetch ci-dessous (stale-while-revalidate) -> hors-ligne complet.
 const SHELL = ["./", "./index.html", "./app.js", "./rail.js", "./logic.mjs", "./style.css", "./fonts/fonts.css", "./icon.svg", "./manifest.webmanifest"];


### PR DESCRIPTION
## Ce que ça change

L'app affiche la **version déployée** et le **commit qui l'a produite**, en bas du rail, discrètement. Un rapport de bug devient rattachable à un état du code.

Et le nom du cache du service worker suit désormais la version au lieu d'être bumpé à la main.

## Pourquoi

Le dépôt s'est donné des jalons versionnés (`v1.0.1`, `v1.1.0`…) qui ne voulaient rien dire : aucun tag, aucune release, et `package.json` à `1.0.0` sans que rien ne s'y réfère.

Le vrai danger était ailleurs. **`sw.js:8` portait déjà une version — `best-hauling-v7` — écrite à la main.** Son propre commentaire (`sw.js:4-7`) dit ce qu'on risque à l'oublier : la coquille est servie en *stale-while-revalidate*, donc sans changement de nom « un visiteur déjà installé recevrait encore l'ANCIEN index.html — sans CSP et avec son `<script>` inline — pendant toute une visite, tandis que rail.js, lui, serait déjà là ». Une régression de sécurité qui attendait qu'on saute une ligne, et rien ne la surveillait.

`package.json` devient la source unique. Elle redescend par [`scripts/version.mjs`](scripts/version.mjs) aux trois endroits qui ne peuvent pas la lire eux-mêmes :

| Où | Comment | Ce qui l'empêche de dériver |
|---|---|---|
| le nom du cache de `sw.js` | littéral (le SW est servi tel quel, il n'importe rien) | un test `node --test` |
| `data/meta.json` | écrit au build, avec le commit court du runner | un test de lecture de source sur `build-data.mjs` |
| le bas du rail | lu depuis ce `meta.json` | deux tests Playwright |

**L'emplacement** : `.rail-status`, en bas du rail, qui est déjà la zone d'état. Pas `.brand`, convoitée par le retour à l'accueil (#61) et le bouton de tuto (#62).

**Le commit reste vide en local**, à dessein : une copie de travail n'a pas de commit « déployé », et afficher le HEAD local laisserait croire que ce qu'on regarde est en ligne.

**L'estampille est silencieuse quand elle manque.** L'amorce versionnée dans `data/` ne la porte pas tant qu'aucun build n'est passé — et la règle du dépôt interdit de régénérer un `data/*.json` dans une PR de code. Un `v—` de repli vaudrait moins que rien, donc `:empty { display: none }` retire l'élément du flux.

## Vérification

**Les rouges**, avant correctif :

```
✖ le nom du cache de sw.js suit la version — le bump manuel n'est plus oubliable
  actual:   'best-hauling-v7'
  expected: 'best-hauling-v1.0.0'

✖ le build estampille meta.json avec la version et le commit
  le build importe la source unique
```

```
✖ version : l'estampille du déploiement s'affiche dans le rail (#75)
  Expected: "v9.9.9 · abc1234"
  Received: ""
```

**Après** — `node --test` → **411 tests, 411 pass, 0 fail** (407 avant, +4). `npx playwright test` → **133 passed, 2 skipped, 0 failed**.

**Un piège rencontré, et évité** : la première version du test e2e passait à côté. `page.route` n'interceptait rien parce que **le service worker sert `data/meta.json` depuis son cache** — exactement l'écueil que documente `autoload.pw.mjs` (« `serviceWorkers: "block"` est INDISPENSABLE »). Les deux tests sont donc dans un `describe` qui bloque le SW. Sans ça, ils auraient été verts en ne vérifiant rien.

**Périmètre** : aucun `data/*.json` modifié. `meta.json` recevra ses deux champs au prochain build, ce qui est le comportement voulu.

## Ce qui n'est pas couvert

- **`v1.0.1` n'est pas taguée ici** : le jalon n'est pas clos, il reste #20. La procédure est écrite dans le README (`## Versions et déploiement`), elle s'appliquera à sa fermeture.
- **`package.json` reste à `1.0.0`.** Bumper maintenant annoncerait une version qui n'a pas été livrée.
- **Pas de `CHANGELOG.md` tenu à la main** : `gh release create --generate-notes` assemble les titres de PR fusionnées, sans dérive possible. À rouvrir si les notes générées se révèlent illisibles.
- **Pas d'automatisation du bump** (release-please, semantic-release) : outillage lourd pour un dépôt solo, quand trois commandes documentées suffisent.
- **Le second test e2e est faible par construction** : il vérifie que l'absence d'estampille ne produit pas de trou, et l'amorce n'en a pas — il passerait donc même sans interception. Il couvre le cas nominal local, pas une régression fine.

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)
