### PR TITLE
feat(soute): déclarer « j'ai ça à bord » sans voyage, sans jambe et sans manifeste

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,28 @@ Le bouton **`✓ chargé`** sur une jambe dit à l'app « j'ai payé ce manifest
 en prend l'instantané **au prix qu'elle venait d'afficher** — donc sans rien ressaisir. Le panneau
 **Soute** liste alors ce que tu transportes, avec le capital engagé. Re-cliquer annule.
 
+**Deux entrées, pas une.** `✓ chargé` suppose un voyage, une jambe et un terminal qui vend la
+commodité : rien n'y rentre du butin ramassé au sol, d'un vaisseau rangé plein la semaine dernière,
+ni d'une cargaison achetée hors du site. Le bouton **`+ déclarer ce que j'ai à bord`** — présent
+dans **les six vues**, y compris soute vide — ouvre trois champs : la commodité (nom ou code UEX),
+les SCU, et le **prix payé au SCU**. Ce dernier est facultatif : laissé vide, c'est du **butin** au
+coût nul, et la ligne porte alors l'étiquette `butin`, parce que ce zéro fait compter *tout*
+l'encaissement comme profit dans « où écouler ».
+
+Un lot déclaré se comporte ensuite comme n'importe quel autre : il occupe la soute, se vend, se
+dépose, se retire par son ✕, et le manifeste ne remplit que la place qui reste. Deux choses le
+distinguent, et ce sont elles le contrat :
+
+- **il n'appartient à aucune jambe** — aucun `✓ chargé` ne se déclenche pour lui, annuler un
+  chargement ne l'emporte pas, effacer le voyage ne le touche pas ;
+- **il ne vide aucun rayon** — `✓ chargé` déduit le stock de la station parce qu'on vient d'y
+  acheter ; un lot déclaré n'a été pris nulle part que l'app connaisse, et y déduire quoi que ce
+  soit serait inventer un achat.
+
+**Sans voyage, dis où tu es.** Vendre et classer « où écouler » partent d'un terminal. Le champ
+**◈ Je suis à**, sous la soute, le pose — c'est le **même** que le terminal de départ d'« En route »,
+pas une seconde position qui divergerait de la première.
+
 Pourquoi ça compte : jusque-là, une commodité ajoutée depuis un terminal qui ne la vend pas était
 classée **butin**, donc à **coût nul**. Sur 2 200 SCU achetés 1 000 et revendus 1 400, le profit
 annoncé était de 3 038 000 aUEC au lieu de 868 000 — **250 % de surestimation**, et le classement

--- a/app.js
+++ b/app.js
@@ -13,7 +13,7 @@ import {
   multiTrips, tripMetrics, legFromTrip,
   legFromRoute, legsFromLoop, legsFromChain, legFromManifest, stopSuggestions, bestLegBetween,
   manifestJourneyState, manifestIntent, sameIntent, manifestIntentSurvives, legsToPin, journeyMap,
-  loadHold, holdScu, freeCargo, holdByCommodity, sellFromHold, refuseHere, refusActif, migrerRefus, sellableAt, sellAllAt,
+  loadHold, declarerLot, holdScu, freeCargo, holdByCommodity, sellFromHold, refuseHere, refusActif, migrerRefus, sellableAt, sellAllAt,
   offloadPlan, storeFromHold, takeFromStore, stockApres,
   startJourney, startJourneyAt, journeyStations, journeyEnd,
   journeyConnects, addToJourney, setJourneyPosition, currentLeg, journeyMargin,
@@ -1568,8 +1568,14 @@ function renderEntrepots() {
 // « Où écouler ce qui reste ? » — le détour manuel par la vue Commodités, en un panneau.
 let ecoulerOuvert = false;
 function ecoulerHTML() {
+  if (!ecoulerOuvert || !MARKET) return "";
   const idx = stationCourante();
-  if (!ecoulerOuvert || idx == null || !MARKET) return "";
+  // Une soute DÉCLARÉE peut exister sans le moindre voyage : le panneau n'a alors pas de point de
+  // départ. Rendre "" laissait le clic sans effet visible — on dit ce qui manque, et où le saisir.
+  if (idx == null) {
+    return `<div class="hold-ecouler"><p class="muted">Dis d'abord <b>où tu es</b> : le classement part d'un terminal.
+      Le champ <b>◈ Je suis à</b>, juste dessous, l'attend.</p></div>`;
+  }
   const f = readFilters();
   const dest = offloadPlan(MARKET, SOUTE, idx, f, effVals, feeResolver(f), 5);
   if (!dest.length) {
@@ -1595,6 +1601,94 @@ function ecoulerHTML() {
   return `<div class="hold-ecouler"><div class="ec-head">Où écouler — classé par ce que ça rapporte, prix d'achat déduit</div>${lignes}</div>`;
 }
 
+// ---------- Déclarer « j'ai ça à bord » : la deuxième entrée de la soute (#55) ----------
+// Le repli que l'ADR-002 réservait (option D) et n'avait jamais câblé. Jusqu'ici rien n'entrait en
+// soute sans une jambe de voyage et son « ✓ chargé » : ni le butin ramassé au sol, ni un vaisseau
+// rangé plein la semaine dernière, ni une cargaison achetée hors du site.
+//
+// Carte SÉPARÉE de #holdCard, et c'est tout le point : celle-ci se masque dès que la soute est
+// vide — un bouton posé dedans serait invisible au moment exact où il sert. Elle vit dans
+// #voyageLeft, que switchView ne touche jamais : les six vues l'ont donc, y compris Trajets et
+// Commodités, qui n'ont aucun rapport avec un voyage.
+let declarationOuverte = false;
+
+// `force` : repeindre malgré un champ en cours de saisie. Sans lui, cette carte — rendue à CHAQUE
+// rafraîchissement, donc à chaque frappe ailleurs et à chaque arrivée du marché — détruirait le
+// texte tapé et son focus. Les gestes qui changent VRAIMENT son état (ouvrir, annuler, valider)
+// forcent ; les rendus de passage s'abstiennent.
+function renderDeclaration(force = false) {
+  const box = $("holdDeclare");
+  if (!box) return;
+  if (!force && box.contains(document.activeElement)) return;
+  box.hidden = false;
+  // « Je suis à » : sans voyage, la position EST le terminal de départ d'« En route » — déjà le
+  // repli de stationCourante(). On ne crée pas un second store, on rend le premier atteignable
+  // d'ici : deux positions divergeraient au premier aller-retour entre les deux vues. Avec un
+  // voyage, l'étape courante la dit déjà, et un champ ici mentirait.
+  const position = !JOURNEY && (SOUTE.length || declarationOuverte)
+    ? `<div class="hold-ici">
+         <label for="holdWhere">◈ Je suis à</label>
+         <input id="holdWhere" list="originList" type="text" autocomplete="off" value="${esc($("origin").value)}"
+           placeholder="Tape un terminal (ex : Megumi — Pyro)"
+           title="D'où tu pars. Ce terminal fixe le prix d'une vente et le classement de « où écouler » — c'est le même que le départ d'« En route »." />
+       </div>`
+    : "";
+  const corps = declarationOuverte
+    ? `<div class="hold-add">
+         <input id="holdAddName" list="commodityList" type="text" autocomplete="off" placeholder="Commodité (nom ou code UEX)" aria-label="Commodité à déclarer" />
+         <input id="holdAddScu" type="number" min="1" step="1" placeholder="SCU" aria-label="SCU à bord" />
+         <input id="holdAddPaid" type="number" min="0" step="1" placeholder="prix payé /SCU" aria-label="Prix payé au SCU"
+           title="Laisse vide pour du butin : minage, salvage, caisse trouvée — un coût réellement nul." />
+         <button id="holdAddOk" class="hold-sell-ok" title="Ajouter ce lot à la soute">✓ à bord</button>
+         <button id="holdAddNo" class="hold-sell-no" title="Annuler" aria-label="Annuler">✕</button>
+       </div>
+       <p class="hold-add-hint">Prix vide = <b>butin</b>, coût nul : « où écouler » comptera alors tout l'encaissement comme profit.</p>`
+    : `<button id="holdAddOpen" class="hold-add-open" title="Déclarer du fret déjà à bord : butin ramassé, vaisseau rangé plein, cargaison achetée hors de l'app">+ déclarer ce que j'ai à bord</button>`;
+  // L'en-tête n'apparaît QU'à vide : au-dessus d'une carte Soute déjà titrée, un second « ◈ Soute »
+  // ferait lire deux panneaux là où il n'y en a qu'un.
+  const tete = SOUTE.length ? "" : `<div class="hold-head"><span class="hold-title">◈ Soute</span><span class="muted">vide</span></div>`;
+  box.innerHTML = tete + position + corps;
+}
+
+function ouvrirDeclaration() {
+  // La vue par défaut ne lit que routes.json : sans le graphe, ni autocomplétion ni résolution du
+  // nom saisi. On l'attend plutôt que d'ouvrir un formulaire inerte.
+  if (!MARKET) { withMarket(ouvrirDeclaration); return; }
+  declarationOuverte = true;
+  renderDeclaration(true);
+  $("holdAddName")?.focus();
+}
+function fermerDeclaration() { declarationOuverte = false; renderDeclaration(true); }
+
+// Le geste : cette commodité, ce nombre de SCU, à ce prix. Le prix est FACULTATIF et vaut 0 — du
+// butin n'a rien coûté (ADR-002). Une commodité que le marché ne connaît pas est refusée : l'app ne
+// saurait ni la classer, ni dire où l'écouler, et une ligne muette en soute ne vaut pas mieux que rien.
+function declarerABord() {
+  const c = MARKET && findCommodity($("holdAddName").value);
+  if (!c) { showToast("⚠ Commodité inconnue — choisis-la dans la liste (nom ou code UEX)"); return; }
+  const units = Math.floor(Number($("holdAddScu").value) || 0);
+  if (units <= 0) { showToast(`⚠ Indique combien de SCU de ${c.name} tu as à bord`); return; }
+  const saisi = $("holdAddPaid").value.trim();
+  const prix = saisi === "" ? 0 : Number(saisi);
+  const avant = SOUTE;
+  SOUTE = declarerLot(SOUTE, { name: c.name, units, paid: prix }, nowSec());
+  if (SOUTE === avant) return; // la fonction pure a refusé : rien à persister
+  saveSoute();
+  declarationOuverte = false;
+  renderDeclaration(true);
+  refresh();
+  showToast(`◈ ${fmt(units)} SCU de ${c.name} déclarés à bord — ` +
+    (prix > 0 ? `${fmt(prix)} aUEC/SCU payés` : "butin, coût nul"));
+}
+
+// Poser la position revient à écrire dans le champ de départ d'« En route » : c'est lui que
+// stationCourante() lit sans voyage, et lui que le permalien transporte déjà.
+function poserPosition(v) {
+  $("origin").value = v;
+  resolveOrigin();
+  refresh();
+}
+
 // Débarquer le fret n'est pas le remettre en rayon : le registre des chargements n'est pas touché,
 // donc les jambes restent chargées (🔒 « ⬢ à bord ») et leur déduction reste posée. C'est ce qui
 // garde le chemin « annuler » atteignable — le seul qui rende vraiment son stock à la station.
@@ -1604,8 +1698,16 @@ function retirerLot(i) { SOUTE = SOUTE.filter((_, j) => j !== i); saveSoute(); r
 function renderSoute() {
   const box = $("holdCard");
   if (!box) return;
+  // AVANT le retour anticipé : le point d'entrée « déclarer », lui, doit exister précisément quand
+  // la carte n'existe pas. C'est le seul rendu appelé depuis tous les chemins qui repeignent la soute.
+  renderDeclaration();
   if (!SOUTE.length) { box.hidden = true; return; }
   box.hidden = false;
+  // Du fret à bord et pas de graphe : la vue par défaut ne lit que routes.json, et sans marché la
+  // carte ne sait ni nommer une icône, ni proposer une vente, ni classer « où écouler ». Ça se
+  // voyait peu tant qu'on ne pouvait charger que depuis « En route » — qui le charge ; une soute
+  // déclarée, elle, peut naître sur Trajets et y rester.
+  if (!MARKET) withMarket(renderSoute);
   const groupes = holdByCommodity(SOUTE);
   const ici = stationCourante();
   const scu = holdScu(SOUTE);
@@ -1619,10 +1721,19 @@ function renderSoute() {
     return c ? commodityIcon(c.kind) : "";
   };
   const lignes = groupes.map((g) => {
+    // Un lot DÉCLARÉ n'a pas de terminal d'achat (`from` vide) : le dire, plutôt qu'afficher « ? »
+    // qui laisse croire à une donnée perdue. C'est un fait, pas un trou.
+    const ouCharge = (l) => (l.from ? `Chargé à ${esc(l.from)}` : "Déclaré à la main — aucun terminal d'achat");
     // Le détail des lots n'apparaît que s'il y en a plusieurs : sinon c'est du bruit.
     const lots = g.lots.length > 1
-      ? `<div class="hold-lots">${g.lots.map((l) => `<span class="hold-lot" title="Chargé à ${esc(l.from || "?")}">${fmt(l.units)} SCU @ ${fmt(l.paid)}<button class="hold-del" data-i="${l.i}" title="Retirer ce lot" aria-label="Retirer">✕</button></span>`).join("")}</div>`
+      ? `<div class="hold-lots">${g.lots.map((l) => `<span class="hold-lot" title="${ouCharge(l)}">${fmt(l.units)} SCU @ ${fmt(l.paid)}<button class="hold-del" data-i="${l.i}" title="Retirer ce lot" aria-label="Retirer">✕</button></span>`).join("")}</div>`
       : `<button class="hold-del solo" data-i="${g.lots[0].i}" title="Retirer ce lot" aria-label="Retirer">✕</button>`;
+    // Coût nul : « où écouler » comptera tout l'encaissement comme profit. C'est juste — du butin
+    // n'a rien coûté — mais ça change le sens du chiffre, et ça ne doit pas se deviner.
+    const butin = g.invest === 0
+      ? ` <span class="hold-butin" title="Rien payé pour ce fret : « où écouler » compte donc tout l'encaissement comme profit">butin</span>`
+      : "";
+    const sansAchat = g.lots.every((l) => !l.from) ? " — déclaré à la main, aucun terminal d'achat" : "";
     // Vendre suppose de savoir OÙ l'on est, et que le comptoir reprenne la commodité.
     const pt = ici != null && MARKET ? sellableAt(MARKET, ici, g.name, effVals) : null;
     // Vendre suppose que le comptoir reprenne la commodité ; DÉPOSER, non — c'est justement la
@@ -1643,7 +1754,7 @@ function renderSoute() {
     return `<div class="hold-line">
         <span class="hold-name">${icone(g.name)}${esc(g.name)}</span>
         <span class="hold-scu"><b>${fmt(g.units)}</b> SCU</span>
-        <span class="hold-paid" title="Prix payé au SCU${g.lots.length > 1 ? " (moyenne des lots)" : ""}">@ ${fmt(Math.round(g.paidMoyen))}</span>
+        <span class="hold-paid" title="Prix payé au SCU${g.lots.length > 1 ? " (moyenne des lots)" : ""}${sansAchat}">@ ${fmt(Math.round(g.paidMoyen))}</span>${butin}
         ${vente}
         ${lots}
       </div>`;
@@ -3312,6 +3423,26 @@ async function init() {
     // Entrée doit encaisser à la même station que le bouton ✓ : même index figé, lu sur le conteneur.
     if (e.key === "Enter") { e.preventDefault(); vendreIci(venteEnCours, Number(e.target.value), Number(e.target.closest(".hold-sell")?.dataset.idx)); }
     else if (e.key === "Escape") { e.preventDefault(); venteEnCours = null; renderSoute(); }
+  });
+  // Déclarer « j'ai ça à bord » (#55) : le seul chemin qui fait entrer du fret sans jambe.
+  $("holdDeclare").addEventListener("click", (e) => {
+    if (e.target.closest("#holdAddOpen")) { ouvrirDeclaration(); return; }
+    if (e.target.closest("#holdAddNo")) { fermerDeclaration(); return; }
+    if (e.target.closest("#holdAddOk")) declarerABord();
+  });
+  // Entrée valide depuis n'importe lequel des trois champs, Échap abandonne — même patron que la
+  // vente inline de la soute et que les corrections.
+  $("holdDeclare").addEventListener("keydown", (e) => {
+    if (!e.target.closest(".hold-add")) return;
+    if (e.key === "Enter") { e.preventDefault(); declarerABord(); }
+    else if (e.key === "Escape") { e.preventDefault(); fermerDeclaration(); }
+  });
+  // La position se résout à la frappe, DÉBOUNCÉE comme le champ de départ d'« En route » : c'est le
+  // même champ derrière, et une résolution par caractère repeindrait toute la page à chaque lettre.
+  // On capture la valeur tout de suite : l'événement, lui, sera périmé quand le timer se déclenchera.
+  const poserPositionDifferee = debounce(poserPosition);
+  $("holdDeclare").addEventListener("input", (e) => {
+    if (e.target.id === "holdWhere") poserPositionDifferee(e.target.value);
   });
   // Entrepôts : « reprendre » remet le lot en soute. Un seul geste, pas de champ de quantité — on
   // reprend ce qu'on a laissé ; une reprise partielle se ferait en redéposant. La fonction pure,

--- a/app.js
+++ b/app.js
@@ -1649,11 +1649,19 @@ function renderDeclaration(force = false) {
            title="D'où tu pars. Ce terminal fixe le prix d'une vente et le classement de « où écouler » — c'est le même que le départ d'« En route »." />
        </div>`
     : "";
+  // Les valeurs tapées sont RELUES avant le repeint et réémises, comme le fait déjà `holdWhere`
+  // juste au-dessus. La garde de focus ne suffisait pas : elle protège tant que le curseur est dans
+  // la carte, mais un geste fait AILLEURS — toucher la soute, changer de vue — repeignait des
+  // champs sans `value` et effaçait la saisie en silence, le formulaire restant ouvert et vide.
+  // C'est la classe de bug que ce dépôt a déjà rencontrée deux fois (#24, et le champ #journeyStart
+  // commenté plus bas) : ici on ne se contente pas de ne pas repeindre, on rend le repeint inoffensif.
+  const saisi = (id) => esc($(id)?.value ?? "");
+  const [nomSaisi, scuSaisi, paidSaisi] = ["holdAddName", "holdAddScu", "holdAddPaid"].map(saisi);
   const corps = declarationOuverte
     ? `<div class="hold-add">
-         <input id="holdAddName" list="commodityList" type="text" autocomplete="off" placeholder="Commodité (nom ou code UEX)" aria-label="Commodité à déclarer" />
-         <input id="holdAddScu" type="number" min="1" step="1" placeholder="SCU" aria-label="SCU à bord" />
-         <input id="holdAddPaid" type="number" min="0" step="1" placeholder="prix payé /SCU" aria-label="Prix payé au SCU"
+         <input id="holdAddName" list="commodityList" type="text" autocomplete="off" value="${nomSaisi}" placeholder="Commodité (nom ou code UEX)" aria-label="Commodité à déclarer" />
+         <input id="holdAddScu" type="number" min="1" step="1" value="${scuSaisi}" placeholder="SCU" aria-label="SCU à bord" />
+         <input id="holdAddPaid" type="number" min="0" step="1" value="${paidSaisi}" placeholder="prix payé /SCU" aria-label="Prix payé au SCU"
            title="Laisse vide pour du butin : minage, salvage, caisse trouvée — un coût réellement nul." />
          <button id="holdAddOk" class="hold-sell-ok" title="Ajouter ce lot à la soute">✓ à bord</button>
          <button id="holdAddNo" class="hold-sell-no" title="Annuler" aria-label="Annuler">✕</button>

--- a/docs/superpowers/specs/2026-08-12-soute-et-residus-adr.md
+++ b/docs/superpowers/specs/2026-08-12-soute-et-residus-adr.md
@@ -205,6 +205,36 @@ sans aucune saisie, en prenant le prix là où il est déjà : dans le manifeste
 calculée — déjà à bord avant d'ouvrir le site, ou obtenue autrement — une ligne ajoutée à la main
 propose de saisir son prix, « butin » restant offert d'un clic pour le vrai coût nul.
 
+#### Amendement (2026-08-15) — le repli est livré, et il n'a ni jambe ni rayon
+
+Le repli ci-dessus est resté **écrit et non câblé** pendant trois semaines : `manifestLine` acceptait
+bien un `paid` explicite, mais aucun appelant de production ne le posait, et la soute n'avait qu'une
+entrée — « ✓ chargé », au bout d'un entonnoir de six gestes qui exige un voyage, une jambe et un
+terminal qui vend la commodité. À vide, la carte Soute était même masquée : aucun bouton nulle part
+ne permettait de *découvrir* la fonctionnalité.
+
+La décision de l'option A n'est pas révisée : « ✓ chargé » reste la voie normale, celle qui prend le
+prix là où il est déjà. Ce qui est livré, c'est la porte que l'ADR promettait à côté —
+`declarerLot(hold, { name, units, paid }, at)` (`logic.mjs`), servie par un bouton **`+ déclarer ce
+que j'ai à bord`** présent dans les six vues, soute vide comprise.
+
+Deux points que l'ADR n'avait pas tranchés, et qui découlent du reste de l'architecture :
+
+- **Un lot déclaré n'a pas de clé `leg`** — pas même `leg: null`. Le registre des chargements
+  (`best-hauling-jambes-chargees`, posé par #21/#22) suppose une jambe : un lot qui n'en a pas n'y
+  entre jamais, `jambeChargee` reste donc faux et l'annulation d'une jambe (`l.leg !== k`) ne
+  l'emporte pas. `detacherLotsDeJambe` et `reindexerRangsJambe` le rendent tel quel.
+- **Un lot déclaré ne corrige aucun stock.** `✓ chargé` vide le rayon parce qu'on vient d'y acheter ;
+  un lot déclaré n'a été pris à aucun point que l'app connaisse — son `from` est vide — et y déduire
+  quoi que ce soit serait inventer un achat. C'est la même règle que « on ne persiste que
+  l'intention », appliquée au stock.
+
+Corollaire d'interface : « où écouler » a besoin d'un point de départ, que le voyage fournissait
+seul. Sans voyage, la position vient du **terminal de départ d'« En route »** — déjà le repli de
+`stationCourante()`. Le champ **◈ Je suis à** de la carte de déclaration écrit dans ce champ-là, et
+non dans un second store : deux positions divergeraient au premier aller-retour entre les deux vues.
+Voir #55.
+
 ## Analyse des compromis
 
 Le vrai arbitrage n'est pas « quelle option », mais **dans quel ordre**, parce que les options ne

--- a/docs/superpowers/specs/2026-08-12-soute-et-residus-adr.md
+++ b/docs/superpowers/specs/2026-08-12-soute-et-residus-adr.md
@@ -224,6 +224,11 @@ Deux points que l'ADR n'avait pas tranchés, et qui découlent du reste de l'arc
   (`best-hauling-jambes-chargees`, posé par #21/#22) suppose une jambe : un lot qui n'en a pas n'y
   entre jamais, `jambeChargee` reste donc faux et l'annulation d'une jambe (`l.leg !== k`) ne
   l'emporte pas. `detacherLotsDeJambe` et `reindexerRangsJambe` le rendent tel quel.
+
+  *Correction du 2026-08-15 : une première rédaction justifiait l'absence de clé en affirmant que
+  `leg: null` « aurait trompé » le filtre d'annulation. C'est faux, et vérifié — `null !== "0|A|B"`
+  conserve le lot, les quatre chemins se comportent à l'identique. La vraie raison est la cohérence
+  avec `sansEtiquette`, qui **supprime** la clé : un lot détaché de sa jambe n'en a déjà plus.*
 - **Un lot déclaré ne corrige aucun stock.** `✓ chargé` vide le rayon parce qu'on vient d'y acheter ;
   un lot déclaré n'a été pris à aucun point que l'app connaisse — son `from` est vide — et y déduire
   quoi que ce soit serait inventer un achat. C'est la même règle que « on ne persiste que

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -944,6 +944,202 @@ test("Soute : reculer d'une étape ne revend rien", async ({ page }) => {
 });
 
 // ---------- Carte 2D du parcours (ADR-001) ----------
+// ---------- Déclarer « j'ai ça à bord » sans passer par une jambe (#55) ----------
+// L'ADR-002 réservait ce repli (option D) sans jamais le câbler : la soute n'avait qu'un robinet,
+// au bout d'un entonnoir de six gestes, et rien n'y entrait sans voyage, jambe et marché chargé.
+
+// Les milliers sont séparés par une espace insécable étroite en fr-FR : on tolère n'importe quelle
+// espace plutôt que de coder en dur le caractère qu'ICU a choisi ce mois-ci.
+const fr = (n) => new RegExp(String(n).replace(/\B(?=(\d{3})+$)/g, "\\s*"));
+
+async function ouvrirDeclaration(page) {
+  await page.locator("#holdAddOpen").click();
+  await expect(page.locator("#holdAddName")).toBeVisible();
+  // Le marché n'est chargé qu'à la demande (la vue par défaut ne lit que routes.json) : c'est le
+  // clic lui-même qui le réclame, et l'autocomplétion arrive avec lui.
+  await expect.poll(() => page.locator("#commodityList option").count()).toBeGreaterThan(0);
+}
+
+async function declarer(page, nom, scu, prix = null) {
+  await ouvrirDeclaration(page);
+  await page.fill("#holdAddName", nom);
+  await page.fill("#holdAddScu", String(scu));
+  if (prix != null) await page.fill("#holdAddPaid", String(prix));
+  await page.locator("#holdAddOk").click();
+  await expect(page.locator("#holdCard")).toBeVisible();
+}
+
+// « Je suis à » : sans voyage, c'est le terminal de départ d'« En route » qui fait office de
+// position — un seul champ pour les deux, pas deux vérités.
+async function positionner(page, label) {
+  await page.fill("#holdWhere", label);
+  await expect(page.locator("#origin")).toHaveValue(label);
+}
+
+// Les commodités proposées par l'autocomplétion, dans l'ordre du marché.
+const commodites = (page) =>
+  page.locator("#commodityList option").evaluateAll((o) => o.map((x) => x.value));
+
+test("Soute : déclarer du fret à bord sans voyage, sans jambe et sans manifeste (#55)", async ({ page }) => {
+  // À vide, la carte Soute est masquée : sans point d'entrée ailleurs, la fonctionnalité était
+  // littéralement indécouvrable — zéro bouton dans la page pour ouvrir quoi que ce soit.
+  await expect(page.locator("#holdCard")).toBeHidden();
+  await expect(page.locator("#holdAddOpen")).toBeVisible();
+
+  await ouvrirDeclaration(page);
+  const nom = (await commodites(page))[0];
+  await page.fill("#holdAddName", nom);
+  await page.fill("#holdAddScu", "220");
+  await page.fill("#holdAddPaid", "1000");
+  await page.locator("#holdAddOk").click();
+
+  await expect(page.locator("#holdCard")).toBeVisible();
+  await expect(page.locator("#holdCard .hold-line")).toContainText(nom);
+  await expect(page.locator("#holdCard .hold-meta")).toContainText(fr(220));
+  await expect(page.locator("#holdCard .hold-meta")).toContainText(fr(220000)); // capital engagé
+
+  // La place libre compte le lot déclaré comme n'importe quel autre : c'est le même fret.
+  await page.fill("#cargo", "1000");
+  await expect(page.locator("#holdCard .hold-meta")).toContainText(/780 libres/);
+
+  const ls = await lots(page);
+  expect(ls.length).toBe(1);
+  expect(ls[0]).toMatchObject({ name: nom, units: 220, paid: 1000, from: "" });
+  // Le contrat du lot manuel : pas de jambe, donc aucune jambe ne prétend l'avoir chargé.
+  expect("leg" in ls[0]).toBe(false);
+  const registre = await page.evaluate(() => localStorage.getItem("best-hauling-jambes-chargees"));
+  expect(JSON.parse(registre || "{}")).toEqual({});
+});
+
+test("Soute : la déclaration est atteignable depuis les SIX vues (#55)", async ({ page }) => {
+  const vues = ["viewRoutes", "viewLoops", "viewEnroute", "viewChain", "viewCorrections", "viewCommodities"];
+  for (const v of vues) {
+    await page.click(`#${v}`);
+    await expect(page.locator("#holdAddOpen"), `point d'entrée soute absent de #${v}`).toBeVisible();
+  }
+  // Et le geste marche vraiment là où rien ne parle de voyage : Commodités, puis Trajets.
+  await page.click("#viewCommodities");
+  await ouvrirDeclaration(page);
+  const noms = await commodites(page);
+  await page.fill("#holdAddName", noms[0]);
+  await page.fill("#holdAddScu", "40");
+  await page.locator("#holdAddOk").click();
+  await expect(page.locator("#holdCard")).toBeVisible();
+  await expect(page.locator("#commodities")).toBeVisible(); // déclarer n'a pas changé de vue
+
+  await page.click("#viewRoutes");
+  await declarer(page, noms[1], 60, 500);
+  expect(holdScuDe(await lots(page))).toBe(100);
+});
+
+test("Soute : prix laissé vide = BUTIN, et l'écran le dit (#55)", async ({ page }) => {
+  await ouvrirDeclaration(page);
+  const nom = (await commodites(page))[0];
+  await page.fill("#holdAddName", nom);
+  await page.fill("#holdAddScu", "150");
+  await page.locator("#holdAddOk").click(); // prix laissé vide
+
+  const ls = await lots(page);
+  expect(ls[0].paid).toBe(0); // du butin n'a rien coûté
+  // Ce zéro change le sens du profit de « où écouler » : il ne doit pas passer inaperçu.
+  const ligne = page.locator("#holdCard .hold-line", { hasText: nom });
+  await expect(ligne.locator(".hold-butin")).toBeVisible();
+  await expect(ligne.locator(".hold-butin")).toHaveAttribute("title", /profit|coût nul|rien payé/i);
+});
+
+test("Soute : « où écouler » répond à une soute DÉCLARÉE, sans le moindre voyage (#55)", async ({ page }) => {
+  // Le vrai bénéfice : « j'ai 2 200 SCU de X, qui les reprend ? » — la question à laquelle l'app ne
+  // savait répondre qu'après un manifeste, un voyage et un « ✓ chargé ».
+  await ouvrirDeclaration(page);
+  const noms = (await commodites(page)).slice(0, 12);
+  await page.locator("#holdAddNo").click();
+
+  // Aucune ligne « bien connue » en dur : on balaie jusqu'à une commodité qui a un débouché depuis
+  // ce quai, et on échoue franchement si aucune des douze n'en a.
+  let trouve = null;
+  for (const nom of noms) {
+    await declarer(page, nom, 2200, 1000);
+    await positionner(page, "Megumi — Pyro");
+    if (!(await page.locator("#holdCard .ec-head").count())) await page.locator("#holdOffload").click();
+    await expect(page.locator("#holdCard .hold-ecouler")).toBeVisible();
+    if ((await page.locator("#holdCard .ec-dest").count()) > 0) { trouve = nom; break; }
+    await page.locator("#holdClear").click();
+  }
+  expect(trouve, "aucune des douze commodités balayées n'a de débouché : le test ne prouverait rien").toBeTruthy();
+
+  await expect(page.locator("#journeyCard .jstep")).toHaveCount(0); // aucun voyage n'a été créé
+  const dest = page.locator("#holdCard .ec-dest");
+  const profits = (await dest.locator(".ec-profit").allTextContents())
+    .map((t) => Number(t.replace(/\s/g, "").replace(/[^\d+-]/g, "")));
+  for (const v of profits) expect(Number.isFinite(v)).toBe(true);
+  for (let i = 1; i < profits.length; i++) expect(profits[i - 1]).toBeGreaterThanOrEqual(profits[i]);
+});
+
+test("Soute : déclarer un lot ne corrige AUCUN stock de station (#55)", async ({ page }) => {
+  // `✓ chargé` vide le rayon parce qu'on vient d'y acheter. Un lot déclaré n'a été pris nulle part
+  // que l'app connaisse : y déduire quoi que ce soit serait inventer un achat.
+  await expect(page.locator("#viewCorrections")).toHaveText("✎ Corrections");
+  await ouvrirDeclaration(page);
+  const nom = (await commodites(page))[0];
+  await page.fill("#holdAddName", nom);
+  await page.fill("#holdAddScu", "9999");
+  await page.locator("#holdAddOk").click();
+
+  await expect(page.locator("#viewCorrections")).toHaveText("✎ Corrections"); // compteur inchangé
+  const ov = await page.evaluate(() => localStorage.getItem("best-hauling-overrides"));
+  expect(JSON.parse(ov || "{}")).toEqual({});
+});
+
+test("Soute : un lot déclaré survit au rechargement et sort par les sorties existantes (#55)", async ({ page }) => {
+  await ouvrirDeclaration(page);
+  const nom = (await commodites(page))[0];
+  await page.fill("#holdAddName", nom);
+  await page.fill("#holdAddScu", "300");
+  await page.locator("#holdAddOk").click();
+  await expect(page.locator("#holdCard")).toBeVisible();
+
+  await page.reload();
+  await expect(page.locator("#holdCard")).toBeVisible({ timeout: 8000 }); // aucune péremption
+  expect(holdScuDe(await lots(page))).toBe(300);
+
+  // Le ✕ du lot d'abord : c'est la sortie fine, elle doit connaître le lot manuel.
+  await page.locator("#holdCard .hold-del").first().click();
+  await expect(page.locator("#holdCard")).toBeHidden();
+  expect(await lots(page)).toEqual([]);
+});
+
+test("Soute : un lot déclaré ne rend AUCUNE jambe « à bord » (#55)", async ({ page }) => {
+  // Un lot manuel n'a pas de jambe : le registre des chargements (#21, #22) ne doit pas le voir
+  // passer, sans quoi le bouton d'une jambe prétendrait avoir chargé un fret qu'elle n'a pas pris —
+  // et l'annuler rendrait à une station un stock qu'elle n'a jamais cédé.
+  await jambeChargeable(page);
+  const bouton = page.locator("#journeyCard .jleg-load").first();
+  await expect(bouton).toHaveText(/chargé/i);
+  const stockAvant = await page.locator("#viewCorrections").innerText();
+
+  await page.click("#viewRoutes");
+  await ouvrirDeclaration(page);
+  await page.fill("#holdAddName", (await commodites(page))[0]);
+  await page.fill("#holdAddScu", "120");
+  await page.locator("#holdAddOk").click();
+  await expect(page.locator("#holdCard")).toBeVisible();
+
+  await page.click("#viewEnroute");
+  await expect(bouton).toHaveText(/chargé/i);      // toujours pas « ⬢ à bord »
+  await expect(bouton).not.toHaveText(/à bord/i);
+  expect(await page.locator("#viewCorrections").innerText()).toBe(stockAvant); // aucun rayon touché
+});
+
+test("Soute : une commodité inconnue ne crée pas un lot que l'app ne saurait pas écouler (#55)", async ({ page }) => {
+  await ouvrirDeclaration(page);
+  await page.fill("#holdAddName", "Kryptonite");
+  await page.fill("#holdAddScu", "100");
+  await page.locator("#holdAddOk").click();
+  await expect(page.locator("#toast")).toContainText(/inconnue/i);
+  await expect(page.locator("#holdCard")).toBeHidden();
+  expect(await lots(page)).toEqual([]);
+});
+
 test("Carte : absente sans voyage, dessinée dès qu'il y en a un", async ({ page }) => {
   await expect(page.locator("#journeyMap")).toBeHidden();
   await page.locator("#rows tr").first().locator(".journey-pick").click();

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -2616,3 +2616,22 @@ test.describe("version déployée", () => {
   });
 });
 
+
+test("Soute : une déclaration en cours de saisie survit à un geste fait ailleurs (#55)", async ({ page }) => {
+  // La garde de focus de `renderDeclaration` ne protégeait que tant que le curseur restait dans la
+  // carte. Toucher la soute ou changer de vue repeignait des champs sans `value` : le texte tapé
+  // disparaissait en silence, le formulaire restant ouvert et vide. Deux gestes ordinaires.
+  await page.click("#holdAddOpen");
+  await page.fill("#holdAddName", "Titanium");
+  await page.fill("#holdAddScu", "42");
+
+  await page.fill("#cargo", "120");        // un geste ailleurs, qui déclenche un rendu
+  await page.locator("#cargo").blur();
+  await expect(page.locator("#holdAddName")).toHaveValue("Titanium");
+  await expect(page.locator("#holdAddScu")).toHaveValue("42");
+
+  await page.click("#viewLoops");          // et un changement de vue
+  await page.click("#viewRoutes");
+  await expect(page.locator("#holdAddName")).toHaveValue("Titanium");
+  await expect(page.locator("#holdAddScu")).toHaveValue("42");
+});

--- a/index.html
+++ b/index.html
@@ -175,6 +175,12 @@
                  tant qu'elle n'est pas vide — c'est ce rappel qui remplace une date de péremption. -->
             <aside id="holdCard" class="hold-card" hidden></aside>
 
+            <!-- La DEUXIÈME entrée de la soute (#55) : « j'ai ça à bord », sans voyage ni jambe.
+                 Carte à part, et c'est délibéré : #holdCard se masque dès que la soute est vide —
+                 le point d'entrée y serait donc invisible exactement quand il sert. Elle porte
+                 aussi le « je suis à » sans lequel « où écouler » n'a pas de point de départ. -->
+            <aside id="holdDeclare" class="hold-card hold-declare" hidden></aside>
+
             <!-- Les entrepôts : le fret DÉPOSÉ à une station. Sous la soute et dans la même
                  colonne, pour la même raison qu'elle : ce n'est pas un plan, c'est du fret réel
                  déjà payé. Masquée tant qu'aucun dépôt n'existe — sinon elle occuperait la colonne

--- a/logic.mjs
+++ b/logic.mjs
@@ -1648,6 +1648,31 @@ export function loadHold(hold, lignes, from, at) {
   return hold.concat(lots);
 }
 
+// La DEUXIÈME entrée de la soute, et la seule qui ne suppose ni voyage, ni jambe, ni manifeste :
+// « j'ai ça à bord ». C'est le repli que l'option D d'ADR-002 réservait aux cargaisons que l'app
+// n'a PAS calculées — butin ramassé, vaisseau rangé plein, achat fait hors du site.
+//
+// Le lot produit a exactement la forme de ceux de `loadHold`, à deux absences près, et ce sont
+// elles le contrat :
+//   - AUCUNE clé `leg`. Rien ne l'a chargé, donc aucune jambe ne peut s'en dire responsable :
+//     l'annulation d'une jambe (`l.leg !== k`) ne l'emporte pas, `detacherLotsDeJambe` et
+//     `reindexerRangsJambe` le rendent tel quel, et `migrerChargements` ne lui invente pas
+//     d'entrée au registre. Poser `leg: null` aurait suffi à tromper le premier de ces quatre.
+//   - `from` VIDE. Il n'a été pris à aucun rayon que l'app connaisse, et c'est ce qui interdit
+//     toute déduction de stock : les déductions se lisent dans le registre, que ce lot n'atteint
+//     jamais. Déduire ici serait inventer un achat.
+//
+// `paid` omis vaut 0 — du butin n'a rien coûté (ADR-002 : « butin offert d'un clic »). Un prix
+// NÉGATIF est ramené à 0 : un achat ne rapporte pas d'argent, le pire cas est le coût nul.
+// Sans nom ou sans quantité, on rend la MÊME soute : l'identité dit « rien n'a bougé », et
+// l'appelant y rend la main sans écrire — même convention que `storeFromHold`.
+export function declarerLot(hold, { name, units, paid } = {}, at = 0) {
+  const nom = typeof name === "string" ? name.trim() : "";
+  const scu = Math.floor(Number(units) || 0);
+  if (!nom || scu <= 0) return hold;
+  return hold.concat([{ name: nom, units: scu, paid: Math.max(0, Number(paid) || 0), from: "", at: at || 0 }]);
+}
+
 // SCU à bord, toutes commodités confondues — donc la place qu'il reste pour charger.
 export const holdScu = (hold) => hold.reduce((s, l) => s + (l.units || 0), 0);
 export const freeCargo = (hold, cargo) => Math.max(0, (cargo || 0) - holdScu(hold));

--- a/logic.mjs
+++ b/logic.mjs
@@ -1730,7 +1730,10 @@ export function loadHold(hold, lignes, from, at) {
 //   - AUCUNE clé `leg`. Rien ne l'a chargé, donc aucune jambe ne peut s'en dire responsable :
 //     l'annulation d'une jambe (`l.leg !== k`) ne l'emporte pas, `detacherLotsDeJambe` et
 //     `reindexerRangsJambe` le rendent tel quel, et `migrerChargements` ne lui invente pas
-//     d'entrée au registre. Poser `leg: null` aurait suffi à tromper le premier de ces quatre.
+//     d'entrée au registre. `leg: null` aurait d'ailleurs fait l'affaire pour les quatre — vérifié,
+//     `null !== "0|A|B"` conserve bien le lot. On ne le pose pas pour être cohérent avec
+//     `sansEtiquette`, qui SUPPRIME la clé : un lot détaché de sa jambe n'en a déjà plus, un lot
+//     déclaré ne doit pas s'en distinguer par une clé vide.
 //   - `from` VIDE. Il n'a été pris à aucun rayon que l'app connaisse, et c'est ce qui interdit
 //     toute déduction de stock : les déductions se lisent dans le registre, que ce lot n'atteint
 //     jamais. Déduire ici serait inventer un achat.

--- a/logic.test.mjs
+++ b/logic.test.mjs
@@ -17,7 +17,7 @@ import {
   legFromRoute, legsFromLoop, legsFromChain, legFromManifest, stopSuggestions, bestLegBetween,
   manifestJourneyState, manifestIntent, sameIntent, manifestIntentSurvives, legsToPin,
   journeyMap, nameAngle, CARTE, nomPasserelle,
-  loadHold, holdScu, freeCargo, holdByCommodity, sellFromHold, storeFromHold, takeFromStore,
+  loadHold, declarerLot, holdScu, freeCargo, holdByCommodity, sellFromHold, storeFromHold, takeFromStore,
   refusActif, migrerRefus, DUREE_VOL,
   refuseHere, sellableAt, sellAllAt, offloadPlan, stockApres,
   startJourney, startJourneyAt, journeyStations, journeyEnd,
@@ -1978,6 +1978,54 @@ test("loadHold : recharger la même commodité crée un SECOND lot, sans fondre 
   assert.equal(g[0].paidMoyen, 1200); // affichage seulement — les ventes consomment lot par lot
 });
 
+// ---------- La DEUXIÈME entrée de la soute : déclarer « j'ai ça à bord » (#55) ----------
+// Le repli de l'option D d'ADR-002 : une cargaison que l'app n'a PAS calculée — butin ramassé,
+// vaisseau rangé plein, achat fait hors du site.
+test("declarerLot : la forme exacte d'un lot, mais sans jambe ni terminal d'achat", () => {
+  const h = declarerLot([], { name: "Titanium", units: 2200, paid: 1000 }, 42);
+  assert.equal(h.length, 1);
+  assert.deepEqual(h[0], { name: "Titanium", units: 2200, paid: 1000, from: "", at: 42 });
+  // LE contrat : rien ne l'a chargé, donc aucune jambe ne doit pouvoir s'en dire responsable.
+  assert.equal("leg" in h[0], false);
+  // `from` vide : il n'a été pris à AUCUN rayon, et c'est ce qui interdit toute déduction de stock.
+  assert.equal(h[0].from, "");
+});
+
+test("declarerLot : prix omis = butin, donc capital engagé nul", () => {
+  const h = declarerLot([], { name: "Titanium", units: 2200 }, 1);
+  assert.equal(h[0].paid, 0);
+  const g = holdByCommodity(h);
+  assert.equal(g[0].invest, 0);   // du butin n'a rien coûté — tout l'encaissement sera du profit
+  assert.equal(g[0].paidMoyen, 0);
+});
+
+test("declarerLot : un lot déclaré et un lot chargé fusionnent, à la moyenne PONDÉRÉE", () => {
+  let h = loadHold([], [ligne(100, 1000, 1400, { name: "Titanium" })], "Megumi", 1);
+  h = declarerLot(h, { name: "Titanium", units: 300, paid: 200 }, 2);
+  const g = holdByCommodity(h);
+  assert.equal(g.length, 1);                                 // une seule ligne à l'écran
+  assert.equal(g[0].lots.length, 2);                         // deux lots dessous, prix distincts
+  assert.equal(g[0].units, 400);
+  assert.equal(g[0].invest, 100 * 1000 + 300 * 200);
+  assert.equal(g[0].paidMoyen, 400);
+  assert.equal(holdScu(h), 400);                             // la place libre reste juste
+  assert.equal(freeCargo(h, 1000), 600);
+});
+
+test("declarerLot : sans nom ou sans quantité, la soute ne bouge pas (identité)", () => {
+  const h = [{ name: "Gold", units: 10, paid: 5, from: "", at: 1 }];
+  assert.equal(declarerLot(h, { name: "   ", units: 10 }, 1), h);
+  assert.equal(declarerLot(h, { name: "Gold", units: 0 }, 1), h);
+  assert.equal(declarerLot(h, { name: "Gold", units: -5 }, 1), h);
+  assert.equal(declarerLot(h), h); // l'appelant peut rendre la main sur cette égalité, comme storeFromHold
+});
+
+test("declarerLot : ni SCU fractionnaires, ni prix négatif", () => {
+  const h = declarerLot([], { name: "Gold", units: 12.7, paid: -50 }, 1);
+  assert.equal(h[0].units, 12);
+  assert.equal(h[0].paid, 0); // un achat ne rapporte pas d'argent : le pire cas est le coût nul
+});
+
 test("sellFromHold : FIFO — le lot le plus ancien part en premier", () => {
   let h = loadHold([], [ligne(100, 1000, 1400)], "A", 1);
   h = loadHold(h, [ligne(100, 1400, 1800)], "B", 2);
@@ -2827,6 +2875,25 @@ test("detacherLotsDeJambe : effacer le voyage délie les lots sans les débarque
   assert.equal(r.length, 2);
   assert.equal("leg" in r[0], false);
   assert.equal(r[0].units, 100); // le fret payé survit à l'effacement du parcours (ADR-002)
+});
+
+test("declarerLot : un lot sans jambe TRAVERSE la comptabilité de jambe sans y entrer (#21, #22)", () => {
+  // Poser une catégorie de fret sans `leg` sur le terrain que #21/#22 viennent de réparer : chacun
+  // des quatre chemins qui manipulent une étiquette de jambe doit le laisser strictement intact.
+  const h = declarerLot([lotDe("0|A|B")], { name: "Titanium", units: 50 }, 9);
+  const manuel = h[1];
+
+  // 1. Annuler la jambe (app.js : `SOUTE.filter((l) => l.leg !== k)`) n'emporte que SES lots.
+  assert.deepEqual(h.filter((l) => l.leg !== "0|A|B"), [manuel]);
+  // 2. Effacer le parcours : rien à délier, l'objet ne bouge pas.
+  assert.equal(detacherLotsDeJambe(h)[1], manuel);
+  // 3. Renuméroter les jambes : idem, il n'a pas de rang à décaler.
+  const r = reindexerRangsJambe({ lots: h }, removeJourneyStop(parcours(["A", "B", "C"], 0), 0));
+  assert.equal(r.lots[1], manuel);
+  // 4. La migration du registre ne lui invente aucune entrée — donc aucune jambe ne se dira chargée.
+  assert.deepEqual(Object.keys(migrerChargements({}, h).chargements), ["0|A|B"]);
+  // Et il ne pèse sur AUCUN rayon : le registre est la seule source des déductions de stock.
+  assert.deepEqual(soldeDuPoint(migrerChargements({}, h).chargements, "Titanium", ""), { ref: null, pris: 0 });
 });
 
 // ---------- Le registre des chargements : quelle jambe a pris quoi, et où (#21, #22) ----------

--- a/style.css
+++ b/style.css
@@ -504,6 +504,35 @@ input.jman-qty { width: 56px; min-width: 0; padding: 3px 5px; text-align: right;
 .hold-meta { margin-top: 10px; padding-top: 9px; border-top: 1px solid var(--line); font-size: 11px; color: var(--muted); font-variant-numeric: tabular-nums; }
 .hold-meta b { color: var(--text); }
 
+/* ---------- Déclarer « j'ai ça à bord » (#55) ---------- */
+/* Même bordure verte que la soute : c'est la même chose — du fret réel — par une autre porte. */
+.hold-declare { display: flex; flex-direction: column; gap: 9px; }
+.hold-add-open {
+  font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.4px; text-align: left;
+  color: var(--good); background: none; border: 1px dashed rgba(70, 229, 160, 0.4);
+  border-radius: 3px; padding: 6px 9px; cursor: pointer;
+}
+.hold-add-open:hover { color: #04120a; background: var(--good); border-style: solid; }
+.hold-add { display: flex; flex-wrap: wrap; align-items: center; gap: 5px; }
+.hold-add input { min-width: 0; padding: 3px 7px; font-size: 11.5px; }
+#holdAddName { flex: 1 1 130px; }
+#holdAddScu { flex: 0 0 62px; font-family: var(--mono); text-align: center; }
+#holdAddPaid { flex: 0 0 96px; font-family: var(--mono); text-align: center; }
+.hold-add-hint { margin: 0; font-size: 10.5px; line-height: 1.5; color: var(--muted); }
+.hold-add-hint b { color: var(--text); }
+/* « Coût nul » n'est pas une absence de donnée : c'est une donnée, et elle change le sens du
+   profit affiché juste au-dessus. Teinte ambre, celle de tout ce qui demande une lecture avertie. */
+.hold-butin {
+  font-family: var(--mono); font-size: 9px; letter-spacing: 0.6px; text-transform: uppercase;
+  color: var(--warn); border: 1px solid rgba(255, 176, 32, 0.35); border-radius: 2px;
+  padding: 0 4px; cursor: help;
+}
+/* « Je suis à » : sans voyage, c'est la seule façon de dire d'où l'on part — donc de vendre et de
+   classer « où écouler ». Le champ est le départ d'« En route », pas une seconde vérité. */
+.hold-ici { display: flex; flex-wrap: wrap; align-items: center; gap: 5px 8px; font-size: 11px; }
+.hold-ici label { font-family: var(--mono); font-size: 10px; letter-spacing: 0.6px; color: var(--muted); }
+.hold-ici input { flex: 1 1 150px; min-width: 0; padding: 3px 7px; font-size: 11.5px; }
+
 /* ---------- Les entrepôts : le fret déposé ---------- */
 /* Mêmes classes de ligne que la soute : c'est le même objet (des lots), il se lit pareil. Seule la
    teinte change — violette, celle des panneaux qui ne décrivent pas ce qui est À BORD. Confondre


### PR DESCRIPTION
## Ce que ça change

Un bouton **`+ déclarer ce que j'ai à bord`**, présent dans les **six vues** et **soute vide
comprise**, ouvre trois champs : la commodité (nom ou code UEX), les SCU, et le prix payé au SCU.
Le prix est facultatif — vide, c'est du **butin** au coût nul, et la ligne le dit à l'écran. Un
champ **◈ Je suis à** pose le point de départ quand il n'y a pas de voyage, de sorte que
**« où écouler » répond enfin à « j'ai 2 200 SCU de Titanium, qui les reprend ? »** sans qu'aucun
parcours n'existe.

## Pourquoi

La soute n'avait **qu'un robinet**, au bout d'un entonnoir : `chargerJambe` (`app.js:1403`) s'ouvre
sur `const leg = JOURNEY && JOURNEY.legs[i]; if (!leg || !MARKET) return;` et son unique écriture
d'ajout est `app.js:1438`, `SOUTE = SOUTE.concat(lots)`. Les douze autres écritures sur `SOUTE`
retirent, transforment ou déplacent. Il fallait donc un voyage, un manifeste et un terminal qui
vend la commodité pour énoncer un fait qui tient en deux mots : *quoi*, *combien*. Le butin ramassé
au sol, un vaisseau rangé plein la semaine dernière, un achat fait hors du site : aucune porte.

Et à vide il n'y avait **aucun point d'entrée nulle part** : `renderSoute` (`app.js:1700`) sort sur
`if (!SOUTE.length) { box.hidden = true; return; }`, donc le seul endroit imaginable pour un bouton
n'existait pas au moment exact où il servait.

Ce n'est pas une nouveauté : **l'ADR-002 réservait ce repli** (option D, « conservée comme repli »)
et son plan d'action l'annonçait à l'étape 1. `manifestLine` acceptait déjà un `paid` explicite —
sans le moindre appelant de production.

**Ce que le correctif tranche, et qui n'était pas écrit :**

- **Un lot déclaré n'a pas de clé `leg`** — pas même `leg: null`. Le registre des chargements
  (`best-hauling-jambes-chargees`, #21/#22) suppose une jambe : un lot qui n'en a pas n'y entre
  jamais, `jambeChargee` reste faux, `SOUTE.filter((l) => l.leg !== k)` ne l'emporte pas, et
  `detacherLotsDeJambe` / `reindexerRangsJambe` le rendent **tel quel** (identité d'objet vérifiée
  en test).
- **Il ne corrige aucun stock.** `✓ chargé` vide le rayon parce qu'on vient d'y acheter ; un lot
  déclaré a `from: ""` — il n'a été pris nulle part que l'app connaisse, et y déduire serait
  inventer un achat. Le compteur de `updateOvBadge` reste à zéro même en déclarant 9 999 SCU.
- **Le prix vaut 0 par défaut**, et ce zéro est **dit à l'écran** : la ligne porte une étiquette
  `butin` dont l'infobulle explique que « où écouler » comptera alors *tout* l'encaissement comme
  profit.
- **La place libre et les plafonds restent justes** : `holdScu` / `freeCargo` ne distinguent pas les
  lots, donc le manifeste ne remplit toujours que ce qui reste (vérifié : soute à 1 000, 220 SCU
  déclarés → `780 libres`).

Côté position, aucun second store : `poserPosition` (`app.js:1686`) écrit dans le champ de départ
d'« En route », déjà le repli de `stationCourante()`. Deux positions divergeraient au premier
aller-retour entre les deux vues.

La fonction pure est `declarerLot(hold, { name, units, paid }, at)` (`logic.mjs:1669`) : elle rend
la **même** soute quand le nom ou la quantité manquent — l'identité dit « rien n'a bougé », comme
`storeFromHold` — et c'est elle que #57 réutilisera.

## Vérification

**Rouge avant** — `node --test logic.test.mjs`, avec les tests écrits et la fonction absente :

```
SyntaxError: The requested module './logic.mjs' does not provide an export named 'declarerLot'
    at #asyncInstantiate (node:internal/modules/esm/module_job:327:21)
✖ logic.test.mjs (47.8346ms)
ℹ pass 0
ℹ fail 1
```

**Rouge avant** — `npx playwright test -g "#55"`, avant l'interface :

```
Error: locator.click: Test timeout of 30000ms exceeded.
Call log:
  - waiting for locator('#holdAddOpen')

  7 failed
```

**Vert après** — `node --test` (416 tests avant, **+6** ; `logic.test.mjs` passe de 366 à 372) :

```
ℹ tests 422
ℹ pass 422
ℹ fail 0
ℹ duration_ms 235.9226
```

**Vert après** — `npx playwright test` (suite entière) :

```
  2 skipped
  141 passed (1.3m)
```

Et le sous-ensemble de non-régression demandé par la grappe,
`npx playwright test -g "Soute|soute|jambe|Entrepôts"` — les tests de #20, #21, #22 compris :

```
  1 skipped
  35 passed (26.6s)
```

Les **huit** tests e2e neufs (`npx playwright test --list` : 135 → 143), en plus des six tests
unitaires de `declarerLot` :

- déclarer sans voyage, sans jambe et sans manifeste (forme du lot, absence de `leg`, registre vide,
  place libre) ;
- le point d'entrée est visible dans **les six vues**, et le geste marche depuis Commodités et
  Trajets sans changer de vue ;
- prix vide = butin, et l'étiquette le dit ;
- « où écouler » classe des destinations sur une soute déclarée, **sans qu'un seul voyage n'existe**
  (la commodité est trouvée par **balayage** des douze premières, pas codée en dur) ;
- déclarer ne crée **aucune** correction locale ;
- un lot déclaré ne fait passer aucune jambe à `⬢ à bord` ;
- il survit au rechargement et sort par le ✕ du lot ;
- une commodité inconnue est refusée avec un message plutôt que d'entrer en soute.

## Ce qui n'est pas couvert

- **Modifier les SCU d'un lot en place** : hors périmètre de l'issue, le geste actuel (retirer puis
  re-déclarer) tient.
- **Le champ « Je suis à » ne propose que les 108 terminaux d'achat** (`originList`, contre 114 au
  total) : c'est la datalist du départ d'« En route », qu'on réutilise plutôt que d'en inventer une
  seconde. Six terminaux sans point d'achat restent donc hors position.
- **La déclaration exige une commodité connue du marché** : un fret qu'UEX ne référence pas n'entre
  pas en soute. L'app ne saurait ni le classer, ni dire où l'écouler.
- **#21 et #22** (cycle de vie des lots portés par une jambe) ne sont pas touchés : un lot déclaré
  n'entre pas dans cette comptabilité, et les tests le prouvent plutôt que de la modifier.
- **La tournée d'écoulement (#57)** reste à faire ; ce travail lui livre la porte d'entrée qui lui
  manquait.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)

