### PR TITLE
fix(ci): les tests de jambe ne dépendent plus de l'ordre du classement

### DIFF
--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -1286,7 +1286,7 @@ test("Compagnon de voyage : une suggestion filtrée par la vue n'est jamais prop
 //
 // On balaie donc les premières lignes jusqu'à en trouver une qui convient, et on échoue franchement
 // si aucune ne convient : ça, ce serait une vraie régression de l'éditeur de jambe.
-async function ouvrirUneJambeEditable(page, essais = 10) {
+async function ouvrirUneJambeEditable(page, essais = 10, convient = null) {
   for (let i = 0; i < essais; i++) {
     const lignes = page.locator("#rows tr");
     if (i >= (await lignes.count())) break;
@@ -1294,11 +1294,16 @@ async function ouvrirUneJambeEditable(page, essais = 10) {
     const charge = page.locator("#journeyCard .jcargo-item").first();
     if (await charge.isVisible({ timeout: 4000 }).catch(() => false)) {
       await page.locator("#journeyCard .jleg-head").first().click();
-      if (await page.locator("#journeyCard .jman").isVisible({ timeout: 2000 }).catch(() => false)) return;
+      if (await page.locator("#journeyCard .jman").isVisible({ timeout: 2000 }).catch(() => false)) {
+        if (!convient || (await convient())) return;
+      }
     }
     await page.locator("#journeyClear").click().catch(() => {});
+    // Un voyage effacé laisse une entrée vide dans le store d'intentions : on la retire, sinon les
+    // tests qui vérifient « aucune intention enregistrée » liraient les traces du balayage.
+    await page.evaluate(() => localStorage.removeItem("best-hauling-journey-edits-v2"));
   }
-  throw new Error("aucune des premières lignes ne mène à une jambe au manifeste éditable");
+  throw new Error("aucune des premières lignes ne mène à une jambe qui convienne");
 }
 
 test("Compagnon de voyage : éditer le manifeste d'une jambe (SCU) persiste hors lien", async ({ page }) => {
@@ -1316,11 +1321,21 @@ test("Compagnon de voyage : éditer le manifeste d'une jambe (SCU) persiste hors
 
 // Déplie l'éditeur de la 1re jambe et vide les SCU de chaque ligne (1 SCU) pour libérer la soute,
 // quel que soit le manifeste optimal du jour -> il reste forcément de la place à suggérer.
-async function openLegEditorWithFreeSpace(page) {
-  await ouvrirUneJambeEditable(page);
-  const qty = page.locator("#journeyCard .jman-qty");
-  for (let i = 0; i < (await qty.count()); i++) await qty.nth(i).fill("1");
-  await qty.first().blur();
+// Ouvre une jambe ET libère de la place — assez pour qu'une saisie de plusieurs dizaines de SCU
+// laisse encore des SCU libres. Sans ce seuil, la boîte de suggestions disparaît en cours de test
+// sur une jambe étroite, et l'assertion échoue sur un élément absent plutôt que sur son contenu.
+async function openLegEditorWithFreeSpace(page, libresMin = 60) {
+  const libres = async () => {
+    const t = await page.locator("#journeyCard .jman-suggest .suggest-head").innerText().catch(() => "");
+    const m = t.match(/(\d+)\s*SCU libres/i);
+    return m ? Number(m[1]) : 0;
+  };
+  await ouvrirUneJambeEditable(page, 10, async () => {
+    const qty = page.locator("#journeyCard .jman-qty");
+    for (let i = 0; i < (await qty.count()); i++) await qty.nth(i).fill("1");
+    await qty.first().blur();
+    return (await libres()) >= libresMin;
+  });
 }
 
 test("Compagnon de voyage : libérer des SCU dans une jambe propose de quoi remplir", async ({ page }) => {
@@ -1733,7 +1748,10 @@ test("jambe : un ajout refusé pour doublon ne bascule pas la jambe en « édit�
   // Rien n'a été ajouté ET la jambe n'est pas devenue « personnalisée » : sans le correctif,
   // materializeLeg s'exécutait AVANT la garde et gelait le manifeste sur les prix du jour.
   await expect(page.locator("#journeyCard .jleg-edited")).toHaveCount(0);
-  expect(await page.evaluate(() => localStorage.getItem("best-hauling-journey-edits-v2"))).toBeFalsy();
+  // Sur le CONTENU, pas sur la chaîne : un voyage effacé écrit "{}", qui est « truthy » tout en
+  // n'enregistrant aucune intention. C'est l'absence d'intention qu'on veut ici.
+  const edits = await page.evaluate(() => JSON.parse(localStorage.getItem("best-hauling-journey-edits-v2") || "{}"));
+  expect(Object.keys(edits)).toEqual([]);
 });
 
 test("jambe : seule l'intention est persistée, jamais un instantané de marché", async ({ page }) => {

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -1276,11 +1276,33 @@ test("Compagnon de voyage : une suggestion filtrée par la vue n'est jamais prop
   await expect(page.locator("#journeyCard .jcargo-item .illegal")).toHaveCount(0);
 });
 
+// Démarre un voyage depuis la première ligne DONT LA JAMBE A UN MANIFESTE ÉDITABLE.
+//
+// Ces amorces cliquaient la première ligne du tableau. Elles dépendaient donc de l'ORDRE du
+// classement, qui a changé avec l'ADR-005 (tri sur le profit net) : la nouvelle tête de liste mène
+// à une jambe sans manifeste à éditer, et `.jman` n'apparaît jamais. Le défaut n'était pas visible
+// chez moi et l'était en CI — la démonstration qu'un test adossé à « la première ligne » teste le
+// classement en croyant tester autre chose.
+//
+// On balaie donc les premières lignes jusqu'à en trouver une qui convient, et on échoue franchement
+// si aucune ne convient : ça, ce serait une vraie régression de l'éditeur de jambe.
+async function ouvrirUneJambeEditable(page, essais = 10) {
+  for (let i = 0; i < essais; i++) {
+    const lignes = page.locator("#rows tr");
+    if (i >= (await lignes.count())) break;
+    await lignes.nth(i).locator(".journey-pick").click();
+    const charge = page.locator("#journeyCard .jcargo-item").first();
+    if (await charge.isVisible({ timeout: 4000 }).catch(() => false)) {
+      await page.locator("#journeyCard .jleg-head").first().click();
+      if (await page.locator("#journeyCard .jman").isVisible({ timeout: 2000 }).catch(() => false)) return;
+    }
+    await page.locator("#journeyClear").click().catch(() => {});
+  }
+  throw new Error("aucune des premières lignes ne mène à une jambe au manifeste éditable");
+}
+
 test("Compagnon de voyage : éditer le manifeste d'une jambe (SCU) persiste hors lien", async ({ page }) => {
-  await page.locator("#rows tr").first().locator(".journey-pick").click();
-  await expect(page.locator("#journeyCard .jcargo-item").first()).toBeVisible({ timeout: 8000 });
-  await page.locator("#journeyCard .jleg-head").first().click();          // déplie l'éditeur
-  await expect(page.locator("#journeyCard .jman")).toBeVisible();
+  await ouvrirUneJambeEditable(page);
   await page.locator("#journeyCard .jman-qty").first().fill("7");
   await page.locator("#journeyCard .jman-qty").first().blur();
   await expect(page.locator("#journeyCard .jleg-edited")).toHaveCount(1);  // ✎ = manifeste personnalisé
@@ -1295,10 +1317,7 @@ test("Compagnon de voyage : éditer le manifeste d'une jambe (SCU) persiste hors
 // Déplie l'éditeur de la 1re jambe et vide les SCU de chaque ligne (1 SCU) pour libérer la soute,
 // quel que soit le manifeste optimal du jour -> il reste forcément de la place à suggérer.
 async function openLegEditorWithFreeSpace(page) {
-  await page.locator("#rows tr").first().locator(".journey-pick").click();
-  await expect(page.locator("#journeyCard .jcargo-item").first()).toBeVisible({ timeout: 8000 });
-  await page.locator("#journeyCard .jleg-head").first().click();
-  await expect(page.locator("#journeyCard .jman")).toBeVisible();
+  await ouvrirUneJambeEditable(page);
   const qty = page.locator("#journeyCard .jman-qty");
   for (let i = 0; i < (await qty.count()); i++) await qty.nth(i).fill("1");
   await qty.first().blur();
@@ -1700,10 +1719,7 @@ test("les filtres à saisie libre sont débouncés : un mot tapé ne re-rend qu'
 // Ouvre l'éditeur d'une jambe SANS y toucher (le helper ci-dessus, lui, ajuste les SCU et bascule
 // donc la jambe en « éditée » — ce qu'on veut justement éviter ici).
 async function openLegEditorPristine(page) {
-  await page.locator("#rows tr").first().locator(".journey-pick").click();
-  await expect(page.locator("#journeyCard .jcargo-item").first()).toBeVisible({ timeout: 8000 });
-  await page.locator("#journeyCard .jleg-head").first().click();
-  await expect(page.locator("#journeyCard .jman")).toBeVisible();
+  await ouvrirUneJambeEditable(page);
 }
 
 test("jambe : un ajout refusé pour doublon ne bascule pas la jambe en « éditée »", async ({ page }) => {


### PR DESCRIPTION
## Ce que ça change

Répare `main`, dont la CI e2e est rouge depuis la fusion de #85.

## Pourquoi — et une erreur de ma part

**J'ai fusionné #85 alors que sa CI e2e était rouge.** Ma boucle d'attente ne vérifiait que la fusionnabilité de la PR, pas la conclusion des jobs. Le correctif ci-dessous répare la conséquence ; la cause côté procédé est notée.

Sept tests sont tombés, tous passant en local. Ils partaient du même geste : cliquer la **première ligne** du tableau, puis déplier l'éditeur de jambe. Ils dépendaient donc de l'**ordre du classement**, que l'ADR-005 vient de changer pour le profit net — et la nouvelle tête de liste mène à une jambe sans manifeste éditable, donc `.jman` n'apparaît jamais.

Ces tests visaient l'éditeur de jambe ; ils mesuraient le classement. **Qu'ils tiennent en local et cèdent en CI est la démonstration du défaut** : une amorce adossée à « la première ligne » n'énonce aucune propriété stable, elle décrit un jeu de données à un instant donné.

Les trois amorces — `openLegEditorWithFreeSpace`, `openLegEditorPristine`, et un test qui les inlinait — passent derrière `ouvrirUneJambeEditable`, qui balaie les premières lignes jusqu'à en trouver une dont la jambe a un manifeste éditable, et **échoue franchement** si aucune n'en a. Ça, ce serait une vraie régression de l'éditeur.

C'est la même correction que celle déjà appliquée dans #85 à deux tests de suggestions d'arrêt — je n'avais pas vu que six autres partageaient le défaut, parce qu'ils passaient chez moi.

## Vérification

`node --test` → **416 pass, 0 fail** · `npx playwright test` → **133 passed, 2 skipped, 0 failed**.

Les sept tests concernés, isolés : **23 passed, 1 skipped**.

Le vrai juge reste la CI, puisque c'est le seul environnement où le défaut se manifestait.

## Ce qui n'est pas couvert

- **Pourquoi l'ordre diffère entre ma machine et le runner** n'est pas élucidé : même commit, même amorce `data/*.json`, mêmes filtres. Je n'ai pas reproduit en local, y compris avec `CI=1`. Le correctif rend la question sans objet pour ces tests, mais elle reste ouverte si d'autres s'y adossent.
- **Ma procédure de fusion** : à l'avenir je gate le merge sur la conclusion des jobs, pas seulement sur `mergeStateStatus`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)