### PR TITLE
chore(release): v1.0.1 — assainissement

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,11 +486,16 @@ pas la version.
 Quand toutes les issues d'un jalon sont fermées, trois commandes :
 
 ```bash
-npm version 1.0.1 --no-git-tag-version   # bump package.json
+git checkout -b chore/release-v1-0-1        # `main` ne reçoit jamais de commit direct
+npm version 1.0.1 --no-git-tag-version      # bump package.json
 # bump le CACHE de sw.js pour qu'il suive — `node --test` refuse le contraire
-git commit -am "chore(release): v1.0.1" && git push
+git commit -am "chore(release): v1.0.1" && git push -u origin HEAD
+gh pr create --label chore && gh pr merge --merge   # CI verte, puis fusion
+git checkout main && git pull
 gh release create v1.0.1 --generate-notes   # tag + changelog assemblé depuis les PR fusionnées
 ```
+
+Le tag se pose **après** la fusion, sur `main` : il doit désigner le commit réellement déployé.
 
 Les notes sont **générées** à partir des titres de PR : c'est pour ça qu'ils décrivent ce qui change
 pour l'utilisateur plutôt que le fichier qui a bougé.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "best-hauling",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "best-hauling",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.48.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "best-hauling",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Site statique des meilleures routes d'arbitrage de commodités Star Citizen (données UEX Corp).",
   "license": "MIT",
   "author": "0xKestrelNova",

--- a/sw.js
+++ b/sw.js
@@ -5,7 +5,7 @@
 // recevrait encore l'ANCIEN index.html — sans CSP et avec son <script> inline — pendant toute une
 // visite, tandis que rail.js, lui, serait déjà là. `activate` purge tout cache au nom différent :
 // le bump garantit que la nouvelle page et son script arrivent ENSEMBLE.
-const CACHE = "best-hauling-v1.0.0";
+const CACHE = "best-hauling-v1.0.1";
 // Coquille précachée. Les woff2 (mêmes-origine depuis fonts/) sont mis en cache au premier
 // rendu par le gestionnaire fetch ci-dessous (stale-while-revalidate) -> hors-ligne complet.
 const SHELL = ["./", "./index.html", "./app.js", "./rail.js", "./logic.mjs", "./style.css", "./fonts/fonts.css", "./icon.svg", "./manifest.webmanifest"];


### PR DESCRIPTION
## Ce que ça change

Clôture du jalon **v1.0.1 — Assainissement** : **15 issues fermées**, aucune nouveauté. `package.json` passe à `1.0.1`, le cache du service worker suit.

## Pourquoi

Incrément de **correctif** au sens semver, et c'est le bon : le comportement *attendu* n'a pas changé, c'est le comportement *réel* qui s'y conforme enfin.

Le bump du cache n'est pas cosmétique — c'est lui qui garantit qu'un visiteur déjà installé reçoit la nouvelle coquille **en entier**, au lieu de garder l'ancien `index.html` pendant toute une visite (stale-while-revalidate). `scripts/version.test.mjs` refuse désormais qu'il diverge de `package.json`.

**Correction au passage** : la procédure de clôture que j'avais écrite dans le README décrivait un `git commit -am` sur `main`, ce que le dépôt interdit explicitement. Elle passe par une branche et une PR, et précise que le tag se pose **après** la fusion — il doit désigner le commit réellement déployé.

## Vérification

`node --test` → **420 tests, 420 pass, 0 fail**, dont celui qui aurait échoué si le cache n'avait pas suivi.

Jalon vérifié avant bump : `v1.0.1 — Assainissement` → **0 ouverte, 15 fermées**.

## Ce qui n'est pas couvert

Le tag et la release sont posés **après** cette fusion, pas dans cette PR — c'est tout l'objet de la correction de procédure ci-dessus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)