### PR TITLE
fix(soute): un comptoir plein le redevient — le refus périme en 3 h

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,13 @@ affaire à l'escale que je quitte »** et solde ce qui s'y vendait encore. Sans 
 disparaîtrait au moment exact où il devient le sujet. Un geste explicite, lui, passe outre.
 Reculer ne revend rien.
 
+Ce marqueur **périme en 3 h**, sur la même horloge qu'un volume corrigé — et pour la même raison.
+Un comptoir n'est plein que sur **son shard et à cet instant** : en changeant de shard, ou
+simplement dix minutes plus tard, le même terminal en reprend. Une saturation observée est donc
+périssable, exactement comme un stock. Sans date, le refus était éternel, alors que la même
+information saisie à la main dans la vue Corrections périmait déjà : deux durées de vie pour un
+seul fait, dont l'une n'avait jamais été décidée.
+
 **⬓ Déposer** est la troisième sortie du fret, et elle marche **même là où le comptoir ne reprend
 rien** — c'est précisément le cas où elle sert. Le fret quitte la soute sans être vendu : ni perdu,
 ni encaissé, du capital immobilisé qui reste tracé.

--- a/app.js
+++ b/app.js
@@ -13,7 +13,7 @@ import {
   multiTrips, tripMetrics, legFromTrip,
   legFromRoute, legsFromLoop, legsFromChain, legFromManifest, stopSuggestions, bestLegBetween,
   manifestJourneyState, manifestIntent, sameIntent, manifestIntentSurvives, legsToPin, journeyMap,
-  loadHold, holdScu, freeCargo, holdByCommodity, sellFromHold, refuseHere, sellableAt, sellAllAt,
+  loadHold, holdScu, freeCargo, holdByCommodity, sellFromHold, refuseHere, refusActif, migrerRefus, sellableAt, sellAllAt,
   offloadPlan, storeFromHold, takeFromStore, stockApres,
   startJourney, startJourneyAt, journeyStations, journeyEnd,
   journeyConnects, addToJourney, setJourneyPosition, currentLeg, journeyMargin,
@@ -1347,6 +1347,11 @@ let SOUTE = [];
 function loadSoute() {
   try { SOUTE = JSON.parse(localStorage.getItem(HOLD_KEY)) || []; } catch { SOUTE = []; }
   if (!Array.isArray(SOUTE)) SOUTE = [];
+  // Marqueurs de refus hérités d'avant #20 : sans date, ils seraient tenus pour périmés d'un coup
+  // et un résidu volontairement gardé pourrait partir à la première étape franchie. On leur donne
+  // une fenêtre pleine à partir de maintenant. N'écrit que s'il y avait vraiment à migrer.
+  const m = migrerRefus(SOUTE);
+  if (m.migres) { SOUTE = m.hold; saveSoute(); }
 }
 function saveSoute() { try { localStorage.setItem(HOLD_KEY, JSON.stringify(SOUTE)); } catch {} }
 
@@ -1476,7 +1481,7 @@ function vendreIci(nom, units, idxFige) {
   renderSoute(); refresh();
   const reste = avant - r.vendu;
   showToast(`✓ ${fmt(r.vendu)} SCU de ${nom} vendus — ${fmtSigne(r.profit)} aUEC` +
-    (reste > 0 ? ` · ${fmt(reste)} SCU restent à bord (refusés ici)` : ""));
+    (reste > 0 ? ` · ${fmt(reste)} SCU restent à bord — le comptoir n'en a pas repris plus` : ""));
 }
 
 // Quitter une escale sous-entend qu'on y a fait son affaire : ce qu'elle reprend est vendu.

--- a/docs/superpowers/specs/2026-08-12-soute-et-residus-adr.md
+++ b/docs/superpowers/specs/2026-08-12-soute-et-residus-adr.md
@@ -318,6 +318,21 @@ Règle retenue, qui préserve les deux intentions :
 
 Sans quoi le geste le plus naturel de l'app détruirait silencieusement la donnée la plus précieuse.
 
