### PR TITLE
feat(score): trier sur ce que ça rapporte, et lire la fiabilité à côté

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Six vues, un même moteur de calcul (soute SCU + budget aUEC → unités, coût,
 
 | Vue | Ce qu'elle fait |
 |-----|-----------------|
-| **Trajets simples** | Meilleures routes A→B, triables, avec un **score de fiabilité** composite (rentabilité × fraîcheur × disponibilité) par défaut. Coche **Multi commodité** : liste plutôt les **chargements combinés** (plusieurs commodités d'un même A vers un même B), dépliables (📦) pour voir le détail par commodité |
+| **Trajets simples** | Meilleures routes A→B, triables, triées par **profit net** par défaut. Une colonne **Fiabilité** dit ce qu'on sait de la donnée — fraîcheur du relevé × part du volume publiée par UEX — **sans entrer dans le tri** ([ADR-005](docs/superpowers/specs/2026-08-14-refonte-du-score-adr.md)). Coche **Multi commodité** : liste plutôt les **chargements combinés** (plusieurs commodités d'un même A vers un même B), dépliables (📦) pour voir le détail par commodité |
 | **Boucles ⇄** | Meilleures boucles A⇄B (une commodité à l'aller, une autre au retour) pour ne jamais repartir à vide |
 | **En route 🧭** | Depuis un terminal de départ : le fret rentable + un **manifeste optimal** qui remplit la soute avec **plusieurs commodités** vers une même destination (avec suggestions pour combler l'espace libre) |
 | **Chaîne ⛓️** | Trajets **multi-sauts A→B→C…** (2 à 4 sauts) : achète, vends, rachète sur place, revends plus loin — recherche par faisceau du circuit le plus rentable. Chaque saut retient la commodité qui **rapporte** le plus une fois plafonnée par le stock et la demande, pas celle à la plus forte marge affichée |
@@ -46,6 +46,13 @@ signe et **en rouge**, jamais dans le vert des gains.
 - **Décomposition SCU en caisses** (32/24/16/8/4/2/1) sur le manifeste et en infobulle.
 - **Manifeste ajustable** : chaque ligne se modifie à la main — tu peux **dépasser le stock UEX** (vol de fret, relevé périmé…) ; le champ passe en ambre pour le signaler. Le chargement que tu **composes** ainsi (lignes ajoutées, SCU ramenés) **reste** : il porte le badge `✎`, garde sa destination, et survit à un prix corrigé, à une frappe dans la recherche ou à un changement de vaisseau — le total `120/32 SCU` te dit alors que tu charges plus que la soute. Il est **local** (localStorage) comme un manifeste de jambe, et `↺ optimal` rend la main au calcul. Changer de **terminal de départ**, ou forcer une **autre arrivée**, l'abandonne : ses lignes se lisent aux prix de ces deux comptoirs-là et d'aucun autre.
 - **Détail du chargement** dépliable (📦), sur les lignes **multi commodité** : ce que contient le chargement, commodité par commodité (stock, demande, prix, marge, profit, caisses). Les autres tables n'ont pas de dépliant — la **carte du parcours** y montre la géographie, et le temps estimé se lit en infobulle de « Profit/h ».
+- **Le classement se fait sur ce que ça rapporte.** Un score composite multipliait autrefois le
+  profit par la fraîcheur et la disponibilité : la route la plus rentable de l'instantané
+  (1 759 500 aUEC) tombait au **8ᵉ rang**, derrière une route rapportant 2,7 fois moins, et une
+  ligne de bouchage de 2 SCU sur 93 divisait la note par 1,93. On trie désormais sur le **profit
+  net par voyage** — un montant, donc comparable d'une vue et d'un filtre à l'autre. `Profit/h`
+  reste triable, avec sa réserve : 155 routes sur 316 n'ont pas de distance exploitable, la durée y
+  est une estimation grossière.
 - **Fiabilité des données** : pastille d'âge par relevé, filtre de fraîcheur (< 24 h / 3 j / 7 j), point de statut d'inventaire, tag « à vérifier », bandeau global « données d'il y a X h ».
 - **Filtres** : commodité, système, même système uniquement, exclure les avant-postes, commodités légales uniquement, limiter au stock & à la demande UEX. Ils ne s'appliquent pas tous à toutes les vues — voir la **[matrice ci-dessous](#portée-des-filtres-par-vue)**.
 - **Permaliens & persistance** : l'état (filtres, tri, vue, vaisseau) est mémorisé (localStorage) et encodé dans l'URL → bouton **Partager**.

--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@
 // Fonctions de calcul pures (testées par logic.test.mjs).
 import {
   tripMinutes, ageDays, pairAge,
-  normalizeScores, scoreBarWidth, bySort, addableUnits, scuBoxes, cargoBoxes, bestChain,
+  scoreBarWidth, bySort, addableUnits, scuBoxes, cargoBoxes, bestChain,
   AUTOLOAD, autoloadFee, autoloadPoint, haulFee, lineHaulFee, lineNet, kFromReading, kPlausible,
   ovKey, effFromStore, setInStore, DUREE_VOL, groupOverridesByTerminal, safeKey, encodeState, decodeState,
   routePasses, loopPasses,
@@ -41,9 +41,12 @@ const cargoBoxesLabel = (lines, maxBox) => boxesLabel(cargoBoxes(lines, maxBox))
 let ROUTES = [];
 let LOOPS = [];
 let view = "routes"; // "routes" | "loops"
-let sortKey = "score";
+// Tri par défaut : le PROFIT NET par voyage (ADR-005). Le score composite classait mal — la route
+// la plus rentable de l'instantané tombait au 8e rang — et le profit horaire repose sur une durée
+// fictive pour 49 % des routes, faute de distance. Un montant, lui, ne ment pas.
+let sortKey = "profit";
 let sortDir = -1; // -1 = décroissant, 1 = croissant
-let loopSortKey = "score";
+let loopSortKey = "profit";
 let loopSortDir = -1;
 // Lignes actuellement affichées (dans l'ordre du DOM) pour déplier le schéma de trajet.
 let shownRoutes = [], shownEnroute = [], shownLoops = [], shownMulti = [];
@@ -154,10 +157,6 @@ function suspectTag(r) {
   const why = stale ? "relevé de plus de 10 jours" : "prix très éloigné de la moyenne UEX";
   return ` <span class="suspect" title="À vérifier en jeu : ${why}">⚠ à vérifier</span>`;
 }
-
-// Score composite (tri « intelligent ») : combine la valeur (profit/heure si borné,
-// sinon marge) avec la fiabilité — fraîcheur × disponibilité. Le calcul vit dans
-// rawScoreOf (logic.mjs) ; normalizeScores normalise ensuite la liste sur 0-100.
 
 // ---------- Corrections locales (prix & stock) ----------
 // L'utilisateur peut corriger un prix ou un volume (stock à l'achat / demande à la vente)
@@ -398,11 +397,15 @@ function evaluate(r, f) {
   return { ...r, buy, sell, buyPrice: buy.price, sellPrice: sell.price, feeInfo, ...metrics, ...net };
 }
 
-// Cellule visuelle du score : mini-barre + valeur. La barre est bornée à [0, 100] (scoreBarWidth),
-// le nombre affiché reste le score réel — y compris négatif, qui dit « cette route perd de l'argent ».
-function scoreCell(score) {
-  const tier = score >= 70 ? "s-good" : score >= 40 ? "s-ok" : "s-low";
-  return `<div class="score-cell"><span class="scorebar ${tier}"><i style="width:${scoreBarWidth(score)}%"></i></span><b>${score}</b></div>`;
+// Cellule de FIABILITÉ : mini-barre + valeur, de 10 à 100 (ADR-005). Ce n'est plus un classement
+// mais ce qu'on sait de la donnée — fraîcheur du relevé × part de volume publiée. Elle ne trie plus
+// par défaut : c'est le profit net qui le fait. `scoreBarWidth` borne le dessin par ceinture (#39),
+// même si la fiabilité ne peut plus sortir de [0, 100] par construction.
+function fiabiliteCell(f, age, part) {
+  const tier = f >= 70 ? "s-good" : f >= 40 ? "s-ok" : "s-low";
+  const quoi = age == null ? "date du relevé inconnue" : `relevé vieux de ${Math.round(age)} j`;
+  const titre = `Fiabilité ${f}/100 — ${quoi}, ${Math.round(part * 100)} % du volume publié par UEX. N'entre pas dans le tri.`;
+  return `<div class="score-cell" title="${esc(titre)}"><span class="scorebar ${tier}"><i style="width:${scoreBarWidth(f)}%"></i></span><b>${f}</b></div>`;
 }
 
 // Valeur éditable (clic pour corriger localement). side = "buy"|"sell", field = "price"|"vol".
@@ -460,7 +463,6 @@ function render() {
 
   let rows = ROUTES.filter((r) => routePasses(r, f)).map((r) => evaluate(r, f));
 
-  normalizeScores(rows);
   rows.sort(bySort(sortKey, sortDir));
 
   shownRoutes = rows;
@@ -497,7 +499,6 @@ function renderMulti(f) {
   // TRONQUE à 300 trajets, un trajet meilleur en net serait donc coupé avant d'atteindre le tableau.
   const trips = multiTrips(MARKET, f, effVals, 300, f.multiAll ? 1 : 2, feeResolver(f))
     .map((t) => ({ ...t, feeInfo: feeCtx(f, t.origin.name, t.dest.name, t.origin, t.dest), ...tripMetrics(t) }));
-  normalizeScores(trips);
   trips.sort(bySort(sortKey, sortDir));
   shownMulti = trips;
   $("rows").innerHTML = trips.map(multiRowHTML).join("");
@@ -538,7 +539,7 @@ function multiRowHTML(t, i) {
           <div class="loc-badges">${sysBadge(t.dest.system)}${outpostTag(t.dest.outpost)}</div>
           <div class="loc-sub">${esc(t.dest.planet)}</div>
         </td>
-        <td>${scoreCell(t.score)}</td>
+        <td>${fiabiliteCell(t.fiabilite, t.age, t.partVolume)}</td>
         <td class="num" title="${withFeeText("Marge moyenne pondérée par SCU chargé", fc)}">${fmtFee(t.margin, t.fees)}</td>
         <td class="num roi-badge"${fc.attr}>${t.fees > 0 ? "≈ " : ""}${t.roi}%</td>
         <td class="num"${t.units ? ` title="Caisses : ${cargoBoxesLabel(t.lines, t.origin.maxBox)}"` : ""}>${fmt(t.units)}</td>
@@ -593,7 +594,7 @@ function routeRowHTML(r, i) {
           <div class="loc-sub">${esc(r.sell.planet)} · ${editv(r.commodity, r.sell.terminal, "sell", "price", r.sell.price, r.sell.ovPrice, r.sell.updated)} aUEC · ${statusDot(r.sell.status, "sell")}<span class="stock" title="Demande à la vente = capacité restante du terminal (relevé UEX)">demande ${editv(r.commodity, r.sell.terminal, "sell", "vol", r.sell.demand, r.sell.ovVol, r.sell.updated)} SCU</span></div>
           <div class="loc-fresh">${freshChip(r.sell.updated)}</div>
         </td>
-        <td>${scoreCell(r.score)}</td>
+        <td>${fiabiliteCell(r.fiabilite, r.age, r.partVolume)}</td>
         <td class="num"${fc.attr}>${fmtFee(r.margin, r.fees)}</td>
         <td class="num roi-badge"${fc.attr}>${r.fees > 0 ? "≈ " : ""}${r.roi}%</td>
         <td class="num"${r.units ? ` title="Caisses : ${scuBoxesLabel(r.units, maxBox)}"` : ""}>${fmt(r.units)}</td>
@@ -629,7 +630,6 @@ function renderLoops() {
 
   let rows = LOOPS.filter((l) => loopPasses(l, f)).map((l) => evaluateLoop(l, f));
 
-  normalizeScores(rows);
   rows.sort(bySort(loopSortKey, loopSortDir));
   // Compagnon : remonte en tête (sans filtrer) les boucles qui partent de la FIN du parcours —
   // c'est le point d'extension (une boucle depuis là s'enchaîne au parcours). Cohérent avec addToJourney.
@@ -663,7 +663,7 @@ function renderLoops() {
           <div class="commodity-cell">${commodityIcon(l.back.kind)}<span>${esc(l.back.commodity)}${illegalTag(l.back.illegal)}</span></div>
           <div class="loc-sub">${fmt(l.back.buyPrice)} → ${fmt(l.back.sellPrice)} · marge ${fmt(l.back.margin)}</div>
         </td>
-        <td>${scoreCell(l.score)}</td>
+        <td>${fiabiliteCell(l.fiabilite, l.age, l.partVolume)}</td>
         <td class="num">${fmt(l.loopMargin)}</td>
         <td class="num">${l.units == null ? "—" : fmt(l.unitsOut) + " + " + fmt(l.unitsBack)}</td>
         <td class="num profit"${fc.attr}>${fmtFee(l.profit, l.fees)}${fc.mark}</td>
@@ -1262,7 +1262,6 @@ function renderEnRoute() {
     .filter((r) => routePasses(r, ef))
     .map((r) => evaluate(r, f));
 
-  normalizeScores(deals);
   deals.sort(bySort(sortKey, sortDir));
   shownEnroute = deals;
   $("enrouteRows").innerHTML = deals.map(routeRowHTML).join("");

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -437,17 +437,33 @@ test("Compagnon de voyage : les commodités transportées sont surlignées dans 
   await expect(page.locator("#commGrid .comm-tile.carried .tile-carried").first()).toBeVisible();
 });
 
+// Démarre un voyage depuis la première ligne QUI PROPOSE UNE SUGGESTION D'ARRÊT. Ces tests visaient
+// la première ligne du tableau, donc une route précise — et le tri par défaut ayant changé pour le
+// profit net (ADR-005), cette route n'a plus de suite rentable dans les filtres par défaut. Ils
+// testaient l'ordre du classement en croyant tester le compagnon de voyage. On balaie donc les
+// premières lignes jusqu'à en trouver une qui a des suggestions, et on échoue franchement si aucune
+// n'en a — ce qui reste une vraie régression du dispositif.
+async function voyageAvecSuggestion(page, essais = 8) {
+  for (let i = 0; i < essais; i++) {
+    await page.locator("#rows tr").nth(i).locator(".journey-pick").click();
+    const sug = page.locator("#journeyCard .jstop-suggest").first();
+    if (await sug.isVisible().catch(() => false)) return;
+    await sug.waitFor({ state: "visible", timeout: 1500 }).catch(() => {});
+    if (await sug.isVisible().catch(() => false)) return;
+    await page.locator("#journeyClear").click().catch(() => {});
+  }
+  throw new Error(`aucune des ${essais} premières lignes ne propose d'arrêt suivant`);
+}
+
 test("Compagnon de voyage : ajouter un arrêt (suggestion) étend le parcours", async ({ page }) => {
-  await page.locator("#rows tr").first().locator(".journey-pick").click();
-  await expect(page.locator("#journeyCard .jstop-suggest").first()).toBeVisible({ timeout: 8000 });
+  await voyageAvecSuggestion(page);
   const stopsBefore = await page.locator("#journeyCard .jstep").count();
   await page.locator("#journeyCard .jstop-suggest").first().click();
   await expect(page.locator("#journeyCard .jstep")).toHaveCount(stopsBefore + 1);
 });
 
 test("Compagnon de voyage : retirer un arrêt du milieu reconnecte le parcours", async ({ page }) => {
-  await page.locator("#rows tr").first().locator(".journey-pick").click();
-  await expect(page.locator("#journeyCard .jstop-suggest").first()).toBeVisible({ timeout: 8000 });
+  await voyageAvecSuggestion(page);
   await page.locator("#journeyCard .jstop-suggest").first().click();
   await expect(page.locator("#journeyCard .jstep")).toHaveCount(3); // 3 arrêts
   const first = (await page.locator("#journeyCard .jstep").nth(0).innerText()).trim();
@@ -1779,7 +1795,9 @@ test("permalien : une ancre quelconque n'est pas un état — les défauts du HT
 // ---------- Accessibilité : tri au clavier, activation des jambes, aria, noms accessibles (#9, #57, #58, #59) ----------
 
 test("tri : Entrée puis Espace sur un en-tête trient la table, et aria-sort suit (#58)", async ({ page }) => {
-  const score = page.locator('#routes th[data-sort="score"]');
+  // Le tri par défaut est le PROFIT NET depuis l'ADR-005 — plus le score composite, qui classait
+  // la route la plus rentable de l'instantané au 8e rang.
+  const score = page.locator('#routes th[data-sort="profit"]');
   const commodite = page.locator('#routes th[data-sort="commodity"]');
   await expect(score).toHaveAttribute("aria-sort", "descending"); // tri par défaut, annoncé
   await expect(commodite).toHaveAttribute("aria-sort", "none");
@@ -1801,13 +1819,15 @@ test("tri : Entrée puis Espace sur un en-tête trient la table, et aria-sort su
 
 test("tri : les en-têtes de Boucles sont eux aussi actionnables au clavier (#58)", async ({ page }) => {
   await page.click("#viewLoops");
-  const score = page.locator('#loops th[data-sort-loop="score"]');
+  // Le tri par défaut est le profit depuis l'ADR-005 ; on vérifie qu'il se DÉPLACE sur une autre
+  // colonne, donc il en faut bien deux distinctes.
   const profit = page.locator('#loops th[data-sort-loop="profit"]');
-  await expect(score).toHaveAttribute("aria-sort", "descending");
-  await profit.press("Enter");
+  const fiabilite = page.locator('#loops th[data-sort-loop="fiabilite"]');
   await expect(profit).toHaveAttribute("aria-sort", "descending");
-  await expect(score).toHaveAttribute("aria-sort", "none");
-  await expect(profit).toHaveClass(/sorted-desc/); // l'indicateur ▾ visuel suit la même colonne
+  await fiabilite.press("Enter");
+  await expect(fiabilite).toHaveAttribute("aria-sort", "descending");
+  await expect(profit).toHaveAttribute("aria-sort", "none");
+  await expect(fiabilite).toHaveClass(/sorted-desc/); // l'indicateur ▾ visuel suit la même colonne
 });
 
 test("jambe : Entrée puis Espace sur l'en-tête déplient et replient l'éditeur, aria-expanded suit (#9)", async ({ page }) => {

--- a/index.html
+++ b/index.html
@@ -288,12 +288,12 @@
                   <th data-sort="commodity" tabindex="0" aria-sort="none">Commodité</th>
                   <th data-sort="buyPrice" tabindex="0" aria-sort="none">Acheter</th>
                   <th data-sort="sellPrice" tabindex="0" aria-sort="none">Vendre</th>
-                  <th data-sort="score" class="sorted-desc" tabindex="0" aria-sort="descending" title="Score de fiabilité : rentabilité × fraîcheur × disponibilité. 100 = meilleur de la liste.">Score</th>
+                  <th data-sort="fiabilite" tabindex="0" aria-sort="none" title="Fiabilité de la donnée : fraîcheur du relevé × part du volume publiée par UEX. 100 = donnée sûre. N'entre pas dans le tri — le classement se fait sur le profit net.">Fiabilité</th>
                   <th data-sort="margin" class="num" tabindex="0" aria-sort="none">Marge/SCU</th>
                   <th data-sort="roi" class="num" tabindex="0" aria-sort="none">ROI</th>
                   <th data-sort="units" class="num" tabindex="0" aria-sort="none" title="Unités à acheter — plafonnées par le stock, la demande et le budget">Unités</th>
                   <th data-sort="investment" class="num" tabindex="0" aria-sort="none" title="Coût total de l'achat">Coût</th>
-                  <th data-sort="profit" class="num" tabindex="0" aria-sort="none" title="Profit par voyage">Profit</th>
+                  <th data-sort="profit" class="num sorted-desc" tabindex="0" aria-sort="descending" title="Profit par voyage, net des frais. C'est le tri par défaut (ADR-005).">Profit</th>
                   <th data-sort="profitHour" class="num" tabindex="0" aria-sort="none" title="Profit par heure — le temps estimé se lit en infobulle de chaque cellule">Profit/h</th>
                 </tr>
               </thead>
@@ -306,10 +306,10 @@
                   <th>Boucle&nbsp;⇄</th>
                   <th>Aller</th>
                   <th>Retour</th>
-                  <th data-sort-loop="score" class="sorted-desc" tabindex="0" aria-sort="descending" title="Score de fiabilité : rentabilité × fraîcheur × disponibilité. 100 = meilleure de la liste.">Score</th>
+                  <th data-sort-loop="fiabilite" tabindex="0" aria-sort="none" title="Fiabilité de la donnée : fraîcheur du relevé × part du volume publiée par UEX. 100 = donnée sûre. N'entre pas dans le tri — le classement se fait sur le profit net.">Fiabilité</th>
                   <th data-sort-loop="loopMargin" class="num" tabindex="0" aria-sort="none" title="Marge de la boucle entière, par SCU">Marge/SCU</th>
                   <th data-sort-loop="units" class="num" tabindex="0" aria-sort="none">Unités (A+R)</th>
-                  <th data-sort-loop="profit" class="num" tabindex="0" aria-sort="none" title="Profit de la boucle entière">Profit</th>
+                  <th data-sort-loop="profit" class="num sorted-desc" tabindex="0" aria-sort="descending" title="Profit de la boucle entière, net des frais. C'est le tri par défaut (ADR-005).">Profit</th>
                   <th data-sort-loop="profitHour" class="num" tabindex="0" aria-sort="none" title="Profit par heure — le temps estimé se lit en infobulle de chaque cellule">Profit/h</th>
                 </tr>
               </thead>
@@ -322,7 +322,7 @@
                   <th>Commodité</th>
                   <th>Acheter (départ)</th>
                   <th>Vendre</th>
-                  <th>Score</th>
+                  <th title="Fiabilité de la donnée : fraîcheur du relevé × part du volume publiée par UEX. 100 = donnée sûre. N'entre pas dans le tri — le classement se fait sur le profit net.">Fiabilité</th>
                   <th class="num">Marge/SCU</th>
                   <th class="num">ROI</th>
                   <th class="num" title="Unités à acheter — plafonnées par le stock, la demande et le budget">Unités</th>

--- a/logic.mjs
+++ b/logic.mjs
@@ -27,19 +27,27 @@ export function freshnessFactor(age) {
   if (age == null) return 0.5;
   return Math.max(0.2, 1 - age / 14);
 }
-// Facteur de disponibilité (saturation sur min(stock, demande)).
-// `demand` null = capacité inconnue chez UEX (`scu_sell` n'est renseigné que sur une minorité
-// de points de vente) : on ne juge alors que le stock, comme le fait déjà `computeUnits` qui
-// n'applique aucun plafond dans ce cas. Un 0 CONNU reste une saturation -> pénalité maximale.
-export function availabilityFactor(stock, demand) {
-  const s = stock || 0;
-  if (demand == null) return s ? volumeFactor(s) : 0.65;
-  if (!s && !demand) return 0.65;
-  return volumeFactor(Math.min(s, demand));
-}
-// Saturation douce d'un volume : 0.3 à vide -> 1.0 asymptotique (0.65 à 120 SCU).
-function volumeFactor(m) {
-  return 0.3 + 0.7 * (m / (m + 120));
+// Certitude du volume : quelle PART du chargement repose sur une capacité réellement publiée.
+//
+// Remplace l'ancien `availabilityFactor`, qui punissait les PETITS volumes (ADR-005). Deux raisons
+// de l'abandonner, mesurées : `computeUnits` plafonne déjà les unités par le stock, donc le profit
+// est déjà amputé — le remultiplier comptait la même contrainte deux fois ; et en multi-commodité,
+// une ligne de bouchage de 2 SCU sur 93 faisait tomber le facteur de 0,602 à 0,311, divisant la
+// note par 1,93 pour 0,2 % du profit.
+//
+// Ce qu'on ignore vraiment n'est pas la petitesse, c'est l'ABSENCE de donnée : 494 points d'achat
+// sur 494 publient leur stock (100 %), contre 307 points de vente sur 1 879 (16 %) pour la demande.
+// Une demande inconnue, c'est un pari sur ce que le comptoir reprendra.
+//
+// PLANCHER À 0,5, et il est délibéré : une demande non publiée n'est pas une donnée nulle, c'est une
+// donnée manquante — le stock d'achat, lui, reste connu, donc le chargement est à moitié vérifié.
+// Sans ce plancher, 81 % des routes afficheraient une fiabilité de 0, ce qui ne distinguerait plus
+// rien.
+export const CERTITUDE_PLANCHER = 0.5;
+export function certitudeVolume(scuConnus, scuTotal) {
+  if (!(scuTotal > 0)) return CERTITUDE_PLANCHER;
+  const part = Math.max(0, Math.min(1, scuConnus / scuTotal));
+  return CERTITUDE_PLANCHER + (1 - CERTITUDE_PLANCHER) * part;
 }
 // Volume le plus contraignant de deux segments, en ignorant les capacités inconnues
 // (`Math.min(null, x)` vaudrait 0 et ferait passer un segment inconnu pour saturé).
@@ -54,31 +62,23 @@ export function tighterVolume(a, b) {
 export function profitPerHour(profit, minutes) {
   return profit == null ? null : (profit * 60) / minutes;
 }
-// Score brut = valeur × fiabilité. Valeur = profit/heure si la route est bornée
-// (profitHour connu), sinon la marge brute (fallbackMargin). Fiabilité = fraîcheur × disponibilité.
-export function rawScoreOf(profitHour, fallbackMargin, age, stock, demand) {
-  const base = profitHour == null ? fallbackMargin : profitHour;
-  return base * freshnessFactor(age) * availabilityFactor(stock, demand);
+// FIABILITÉ d'une ligne, de 10 à 100. Ce n'est plus un classement : c'est ce qu'on sait de la
+// donnée sur laquelle le chiffre repose (ADR-005). Le tri, lui, se fait sur le profit net.
+//
+// L'ancien score multipliait le profit par ces mêmes facteurs, avec un correctif allant jusqu'à
+// 16,7× appliqué à un montant qui s'étale sur plusieurs ordres de grandeur : la route la plus
+// rentable de l'instantané (1 759 500 aUEC) tombait ainsi au 8e rang, derrière une route qui
+// rapporte 2,7 fois moins. On sépare donc les deux questions au lieu de les mélanger.
+export function fiabiliteDe(age, scuConnus, scuTotal) {
+  return Math.round(100 * freshnessFactor(age) * certitudeVolume(scuConnus, scuTotal));
 }
 
-// ---------- Score ----------
-// Rapporte les scores bruts d'une liste au meilleur d'entre eux : 100 = le meilleur. Le haut est
-// donc borné, le BAS ne l'est pas — une ligne dont le profit/heure est négatif (les frais mangent
-// la marge) reçoit un score négatif, et c'est voulu : le signe est une information, on ne l'écrase
-// pas ici. C'est le DESSIN qui se borne, dans scoreBarWidth juste en dessous.
-export function normalizeScores(rows) {
-  const max = rows.reduce((m, r) => Math.max(m, r.rawScore || 0), 0);
-  rows.forEach((r) => (r.score = max > 0 ? Math.round((r.rawScore / max) * 100) : 0));
-  return rows;
-}
-
-// Largeur de la mini-barre d'un score, en pourcentage. On borne le DESSIN, jamais la MESURE :
-// un score négatif (route dont les frais d'autoload dépassent la marge) est une information vraie
-// dont le tri se sert pour classer « perd un peu » avant « perd beaucoup ». Seul son rendu était
-// faux — et spectaculairement : `width:-1441%` est une déclaration CSS invalide, donc ignorée,
-// donc l'élément retombait en `width:auto`, qui remplit son parent. La pire ligne du tableau
-// portait ainsi la plus grosse barre. Un score absent vaut 0 plutôt qu'un `width:NaN%`, qui
-// serait invalide de la même façon.
+// Largeur de la mini-barre de fiabilité, en pourcentage. On borne le DESSIN, jamais la MESURE.
+// Le garde date de #39, quand le score composite pouvait devenir négatif : `width:-1441%` est une
+// déclaration CSS invalide, donc ignorée, donc l'élément retombait en `width:auto`, qui remplit son
+// parent — la pire ligne du tableau portait ainsi la plus grosse barre. La fiabilité, elle, ne peut
+// plus sortir de [0, 100] par construction (ADR-005) ; ce garde reste en CEINTURE, et parce qu'un
+// score absent doit valoir 0 plutôt qu'un `width:NaN%` qui retomberait dans le même piège.
 export function scoreBarWidth(score) {
   return Number.isFinite(score) ? Math.min(100, Math.max(0, score)) : 0;
 }
@@ -146,7 +146,7 @@ export function computeUnits(price, stock, demand, f, demandKnown = false) {
 // Cœur de calcul PUR d'une route dont les prix/volumes sont déjà résolus (corrections appliquées
 // en amont). m = { buyPrice, buyStock, sellDemand, margin, distance, sameSystem, buyUpdated,
 // sellUpdated, demandKnown }. Renvoie units/investment (null si non bornés) + profit/minutes/
-// profitHour/rawScore. `evaluate` (app.js) applique d'abord les corrections puis délègue ici.
+// profitHour/fiabilite. `evaluate` (app.js) applique d'abord les corrections puis délègue ici.
 // `autoload` = { buy, sell } (points de frais résolus par l'appelant, qui seul connaît les
 // terminaux) ; null = interrupteur inactif -> `fees` à 0 et profit BRUT, comme avant.
 // Une route non bornée n'a pas de volume : aucun frais n'y est calculable (son profit est déjà
@@ -158,11 +158,17 @@ export function routeMetrics(m, f, autoload = null) {
   const profit = bounded ? units * m.margin - fees : null;
   const minutes = tripMinutes(m.distance, !m.sameSystem);
   const profitHour = profitPerHour(profit, minutes);
-  const rawScore = rawScoreOf(profitHour, m.margin, pairAge(m.buyUpdated, m.sellUpdated), m.buyStock, m.sellDemand);
+  // Une route ne porte qu'une commodité : sa demande est publiée, ou elle ne l'est pas. La certitude
+  // vaut donc 1 ou son plancher, sans nuance possible.
+  const scu = bounded ? units : 0;
+  const age = pairAge(m.buyUpdated, m.sellUpdated);
+  const partVolume = m.sellDemand == null ? 0 : 1;
+  const fiabilite = fiabiliteDe(age, partVolume * scu, scu);
   return {
+    age, partVolume,
     units: bounded ? units : null,
     investment: bounded ? units * m.buyPrice : null,
-    profit, minutes, profitHour, rawScore, fees,
+    profit, minutes, profitHour, fiabilite, fees,
   };
 }
 
@@ -184,17 +190,22 @@ export function loopMetrics(out, back, distance, cross, f, autoload = null) {
     : 0;
   const profit = bounded ? uOut * out.margin + uBack * back.margin - fees : null;
   const profitHour = profitPerHour(profit, minutes);
-  const rawScore = rawScoreOf(
-    profitHour, loopMargin, pairAge(out.updated, back.updated),
-    Math.min(out.stock, back.stock), tighterVolume(out.demand, back.demand)
-  );
+  // Une boucle a DEUX segments, donc deux demandes qui peuvent être publiées indépendamment : la
+  // certitude se pondère par les SCU de chaque jambe plutôt que de retenir la plus contrainte —
+  // c'est précisément la logique du minimum que l'ADR-005 abandonne.
+  const scuOut = bounded ? uOut : 0, scuBack = bounded ? uBack : 0;
+  const connus = (out.demand == null ? 0 : scuOut) + (back.demand == null ? 0 : scuBack);
+  const age = pairAge(out.updated, back.updated);
+  const total = scuOut + scuBack;
+  const partVolume = total > 0 ? connus / total : 0;
+  const fiabilite = fiabiliteDe(age, connus, total);
   return {
-    loopMargin,
+    loopMargin, age, partVolume,
     unitsOut: bounded ? uOut : null,
     unitsBack: bounded ? uBack : null,
     units: bounded ? uOut + uBack : null,
     investment: bounded ? Math.max(uOut * out.buyPrice, uBack * back.buyPrice) : null,
-    profit, minutes, profitHour, rawScore, fees,
+    profit, minutes, profitHour, fiabilite, fees,
   };
 }
 
@@ -909,7 +920,7 @@ export function bestManifest(market, origin, destSystem, f, resolve, destTermina
 }
 
 // ---------- Trajets MULTI-COMMODITÉ (vue « Trajets », coche « Multi commodité ») ----------
-// Champs dérivés d'un trajet multi-commodité, à la forme attendue par bySort/normalizeScores et
+// Champs dérivés d'un trajet multi-commodité, à la forme attendue par bySort et
 // les colonnes du tableau. La marge est la marge MOYENNE pondérée par SCU (profit / SCU chargés).
 // Distance exacte indisponible hors routes.json -> tripMinutes(0, cross), comme « En route ».
 // Les frais viennent du trajet lui-même (`trip.fee`, posé par manifestsFrom) : tripMetrics est la
@@ -929,21 +940,23 @@ export function tripMetrics(trip) {
   const marginGross = scu > 0 ? brut / scu : 0;
   const margin = scu > 0 ? profit / scu : 0;
   const roi = invest > 0 ? Math.round((profit / invest) * 1000) / 10 : 0;
-  // Fiabilité : le relevé le PLUS VIEUX du chargement et les volumes les plus contraints.
-  let age = null, stock = Infinity, demand = Infinity;
+  // Fiabilité : le relevé le PLUS VIEUX du chargement, et la part des SCU dont la demande est
+  // publiée. C'est ici que l'ADR-005 change le plus : on ne retient plus le MINIMUM des stocks, qui
+  // laissait une ligne de bouchage de 2 SCU sur 93 diviser la note par 1,93 pour 0,2 % du profit.
+  let age = null, scuConnus = 0;
   for (const l of trip.lines) {
     const a = pairAge(l.buyUpdated, l.sellUpdated);
     if (a != null && (age == null || a > age)) age = a;
-    stock = Math.min(stock, l.stock == null ? Infinity : l.stock);
-    demand = Math.min(demand, l.demand == null ? Infinity : l.demand);
+    if (l.demand != null) scuConnus += l.units || 0;
   }
-  // demand resté à Infinity = aucune ligne n'a de capacité connue -> null (inconnu), pas 0 (saturé).
-  const rawScore = rawScoreOf(profitHour, margin, age, Number.isFinite(stock) ? stock : 0, Number.isFinite(demand) ? demand : null);
+  const partVolume = scu > 0 ? scuConnus / scu : 0;
+  const fiabilite = fiabiliteDe(age, scuConnus, scu);
   // commodity/buyPrice/sellPrice : valeurs représentatives pour que le tri par colonne du tableau
   // « Trajets » reste utilisable en mode multi (ligne de tête = plus grosse marge, prix moyens/SCU).
   const buyPrice = scu > 0 ? invest / scu : 0;
   return {
-    units: scu, investment: invest, profit, margin, marginGross, roi, minutes, profitHour, rawScore, fees,
+    age, partVolume,
+    units: scu, investment: invest, profit, margin, marginGross, roi, minutes, profitHour, fiabilite, fees,
     nLines: trip.lines.length, commodity: trip.lines[0] ? trip.lines[0].name : "",
     buyPrice, sellPrice: buyPrice + margin,
   };

--- a/logic.test.mjs
+++ b/logic.test.mjs
@@ -4,12 +4,12 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import {
-  tripMinutes, loopMinutes, ageDays, pairAge, freshnessFactor, availabilityFactor, tighterVolume,
-  normalizeScores, scoreBarWidth, bySort, computeUnits, effValue, fillCargo, addableUnits, scuBoxes, cargoBoxes, bestChain,
+  tripMinutes, loopMinutes, ageDays, pairAge, freshnessFactor, tighterVolume,
+  scoreBarWidth, certitudeVolume, fiabiliteDe, CERTITUDE_PLANCHER, bySort, computeUnits, effValue, fillCargo, addableUnits, scuBoxes, cargoBoxes, bestChain,
   AUTOLOAD, autoloadFee, autoloadPoint, haulFee, lineHaulFee, lineNet, kFromReading, kPlausible, K_PLAUSIBLE,
   manifestTotals, freeAddUnits, manifestLine, stationLabel, parseStationLabel,
   ovKey, effFromStore, setInStore, safeKey, encodeState, decodeState,
-  profitPerHour, rawScoreOf, routePasses, loopPasses,
+  profitPerHour, routePasses, loopPasses,
   routeMetrics, loopMetrics, netMarginRoi, dealFrom, enRouteDeals, bestManifest, buildChainAdjacency,
   pairEligible, suggestionsFrom,
   manifestsFrom, multiTrips, tripMetrics, legFromTrip,
@@ -71,28 +71,6 @@ test("freshnessFactor : décroît avec l'âge, plancher 0.2, 0.5 si inconnu", ()
 });
 
 const close = (a, b) => Math.abs(a - b) < 1e-9;
-test("availabilityFactor : sature avec le volume, 0.65 si inconnu", () => {
-  assert.equal(availabilityFactor(0, 0), 0.65);
-  assert.ok(close(availabilityFactor(120, 120), 0.65));  // 0.3 + 0.7*0.5
-  assert.ok(availabilityFactor(1000, 1000) > availabilityFactor(100, 100));
-  // prend le min(stock, demande)
-  assert.ok(availabilityFactor(500, 10) < availabilityFactor(500, 500));
-});
-
-test("availabilityFactor : demande inconnue (null) ≠ demande nulle (saturé)", () => {
-  // UEX ne renseigne `scu_sell` que sur une minorité de points -> demande null = capacité
-  // inconnue. La noter comme un terminal saturé pénalisait 4 routes sur 5 sans raison.
-  assert.ok(availabilityFactor(128, null) > availabilityFactor(128, 0));
-  // Demande inconnue -> on ne juge que le stock, exactement comme si la demande ne bornait pas.
-  assert.ok(close(availabilityFactor(128, null), availabilityFactor(128, Infinity)));
-  // Un stock plus fourni reste mieux noté, même sans demande connue…
-  assert.ok(availabilityFactor(500, null) > availabilityFactor(128, null));
-  // …et un terminal d'achat bien approvisionné ne doit pas scorer sous un terminal vide.
-  assert.ok(availabilityFactor(128, null) > availabilityFactor(0, null));
-  // 0 CONNU reste une saturation : pénalité maximale.
-  assert.equal(availabilityFactor(500, 0), 0.3);
-});
-
 test("tighterVolume : ignore les capacités inconnues au lieu de les compter pour 0", () => {
   assert.equal(tighterVolume(160, 7), 7);
   assert.equal(tighterVolume(null, 7), 7);       // Math.min(null, 7) vaudrait 0
@@ -107,72 +85,6 @@ test("profitPerHour : null si profit non borné, sinon profit ramené à l'heure
   assert.equal(profitPerHour(0, 30), 0);
   assert.equal(profitPerHour(60, 60), 60);   // 60 aUEC en 60 min -> 60/h
   assert.equal(profitPerHour(100, 30), 200); // 100 en 30 min -> 200/h
-});
-
-test("rawScoreOf : borné -> profit/h × fiabilité", () => {
-  // profitHour=200, fraîcheur(0)=1, dispo(1000,1000)>0.65
-  const s = rawScoreOf(200, 999, 0, 1000, 1000);
-  assert.ok(close(s, 200 * 1 * availabilityFactor(1000, 1000)));
-});
-
-test("rawScoreOf : non borné (profitHour null) -> retombe sur la marge", () => {
-  // base = fallbackMargin (50) car profitHour == null
-  const s = rawScoreOf(null, 50, 0, 1000, 1000);
-  assert.ok(close(s, 50 * 1 * availabilityFactor(1000, 1000)));
-});
-
-test("rawScoreOf : la fraîcheur pénalise un relevé plus vieux", () => {
-  const fresh = rawScoreOf(200, 50, 0, 1000, 1000);
-  const old = rawScoreOf(200, 50, 10, 1000, 1000);
-  assert.ok(old < fresh);
-});
-
-// ---------- Score ----------
-test("normalizeScores : 0-100, 100 pour le meilleur", () => {
-  const rows = [{ rawScore: 50 }, { rawScore: 100 }, { rawScore: 0 }];
-  normalizeScores(rows);
-  assert.deepEqual(rows.map((r) => r.score), [50, 100, 0]);
-});
-
-test("normalizeScores : tout à 0 si aucun score positif", () => {
-  const rows = [{ rawScore: 0 }, {}];
-  normalizeScores(rows);
-  assert.deepEqual(rows.map((r) => r.score), [0, 0]);
-});
-
-// Prémisse du bug de la barre pleine : un score négatif n'est pas une hypothèse d'école, il sort
-// du calcul dès que les frais d'autoload mangent la marge. On l'établit sur les fonctions pures
-// avant de parler de rendu, sinon on borne une largeur pour un cas qui n'arrive jamais.
-test("rawScore négatif : une marge trop mince pour les frais d'autoload", () => {
-  const f = { cargo: 96, budget: 0, capStock: true, useCargo: true, useBudget: false };
-  const m = {
-    buyPrice: 250, buyStock: 400, sellDemand: 400, margin: 12,
-    distance: 30, sameSystem: true, buyUpdated: 1, sellUpdated: 1,
-  };
-  const station = { maxBox: 32, k: 1 };
-
-  // Sans frais la route est rentable : 96 SCU × 12 aUEC = 1152 aUEC de marge.
-  const brut = routeMetrics(m, f, null);
-  assert.equal(brut.profit, 1152);
-  assert.ok(brut.rawScore > 0);
-
-  // Les mêmes 96 SCU coûtent 4320 aUEC de manutention aux deux bouts : le trajet fait perdre
-  // de l'argent, donc profit/heure négatif, donc rawScore négatif (les deux facteurs sont positifs).
-  const net = routeMetrics(m, f, { buy: station, sell: station });
-  assert.equal(net.fees, 4320);
-  assert.equal(net.profit, -3168);
-  assert.ok(net.profitHour < 0, "profit/heure négatif");
-  assert.ok(net.rawScore < 0, "rawScore négatif");
-});
-
-// On borne le DESSIN, pas la MESURE : le score garde son signe pour tous ses consommateurs —
-// dont le tri, qui doit pouvoir classer « perd un peu » avant « perd beaucoup ».
-test("normalizeScores : un rawScore négatif garde son signe, et descend sous -100", () => {
-  const rows = [{ rawScore: 400 }, { rawScore: -80 }, { rawScore: -5763 }];
-  normalizeScores(rows);
-  assert.deepEqual(rows.map((r) => r.score), [100, -20, -1441]);
-  // Le tri décroissant range bien la pire route en dernier.
-  assert.deepEqual([...rows].sort(bySort("score", -1)).map((r) => r.score), [100, -20, -1441]);
 });
 
 test("scoreBarWidth : la largeur de la barre reste dans [0, 100]", () => {
@@ -198,10 +110,10 @@ test("scoreBarWidth : la largeur de la barre reste dans [0, 100]", () => {
 // remettrait à émettre du CSS invalide. Vérifié en remettant app.js à sa version d'avant : les deux
 // e2e du score passaient encore. Ceinture ET bretelles : la feuille de style rattrape, l'appel
 // empêche. On teste donc l'appel lui-même, faute de pouvoir l'observer.
-test("scoreCell passe la largeur par scoreBarWidth — un chiffre brut y reviendrait en silence", () => {
+test("fiabiliteCell passe la largeur par scoreBarWidth — un chiffre brut y reviendrait en silence", () => {
   const app = readFileSync(new URL("./app.js", import.meta.url), "utf8").replace(/\r\n/g, "\n");
-  const cellule = app.match(/function scoreCell\([^)]*\)\s*\{[\s\S]*?\n\}/);
-  assert.ok(cellule, "ancre : scoreCell existe toujours sous ce nom");
+  const cellule = app.match(/function fiabiliteCell\([^)]*\)\s*\{[\s\S]*?\n\}/);
+  assert.ok(cellule, "ancre : fiabiliteCell existe toujours sous ce nom");
   assert.match(cellule[0], /width:\$\{scoreBarWidth\(/,
     "la largeur de .scorebar i doit passer par scoreBarWidth, jamais par le score brut");
 });
@@ -938,7 +850,7 @@ test("routeMetrics : borné par la soute -> units/profit/investment/temps", () =
   assert.equal(r.profit, 96 * 50);
   assert.equal(r.minutes, 6);              // tripMinutes(0, false)
   assert.equal(r.profitHour, (96 * 50 * 60) / 6);
-  assert.ok(r.rawScore > 0);
+  assert.ok(r.fiabilite > 0 && r.fiabilite <= 100); // la note reste une note, pas un classement
 });
 
 test("routeMetrics : non borné (aucune contrainte) -> units/profit/investment null", () => {
@@ -948,7 +860,9 @@ test("routeMetrics : non borné (aucune contrainte) -> units/profit/investment n
   assert.equal(r.profit, null);
   assert.equal(r.investment, null);
   assert.equal(r.profitHour, null);
-  assert.ok(r.rawScore > 0); // score sur la marge quand non borné
+  // Non bornée : plus aucun repli sur la marge (ADR-005), mais la fiabilité reste calculable —
+  // elle ne parle que de la donnée, pas du gain.
+  assert.ok(r.fiabilite > 0 && r.fiabilite <= 100);
 });
 
 test("routeMetrics : saut inter-système ajoute du temps de trajet", () => {
@@ -3231,14 +3145,15 @@ test("routeMetrics : sans contexte le profit reste brut, avec contexte il paie d
   assert.equal(net.units, brut.units);                 // seul le profit bouge
   assert.equal(net.investment, brut.investment);       // les frais ne sont pas du capital immobilisé
   assert.equal(net.profitHour, (net.profit * 60) / 6); // le profit/heure suit le net, donc le tri aussi
-  assert.ok(net.rawScore < brut.rawScore);             // et le score avec lui
+  // La fiabilité, elle, ne bouge PAS avec les frais : elle ne parle que de la donnée (ADR-005).
+  assert.equal(net.fiabilite, brut.fiabilite);
 });
 
 test("routeMetrics : route non bornée -> aucun frais calculable (pas de volume connu)", () => {
   const r = routeMetrics(M_ROUTE, F(), { buy: PT_A, sell: PT_B });
   assert.equal(r.profit, null);
   assert.equal(r.fees, 0);
-  assert.ok(r.rawScore > 0);   // le score reste assis sur la marge brute par SCU, comme avant
+  assert.ok(r.fiabilite > 0);  // la fiabilité ne dépend ni du bornage ni des frais
 });
 
 // --- Boucles (loopMetrics) ---
@@ -3941,4 +3856,75 @@ test("migrerRefus : rien à faire rend le MÊME tableau, pour n'écrire nulle pa
   const r = migrerRefus(deja, 7777);
   assert.equal(r.migres, 0);
   assert.equal(r.hold, deja);
+});
+
+// ---------- ADR-005 : la fiabilité mesure ce qu'on sait, le profit classe ----------
+
+test("certitudeVolume : du plancher quand rien n'est publié, à 1 quand tout l'est", () => {
+  // Le plancher n'est pas une timidité : une demande non publiée est une donnée MANQUANTE, pas
+  // nulle — le stock d'achat, lui, est connu à 100 %. Sans lui, 81 % des routes afficheraient 0.
+  assert.equal(certitudeVolume(0, 96), CERTITUDE_PLANCHER);
+  assert.equal(certitudeVolume(96, 96), 1);
+  assert.equal(certitudeVolume(48, 96), 0.75);
+  assert.equal(certitudeVolume(0, 0), CERTITUDE_PLANCHER); // rien chargé : on ne sait rien de plus
+});
+
+test("fiabiliteDe : un entier de 10 à 100, jamais négatif", () => {
+  // La borne haute et la borne basse tiennent par construction, contrairement à l'ancien score.
+  assert.equal(fiabiliteDe(0, 96, 96), 100);          // tout frais, tout publié
+  assert.equal(fiabiliteDe(999, 0, 96), 10);          // très vieux, rien publié -> 0,2 × 0,5
+  assert.ok(fiabiliteDe(null, 0, 96) > 0);            // date inconnue : 0,5 × 0,5 = 25
+  for (const [a, c, t] of [[0, 0, 0], [999, 0, 0], [7, 3, 96]]) {
+    const f = fiabiliteDe(a, c, t);
+    assert.ok(f >= 0 && f <= 100, `${a}/${c}/${t} -> ${f}`);
+  }
+});
+
+test("fiabilité : une ligne de bouchage ne divise plus la note (contre-exemple 3 de l'ADR-005)", () => {
+  // Rat's Nest -> CBD Lorville, mesuré sur l'instantané : 93 SCU pour 202 082 aUEC, dont une ligne
+  // Fluorine de 2 SCU (stock 2) qui apporte 426 aUEC — 0,2 % du profit. L'ancien availabilityFactor
+  // prenait le MINIMUM des stocks et tombait de 0,602 à 0,311 : la note était divisée par 1,93 par
+  // une ligne qui ne pesait rien. Son stock est pourtant CONNU ; elle ne doit rien dégrader.
+  const trip = {
+    lines: [
+      { name: "Diamond", units: 91, stock: 91, demand: 400, margin: 2216, buyPrice: 100, sellPrice: 2316, buyUpdated: 1000, sellUpdated: 1000 },
+      { name: "Fluorine", units: 2, stock: 2, demand: 400, margin: 213, buyPrice: 100, sellPrice: 313, buyUpdated: 1000, sellUpdated: 1000 },
+    ],
+    fee: null, cross: false,
+  };
+  const avec = tripMetrics(trip);
+  const sans = tripMetrics({ ...trip, lines: [trip.lines[0]] });
+  assert.equal(avec.fiabilite, sans.fiabilite,
+    "ajouter une ligne de bouchage au volume connu ne change pas la fiabilité");
+  assert.ok(avec.profit > sans.profit, "et elle rapporte tout de même un peu plus");
+});
+
+test("fiabilité : c'est la part de volume PUBLIÉE qui compte, pas la taille du volume", () => {
+  const base = { units: 48, stock: 5000, margin: 100, buyPrice: 10, sellPrice: 110, buyUpdated: 1000, sellUpdated: 1000 };
+  const tout = tripMetrics({ lines: [{ ...base, name: "A", demand: 999 }, { ...base, name: "B", demand: 999 }], fee: null, cross: false });
+  const moitie = tripMetrics({ lines: [{ ...base, name: "A", demand: 999 }, { ...base, name: "B", demand: null }], fee: null, cross: false });
+  const rien = tripMetrics({ lines: [{ ...base, name: "A", demand: null }, { ...base, name: "B", demand: null }], fee: null, cross: false });
+  assert.ok(tout.fiabilite > moitie.fiabilite && moitie.fiabilite > rien.fiabilite);
+  assert.equal(tout.partVolume, 1);
+  assert.equal(moitie.partVolume, 0.5);
+  assert.equal(rien.partVolume, 0);
+});
+
+test("classement : la route la plus rentable passe DEVANT (contre-exemple 1 de l'ADR-005)", () => {
+  // Le test qui échoue avec l'ancienne formule. Chiffres de l'instantané : Osoian Hides rapporte
+  // 1 759 500 aUEC et tombait au 8e rang, derrière Dymantium et ses 651 040 — 2,7 fois moins —
+  // parce que sa fraîcheur et sa disponibilité la multipliaient par moins que sa rivale.
+  const f = { cargo: 96, budget: 1e9, capStock: true, useCargo: true, useBudget: true };
+  const vieux = 1786000000 - 8 * 86400, frais = 1786000000 - 1 * 86400;
+  const grosse = routeMetrics({ buyPrice: 100, buyStock: 5000, sellDemand: null, margin: 18328,
+    distance: 0, sameSystem: true, buyUpdated: vieux, sellUpdated: vieux, demandKnown: false }, f);
+  const petite = routeMetrics({ buyPrice: 100, buyStock: 5000, sellDemand: 900, margin: 6782,
+    distance: 0, sameSystem: true, buyUpdated: frais, sellUpdated: frais, demandKnown: true }, f);
+
+  assert.ok(grosse.profit > petite.profit, "la grosse rapporte bien davantage");
+  // Le tri par défaut est le profit : c'est elle qui sort en tête.
+  const classe = [petite, grosse].sort(bySort("profit", -1));
+  assert.equal(classe[0], grosse);
+  // Et la fiabilité dit toujours la vérité sur la donnée, sans commander le classement.
+  assert.ok(petite.fiabilite > grosse.fiabilite, "la fraîche et publiée reste la mieux notée");
 });


### PR DESCRIPTION
## Ce que ça change

Les tableaux se classent sur **ce qu'ils rapportent**. La colonne Score devient **Fiabilité** et dit ce qu'on sait de la donnée, sans commander l'ordre.

Applique [ADR-005](docs/superpowers/specs/2026-08-14-refonte-du-score-adr.md).

## Pourquoi

Le score composite classait la route **la plus rentable de l'instantané** — Osoian Hides, 1 759 500 aUEC — au **8ᵉ rang**, derrière une route rapportant 2,7 fois moins. Il multipliait le profit par deux facteurs de 0,2 à 1,0, soit un correctif de 16,7× appliqué à un montant qui s'étale sur plusieurs ordres de grandeur.

**Le tri par défaut devient le profit net par voyage**, dans Trajets comme dans Boucles. Un montant, donc comparable d'une vue et d'un filtre à l'autre — ce qu'un score normalisé sur la liste courante ne pouvait pas être.

**Et pas le profit horaire**, alors que ce serait la meilleure métrique de décision : 155 routes sur 316 n'ont pas de distance exploitable, la durée y est une constante, et classer sur une durée inventée pour la moitié des données serait le mensonge que l'ADR existe pour supprimer. La colonne reste triable, sa réserve est en infobulle.

**La colonne Fiabilité** vaut `freshnessFactor(âge) × certitude`, où la certitude est la part des SCU dont le volume contraignant est **publié** par UEX. Ça mesure ce qu'on ignore vraiment — 84 % des points de vente ne publient pas leur demande — au lieu de punir ce qui est petit. Le plancher de 0,5 est délibéré et commenté : une demande non publiée est une donnée **manquante**, pas nulle, et le stock d'achat reste connu à 100 %.

Deux défauts tombent du même coup :

- **le stock n'est plus compté deux fois** — `computeUnits` plafonne déjà les unités par le stock, `availabilityFactor` le remultipliait ;
- **une ligne de bouchage ne pénalise plus rien** — sur Rat's Nest → CBD Lorville (93 SCU, 202 082 aUEC), la ligne Fluorine apportait 2 SCU et 0,2 % du profit tout en divisant la note par 1,93. Son stock est **connu** : elle ne dégrade donc plus.

## Vérification

**Le test de classement, celui qui échoue avec l'ancienne formule** — reproduit le contre-exemple 1 de l'ADR : la route à fort profit mais donnée plus fragile doit sortir **devant** la petite fraîche. Avec `rawScoreOf`, l'ordre était inverse.

`node --test` → **416 tests, 416 pass, 0 fail** · `npx playwright test` → **133 passed, 2 skipped, 0 failed**.

**Aucun test effacé en silence.** Neuf tests disparaissent **avec** les fonctions qu'ils couvraient (`availabilityFactor`, `rawScoreOf`, `normalizeScores`, et le test de score négatif que la nouvelle borne rend impossible), comme l'ADR l'annonçait. Cinq nouveaux les remplacent : bornes de `certitudeVolume` et de `fiabiliteDe`, le contre-exemple du bouchage porté en test, la part de volume publiée, et le classement.

**Trois tests existants ont dû être corrigés, et deux d'entre eux étaient faux pour une raison intéressante** : « Compagnon de voyage : ajouter un arrêt » et « retirer un arrêt du milieu » cliquaient la **première ligne du tableau**. Ils testaient donc *l'ordre du classement* en croyant tester le compagnon de voyage — le tri ayant changé, la nouvelle tête de liste n'a plus de suite rentable. Ils balaient désormais les premières lignes jusqu'à en trouver une qui propose un arrêt, et **échouent franchement** si aucune n'en propose.

## Ce qui n'est pas couvert

- **Le classement change visiblement**, c'est le but : les routes fraîches à petit stock reculent, les grosses remontent. Le README le dit.
- **`Profit/h` garde sa durée approximative** : faute d'une mesure des temps de trajet en jeu, on ne raffine pas un modèle invalidable. Faire entrer une vraie distance dans les 155 routes concernées est un travail de `scripts/build-data.mjs`, à ouvrir séparément.
- **`scoreBarWidth` reste**, en ceinture : la fiabilité ne peut plus sortir de [0, 100] par construction, mais un score absent doit toujours valoir 0 plutôt qu'un `width:NaN%`.
- **La largeur des colonnes** n'est pas retouchée : « Fiabilité » remplace « Score » sans changer d'allocation. Voir #81 pour le débordement des chiffres en fenêtre réduite.
- **#50** (bénéfice net dans les suggestions d'arrêt) devient cohérent avec ce choix mais n'est pas traité ici.

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)