+#### Amendement (2026-08-14) — le refus périme en 3 h
+
+La règle ci-dessus tient, et elle est conservée telle quelle : un résidu déclaré traverse l'étape.
+Ce qui n'avait jamais été décidé, c'est sa **permanence** — elle n'était que l'effet de bord d'un
+marqueur sans date.
+
+Un comptoir n'est plein que sur **son shard et à cet instant**. En changeant de shard, ou même en se
+reconnectant dix minutes plus tard sur le même, le terminal en reprend. La saturation observée est
+donc une information périssable, au même titre qu'un stock — et la même information saisie à la main
+dans la vue Corrections périmait déjà au bout de `DUREE_VOL`, soit 3 h. Le marqueur `refuse` porte
+désormais sa date et suit cette horloge (`refusActif`, `logic.mjs`).
+
+Le scénario fondateur de cet ADR — vendre 30 SCU sur 2 200 et repartir avec 2 170 — reste
+intégralement protégé : à l'échelle d'un voyage, rien ne change. Voir #20.
+
 ### Les lots, et ce qu'ils imposent
 
 La moyenne pondérée était le choix simple ; elle est écartée au profit du **juste**. La soute est

--- a/logic.mjs
+++ b/logic.mjs
@@ -1664,12 +1664,12 @@ export function holdByCommodity(hold) {
 // `refuse: <station>` et sont alors SAUTÉS. C'est ce qui protège le résidu de la vente implicite
 // déclenchée en avançant d'une étape. Un geste EXPLICITE, lui, ne passe pas `at` et vend quand
 // même : l'intention de l'utilisateur prime toujours sur un marqueur posé plus tôt.
-export function sellFromHold(hold, name, units, price, at = null) {
+export function sellFromHold(hold, name, units, price, at = null, nowSec = Date.now() / 1000) {
   let reste = Math.max(0, Math.floor(units || 0));
   const suivant = [], consommes = [];
   let vendu = 0, cout = 0;
   for (const l of hold) {
-    if (l.name !== name || reste <= 0 || (at && l.refuse === at)) { suivant.push(l); continue; }
+    if (l.name !== name || reste <= 0 || (at && refusActif(l, at, nowSec))) { suivant.push(l); continue; }
     const pris = Math.min(l.units || 0, reste);
     if (pris <= 0) { suivant.push(l); continue; }
     reste -= pris; vendu += pris; cout += pris * (l.paid || 0);
@@ -1697,8 +1697,43 @@ export function stockApres(stock, units) {
 // Marque le reste d'une commodité comme REFUSÉ à cette station : le comptoir n'en a pas voulu.
 // Sans ce marqueur, avancer d'une étape — qui vaut « j'ai tout vendu ici » — effacerait le résidu
 // au moment exact où il devient le sujet.
-export function refuseHere(hold, name, station) {
-  return hold.map((l) => (l.name === name ? { ...l, refuse: station } : l));
+//
+// Le marqueur est DATÉ, et c'est tout le sujet de #20. Un comptoir n'est plein que sur son shard et
+// à cet instant : en changeant de shard, ou simplement dix minutes plus tard, le même terminal en
+// reprend. La saturation observée est donc périssable, exactement comme un stock — et la même
+// information saisie à la main dans la vue Corrections périmait déjà en 3 h. Sans date ici, le
+// refus était éternel : deux durées de vie pour un seul fait, dont l'une n'avait été décidée par
+// personne.
+export function refuseHere(hold, name, station, at = Date.now() / 1000) {
+  return hold.map((l) => (l.name === name ? { ...l, refuse: station, refuseAt: at } : l));
+}
+
+// Ce lot est-il encore protégé à cette station ? UNE règle, consultée par les deux chemins de vente
+// — sinon ils divergent, ce qui est précisément le défaut qu'on corrige.
+// Réemploie `DUREE_VOL`, l'horloge des volumes corrigés : le refus décrit le même phénomène (« ce
+// comptoir ne prend plus »), il n'a aucune raison de vieillir autrement.
+export function refusActif(lot, station, nowSec = Date.now() / 1000, dureeVol = DUREE_VOL) {
+  if (!lot || lot.refuse !== station) return false;
+  // Marqueur sans date : hérité d'avant #20. `migrerRefus` les date au chargement ; si l'un passe
+  // malgré tout, on le tient pour périmé plutôt qu'éternel — un refus d'âge inconnu ne prouve rien.
+  if (!(lot.refuseAt > 0)) return false;
+  return nowSec - lot.refuseAt <= dureeVol;
+}
+
+// Date les marqueurs hérités d'avant #20, au chargement de la soute. Sans cette passe ils seraient
+// tous tenus pour périmés d'un coup (voir `refusActif`) et un résidu volontairement gardé pourrait
+// partir à la première étape franchie. On leur offre donc une fenêtre pleine à partir de
+// maintenant : c'est le seul choix qui ne perd rien.
+// Renvoie { hold, migres } — `migres` vaut 0 quand il n'y avait rien à faire, ce qui permet à
+// l'appelant de n'écrire dans localStorage que s'il le faut.
+export function migrerRefus(hold, nowSec = Date.now() / 1000) {
+  let migres = 0;
+  const suivant = (hold || []).map((l) => {
+    if (!l || !l.refuse || l.refuseAt > 0) return l;
+    migres++;
+    return { ...l, refuseAt: nowSec };
+  });
+  return { hold: migres ? suivant : hold, migres };
 }
 
 // Prix et capacité d'une commodité à un terminal donné, corrections appliquées. null si ce
@@ -1717,7 +1752,7 @@ export function sellableAt(market, terminalIdx, name, resolve) {
 // Vend à ce terminal TOUT ce que la soute peut y écouler — c'est la vente implicite : quitter une
 // escale sous-entend qu'on y a fait son affaire. Ce qu'une vente partielle y a explicitement laissé
 // (`refuse`) traverse l'étape intact. Renvoie { hold, ventes, recette, cout, profit }.
-export function sellAllAt(hold, market, terminalIdx, resolve) {
+export function sellAllAt(hold, market, terminalIdx, resolve, nowSec = Date.now() / 1000) {
   const t = market.terminals[terminalIdx];
   if (!t) return { hold, ventes: [], recette: 0, cout: 0, profit: 0 };
   let courant = hold;
@@ -1726,9 +1761,9 @@ export function sellAllAt(hold, market, terminalIdx, resolve) {
   for (const nom of [...new Set(hold.map((l) => l.name))]) {
     const pt = sellableAt(market, terminalIdx, nom, resolve);
     if (!pt) continue; // ce terminal ne reprend pas cette commodité : elle reste à bord
-    const dispo = courant.reduce((s, l) => s + (l.name === nom && l.refuse !== t.name ? l.units || 0 : 0), 0);
+    const dispo = courant.reduce((s, l) => s + (l.name === nom && !refusActif(l, t.name, nowSec) ? l.units || 0 : 0), 0);
     if (dispo <= 0) continue;
-    const r = sellFromHold(courant, nom, dispo, pt.price, t.name);
+    const r = sellFromHold(courant, nom, dispo, pt.price, t.name, nowSec);
     if (!r.vendu) continue;
     courant = r.hold;
     recette += r.recette; cout += r.cout;

--- a/logic.test.mjs
+++ b/logic.test.mjs
@@ -18,6 +18,7 @@ import {
   manifestJourneyState, manifestIntent, sameIntent, manifestIntentSurvives, legsToPin,
   journeyMap, nameAngle, CARTE, nomPasserelle,
   loadHold, holdScu, freeCargo, holdByCommodity, sellFromHold, storeFromHold, takeFromStore,
+  refusActif, migrerRefus, DUREE_VOL,
   refuseHere, sellableAt, sellAllAt, offloadPlan, stockApres,
   startJourney, startJourneyAt, journeyStations, journeyEnd,
   journeyConnects, addToJourney, setJourneyPosition, currentLeg, journeyMargin,
@@ -3865,4 +3866,79 @@ test("groupOverridesByTerminal purge les volumes périmés AVANT de compter", ()
 test("groupOverridesByTerminal : une station dont tout a péri sort de la bande", () => {
   const store = OV({ "Vieux|Levski|buy": { vol: 12, base: 1, pris: 0 } });
   assert.deepEqual(groupOverridesByTerminal(store, null, 10 * 3600), []);
+});
+
+// ---------- #20 : un refus de comptoir est périssable ----------
+// Un comptoir n'est plein que sur son shard et à cet instant. Le marqueur `refuse` n'avait pas de
+// date, donc il était éternel — alors que la MÊME information saisie à la main dans la vue
+// Corrections périmait en 3 h. Deux durées de vie pour un fait, dont l'une n'avait été décidée par
+// personne.
+const LOT_REFUSE = (at) => [{ name: "Agricium", units: 30, paid: 100, from: "A", refuse: "GrimHEX", refuseAt: at }];
+const MARCHE_REFUS = {
+  terminals: [{ name: "GrimHEX", system: "Stanton" }],
+  commodities: [{ name: "Agricium", buys: [], sells: [[0, 300, null, 0]] }],
+};
+
+test("refusActif : un refus de moins de 3 h protège encore le lot", () => {
+  const maintenant = 10_000;
+  assert.equal(refusActif(LOT_REFUSE(maintenant - 600)[0], "GrimHEX", maintenant), true);
+});
+
+test("refusActif : passé 3 h, le lot redevient vendable ici", () => {
+  const maintenant = 10_000 + DUREE_VOL;
+  assert.equal(refusActif(LOT_REFUSE(10_000)[0], "GrimHEX", maintenant + 1), false);
+  // La borne elle-même reste protégée : on périme APRÈS la durée, pas pile dessus.
+  assert.equal(refusActif(LOT_REFUSE(10_000)[0], "GrimHEX", maintenant), true);
+});
+
+test("refusActif : le refus ne vaut QUE pour sa station", () => {
+  assert.equal(refusActif(LOT_REFUSE(10_000)[0], "Area18", 10_100), false);
+});
+
+test("refusActif : un marqueur sans date est tenu pour périmé, jamais pour éternel", () => {
+  // C'est l'état hérité d'avant #20. `migrerRefus` les date au chargement ; celui qui passerait au
+  // travers ne doit pas rester protégé pour toujours.
+  assert.equal(refusActif({ name: "Agricium", refuse: "GrimHEX" }, "GrimHEX", 10_000), false);
+});
+
+test("vente implicite : un refus frais survit à l'étape, un refus périmé non", () => {
+  const t0 = 10_000;
+  const frais = sellAllAt(LOT_REFUSE(t0), MARCHE_REFUS, 0, (v) => v, t0 + 600);
+  assert.equal(frais.ventes.length, 0, "le reste gardé traverse l'étape — ADR-002 tient");
+  assert.equal(holdScu(frais.hold), 30);
+
+  const perime = sellAllAt(LOT_REFUSE(t0), MARCHE_REFUS, 0, (v) => v, t0 + DUREE_VOL + 1);
+  assert.equal(perime.ventes.length, 1, "trois heures plus tard, le comptoir est réinterrogé");
+  assert.equal(perime.ventes[0].units, 30);
+  assert.equal(holdScu(perime.hold), 0);
+});
+
+test("sellFromHold : la péremption vaut aussi pour le chemin nominal", () => {
+  const t0 = 10_000;
+  assert.equal(sellFromHold(LOT_REFUSE(t0), "Agricium", 30, 300, "GrimHEX", t0 + 600).vendu, 0);
+  assert.equal(sellFromHold(LOT_REFUSE(t0), "Agricium", 30, 300, "GrimHEX", t0 + DUREE_VOL + 1).vendu, 30);
+  // Un geste EXPLICITE (sans `at`) vend quand même, marqueur ou pas : l'intention prime.
+  assert.equal(sellFromHold(LOT_REFUSE(t0), "Agricium", 30, 300).vendu, 30);
+});
+
+test("refuseHere date son marqueur", () => {
+  const [l] = refuseHere([{ name: "Agricium", units: 30 }], "Agricium", "GrimHEX", 4242);
+  assert.equal(l.refuse, "GrimHEX");
+  assert.equal(l.refuseAt, 4242);
+});
+
+test("migrerRefus : les marqueurs hérités reçoivent une fenêtre pleine, pas la péremption", () => {
+  const avant = [{ name: "Agricium", units: 30, refuse: "GrimHEX" }, { name: "Titanium", units: 10 }];
+  const { hold, migres } = migrerRefus(avant, 7777);
+  assert.equal(migres, 1);
+  assert.equal(hold[0].refuseAt, 7777);
+  assert.equal(hold[1].refuseAt, undefined, "un lot sans refus n'est pas touché");
+  assert.equal(refusActif(hold[0], "GrimHEX", 7777), true, "protégé à partir de maintenant");
+});
+
+test("migrerRefus : rien à faire rend le MÊME tableau, pour n'écrire nulle part", () => {
+  const deja = [{ name: "Agricium", units: 30, refuse: "GrimHEX", refuseAt: 100 }];
+  const r = migrerRefus(deja, 7777);
+  assert.equal(r.migres, 0);
+  assert.equal(r.hold, deja);
 });


### PR DESCRIPTION
## Ce que ça change

Vendre 20 SCU sur 50 ne condamne plus les 30 restants à ne jamais repartir de cette station. Le marqueur qui les protège **périme en 3 h**, comme un volume corrigé.

## Pourquoi

**La cause écrite dans l'issue était fausse**, et l'agent qui l'a traitée d'abord a eu raison de s'arrêter : `sellFromHold` rend toujours `vendu = min(demandé, à bord)`, il n'applique aucun plafond de demande. La comparaison que #20 prescrivait ne serait jamais vraie, `refuseHere` deviendrait du code mort, et tout reliquat serait soldé par la vente implicite — exactement ce qu'ADR-002 interdit.

La vraie cause est une **asymétrie**. Le même fait — « ce comptoir ne prend plus » — était enregistré à deux endroits, avec deux durées de vie :

| Origine | Durée de vie |
|---|---|
| Une demande corrigée à 0 dans la vue Corrections | **3 h** (`DUREE_VOL`) |
| Déduit par l'app d'une vente partielle | **pour toujours** |

`refuseHere` posait `{ ...l, refuse: station }` — **aucun horodatage**, alors que le lot porte déjà un champ `at`. La permanence n'avait donc jamais été décidée par personne : c'était l'effet de bord d'une date manquante.

**Et elle est fausse dans le jeu.** Un comptoir n'est plein que sur **son shard et à cet instant** : en changeant de shard, ou simplement dix minutes plus tard sur le même, le terminal en reprend. Une saturation observée est périssable, exactement comme un stock — ce qui explique au passage pourquoi seuls **16 %** des points de vente publient leur capacité, et pourquoi cette donnée signale surtout une route fréquentée.

**Ce n'est pas un renversement d'ADR-002, c'est sa précision.** Le scénario fondateur — vendre 30 SCU sur 2 200 et repartir avec 2 170 — reste intégralement protégé : à l'échelle d'un voyage, rien ne change. L'ADR reçoit son amendement daté.

Trois changements, tous dans `logic.mjs` :

- `refuseHere` **date** son marqueur ;
- **une seule règle**, `refusActif`, remplace les deux tests dispersés (`sellFromHold` et `sellAllAt`) qui pouvaient diverger — c'est précisément le défaut qu'on corrige, il aurait été absurde de le recréer ;
- `migrerRefus` donne aux marqueurs hérités une **fenêtre pleine** au chargement, plutôt que de les périmer d'un coup : sinon un résidu volontairement gardé serait parti à la première étape franchie après la mise à jour.

Le toast cesse aussi d'affirmer plus qu'on ne sait : « le comptoir n'en a pas repris plus » plutôt que « refusés ici ».

## Vérification

**Le rouge**, obtenu en remettant le refus éternel (`refusActif` rendant `true` dès que la station correspond) :

```
✖ refusActif : passé 3 h, le lot redevient vendable ici
✖ refusActif : un marqueur sans date est tenu pour périmé, jamais pour éternel
✖ vente implicite : un refus frais survit à l'étape, un refus périmé non
    AssertionError: trois heures plus tard, le comptoir est réinterrogé
    0 !== 1
✖ sellFromHold : la péremption vaut aussi pour le chemin nominal
ℹ tests 370 · pass 366 · fail 4
```

**Après** — `node --test` → **420 tests, 420 pass, 0 fail** (411 avant, +9). `npx playwright test` → **133 passed, 2 skipped, 0 failed**.

Les neuf tests couvrent : un refus frais protège, un refus de plus de 3 h ne protège plus, la borne exacte (on périme **après** la durée, pas pile dessus), un refus ne vaut que pour sa station, un marqueur sans date est tenu pour périmé et jamais pour éternel, les **deux** chemins de vente, un geste explicite qui passe outre le marqueur, et la migration — y compris son cas « rien à faire », qui doit rendre le même tableau pour n'écrire nulle part.

## Ce qui n'est pas couvert

- **La saisie « vendu ⇄ reste »** (#49) : ergonomie du même panneau, issue distincte, jalon suivant.
- **Faire d'une vente partielle une correction de demande** — l'idée est séduisante, et écartée volontairement : elle enregistrerait comme une mesure durable ce que le shard rend circonstanciel. C'est l'erreur que cette PR corrige ailleurs.
- **Modéliser le restock ou les shards** : impossible, déjà tranché — les inventaires ont quitté les fichiers du jeu au patch 3.20.
- **La durée elle-même** : 3 h par alignement sur `DUREE_VOL`, pas par mesure. Le propriétaire observe des reprises **dix minutes** après reconnexion, donc 3 h est probablement généreux. Inventer une seconde horloge demanderait de la justifier ; on préfère une seule règle, quitte à ce qu'elle soit prudente.

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)
