### PR TITLE
feat(soute): emporter ses entrepôts et ses corrections, chacun daté à la seconde

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,15 @@ contrôle de position — l'app ne sait pas où ton vaisseau se trouve vraiment,
 « tu n'y es pas » bloquerait le geste au moment précis où il est vrai ; la station est écrite en
 toutes lettres sur la ligne. La carte disparaît dès qu'il ne reste rien nulle part.
 
+Un **⧉ Copier** dans l'en-tête de la carte met la liste dans le presse-papiers, en texte, lisible
+telle quelle sur un second écran ou dans un canal Discord. Elle est rangée par station, **une ligne
+par lot** — les SCU, la commodité, le prix payé au SCU, la **date du dépôt** et la station où le fret
+avait été chargé — avec un sous-total par station et, en pied, le SCU total et le capital immobilisé.
+Les dates sont en **ISO 8601 UTC** (`2026-08-15T09:12:00Z`), le même format que l'export des
+corrections ([ADR-006](docs/superpowers/specs/2026-08-15-format-des-exports-adr.md)). Un lot déposé
+avant que les dépôts ne soient datés s'affiche « déposé à une date inconnue » : on ne lui invente pas
+celle du jour, ce serait pire que rien.
+
 **Où écouler ?** Le panneau classe les destinations par **ce que ça rapporte, prix d'achat déduit** —
 `min(résidu, capacité) × prix`, net des frais, moins ce que les lots consommés ont coûté. Le chiffre
 descend **sous zéro** quand une destination te ferait vendre à perte : c'est une information, pas
@@ -365,6 +374,32 @@ jamais partagé ni mis dans l'URL) et **intelligent** :
 - Un **volume** (stock, demande, et la déduction d'un `✓ chargé`) périme **aussi au bout de 3 h**, même si UEX n'a rien republié. Un **prix**, non : les deux ne vieillissent pas pareil, [voir plus bas](#pourquoi-un-volume-périme-en-3-h-et-pas-un-prix).
 - Sémantique respectée : un **stock d'achat à 0 = terminal vide** (plafonne à 0), et une **demande que _tu_ corriges fait autorité** — y compris un 0, qui vaut « pas de demande » et plafonne à 0 même là où UEX ne renseignait rien. Les valeurs UEX brutes, elles, gardent leur sémantique propre (`null` = capacité inconnue, `0` = terminal saturé) : [voir le piège des volumes UEX](#sémantique-des-volumes-uex-piège).
 - **Retour arrière par chiffre** : un chiffre corrigé porte, sous lui, un bouton `↺` qui annonce la valeur UEX vers laquelle il ramène. On défait là où on regarde.
+
+### Emporter ses corrections
+
+Le bandeau de la vue Corrections porte un **⧉ Exporter**, juste avant « Tout réinitialiser » — rien
+ne doit s'effacer sans qu'on ait pu l'emporter. Il met dans le presse-papiers un JSON versionné
+(`{ "v": 1, "type": "corrections", "emis": "…Z", "corrections": [ … ] }`), une entrée **par champ
+corrigé** : la commodité, le terminal, le côté (achat / vente), le champ (prix / volume), la valeur,
+et **deux dates qui ne disent pas la même chose** :
+
+- **`saisi`** — quand *tu* l'as corrigée ;
+- **`base`** — la date UEX du point *contre* laquelle la correction vaut.
+
+Les deux en **ISO 8601 UTC** (`2026-08-15T09:12:00Z`), jamais un epoch nu ni un format qui dépend de
+la locale du navigateur : un export se relit sur une autre machine, dans un autre fuseau, des mois
+plus tard. Les **relevés de tarif d'autoload** n'y entrent pas — store séparé, sans date UEX de
+référence et sans péremption par conception.
+
+À la relecture, chaque correction reçoit un verdict, avec les règles déjà en vigueur et pas des
+règles parallèles : `périmée-uex` (UEX a republié le point depuis), `périmée-âge` (un volume de plus
+de 3 h), `date-inconnue` (correction d'un format antérieur — signalée, **jamais** réappliquée en
+silence) ou `appliquer`.
+
+Une correction posée **avant** que les prix ne soient datés n'a pas de date de saisie et n'en reçoit
+pas une fausse : elle sort « inconnue ». Rien n'est encore réinjecté automatiquement — l'export sert
+d'abord à ne plus perdre ce qu'on a relevé. Le détail du format, et pourquoi c'est le presse-papiers
+et pas un fichier : [ADR-006](docs/superpowers/specs/2026-08-15-format-des-exports-adr.md).
 
 ### La vue Corrections se range par station
 

--- a/app.js
+++ b/app.js
@@ -1186,10 +1186,11 @@ function copyManifest() {
 }
 
 // Le SEUL chemin de sortie de l'app, pour les trois boutons de copie (manifeste, entrepôts,
-// corrections). Un fichier téléchargé était l'autre candidat : sous la CSP d'index.html
-// (`default-src 'self'`, sans `blob:`), un `<a download href="blob:…">` ne déclenche RIEN — pas
-// d'erreur console, juste un bouton mort. Mesuré : la même page servie sans la CSP télécharge.
-// Relâcher la politique pour un bouton de copie la paierait bien trop cher (cf. ADR-006).
+// corrections). Un fichier téléchargé était l'autre candidat, écarté parce que les deux issues
+// demandaient une liste à ENVOYER et que ce chemin-ci existait déjà, éprouvé par « ⧉ Copier » et
+// par « Partager » (ADR-006 §3). Il reste techniquement possible : contrairement à ce qu'une
+// première version de l'ADR affirmait, la CSP ne l'interdit pas — la mesure qui le prétendait ne
+// s'est pas reproduite en contre-lecture.
 // `libelle` est le texte à remettre après le retour visuel : chaque bouton a le sien.
 function copierTexte(texte, btn, libelle) {
   navigator.clipboard?.writeText(texte).then(() => {

--- a/app.js
+++ b/app.js
@@ -21,6 +21,7 @@ import {
   reindexerRangsJambe, detacherLotsDeJambe,
   soldeDuPoint, poserChargement, retirerChargement, migrerChargements,
   encodeJourney, decodeJourney,
+  migrerCorrections, exporterCorrections, exporterEntrepots,
 } from "./logic.mjs";
 
 // Libellé compact des caisses SCU standard, ex. « 8×32 · 1×16 · 1×4 · 1×2 · 1×1 ».
@@ -174,6 +175,10 @@ const nowSec = () => Math.floor(Date.now() / 1000);
 
 function loadOverrides() {
   try { OVERRIDES = JSON.parse(localStorage.getItem(OV_KEY)) || {}; } catch { OVERRIDES = {}; }
+  // Mise à niveau des corrections déjà posées (logic.mjs) : `ts` devient `base`, et AUCUNE date de
+  // saisie n'est inventée pour les prix d'avant `saisiPrix` — ils s'exportent « date inconnue ».
+  // On n'écrit que s'il y avait vraiment quelque chose à normaliser.
+  if (migrerCorrections(OVERRIDES).migres) saveOverrides();
 }
 function saveOverrides() {
   try { localStorage.setItem(OV_KEY, JSON.stringify(OVERRIDES)); } catch {}
@@ -1177,12 +1182,21 @@ function copyManifest() {
     `Total : ${fmt(scu)}/${fmt(m.cargo)} SCU · profit ${fmtFee(profit, fees)} aUEC · investissement ${fmt(invest)} aUEC` +
       (fees > 0 ? ` · frais d'autoload ≈ ${fmt(fees)} aUEC (estimation)` : ""),
   ].join("\n");
-  const btn = $("copyManifest");
-  navigator.clipboard?.writeText(text).then(() => {
+  copierTexte(text, $("copyManifest"), "⧉ Copier");
+}
+
+// Le SEUL chemin de sortie de l'app, pour les trois boutons de copie (manifeste, entrepôts,
+// corrections). Un fichier téléchargé était l'autre candidat : sous la CSP d'index.html
+// (`default-src 'self'`, sans `blob:`), un `<a download href="blob:…">` ne déclenche RIEN — pas
+// d'erreur console, juste un bouton mort. Mesuré : la même page servie sans la CSP télécharge.
+// Relâcher la politique pour un bouton de copie la paierait bien trop cher (cf. ADR-006).
+// `libelle` est le texte à remettre après le retour visuel : chaque bouton a le sien.
+function copierTexte(texte, btn, libelle) {
+  navigator.clipboard?.writeText(texte).then(() => {
     if (!btn) return;
     btn.textContent = "✓ Copié";
     btn.classList.add("copied");
-    setTimeout(() => { btn.textContent = "⧉ Copier"; btn.classList.remove("copied"); }, 1500);
+    setTimeout(() => { btn.textContent = libelle; btn.classList.remove("copied"); }, 1500);
   }).catch(() => {});
 }
 
@@ -1511,7 +1525,9 @@ function deposerIci(nom, units, idxFige) {
   const idx = Number.isFinite(idxFige) ? idxFige : stationCourante();
   if (idx == null || !MARKET) return;
   const t = MARKET.terminals[idx];
-  const r = storeFromHold(SOUTE, DEPOTS, nom, units, stationLabel(t.name, t.system));
+  // L'heure du dépôt est fournie ICI : `storeFromHold` est pure et ne lit pas d'horloge. Sans elle,
+  // la liste exportée dirait « 170 SCU d'or à Ruin Station » sans dire si c'était hier ou l'an passé.
+  const r = storeFromHold(SOUTE, DEPOTS, nom, units, stationLabel(t.name, t.system), nowSec());
   if (r.hold === SOUTE) return;
   SOUTE = r.hold; DEPOTS = r.entrepots;
   saveSoute(); saveDepots();
@@ -1559,10 +1575,20 @@ function renderEntrepots() {
       </div>`).join("");
     return `<div class="depot-station"><div class="depot-lieu">${esc(name)}${sysBadge(system)} <span class="muted">${fmt(holdScu(lots))} SCU</span></div>${lignes}</div>`;
   }).join("");
+  // Le bouton de sortie vit dans l'en-tête, sur le modèle exact du `⧉ Copier` du manifeste. Il
+  // n'existe donc que quand la carte est visible — inutile de le masquer à part : la carte entière
+  // sort dès qu'il ne dort plus rien nulle part.
   box.innerHTML =
-    `<div class="hold-head"><span class="hold-title">⬓ Entrepôts</span></div>
+    `<div class="hold-head"><span class="hold-title">⬓ Entrepôts</span>
+       <button id="copyDepots" class="copy-btn" title="Copier la liste du fret déposé, dates comprises">⧉ Copier</button></div>
      <div class="depot-stations">${blocs}</div>
      <div class="hold-meta"><b>${fmt(holdScu(tous))}</b> SCU déposés · capital immobilisé <b>${fmt(invest)}</b> aUEC</div>`;
+}
+
+// La liste de ce qui dort en entrepôt, en texte, dans le presse-papiers : elle ne quittait jamais
+// l'app, et il fallait rouvrir le navigateur qui porte le localStorage pour la relire.
+function copierEntrepots() {
+  copierTexte(exporterEntrepots(DEPOTS, nowSec()), $("copyDepots"), "⧉ Copier");
 }
 
 // « Où écouler ce qui reste ? » — le détour manuel par la vue Commodités, en un panneau.
@@ -2904,10 +2930,20 @@ function correctionsIndexHTML() {
       `<b>${g.corrections}</b></span>` +
       `${g.actif ? '<span class="stn-tile-flag">en cours</span>' : ""}</button>`;
   }).join("");
+  // Le bouton d'export précède « Tout réinitialiser » — c'est l'ordre des gestes : on emporte ses
+  // relevés avant de les effacer. Comme la bande, il n'existe que s'il y a quelque chose à sortir.
   return `<div class="corr-list-head">
       <span>◈ ${autres.length ? `${autres.length} autre${autres.length > 1 ? "s" : ""} station${autres.length > 1 ? "s" : ""} · ` : ""}${total} correction${total > 1 ? "s" : ""}</span>
+      <button id="exportCorrections" class="copy-btn" title="Copier toutes les corrections locales, avec leur date de saisie et leur date UEX">⧉ Exporter</button>
       <button id="resetAll" class="reset-ov">Tout réinitialiser</button>
     </div><div class="stn-band">${tuiles}</div>`;
+}
+
+// Les corrections, en JSON daté, dans le presse-papiers. Du JSON et non du texte libre — celui-ci
+// est fait pour être RELU (cf. relireCorrections), et une correction qu'on ne peut pas dater est
+// une correction qu'on réappliquerait aveuglément des semaines plus tard.
+function copierCorrections() {
+  copierTexte(JSON.stringify(exporterCorrections(OVERRIDES, nowSec()), null, 2), $("exportCorrections"), "⧉ Exporter");
 }
 
 // Liste des relevés d'autoload, à côté des corrections locales et sur le même modèle : ils sont de
@@ -3247,6 +3283,8 @@ async function init() {
     }
     if (e.target.closest("#alSave")) { saveStationReading(); return; }
     if (e.target.closest("#resetAllK")) { resetAllReadings(); return; }
+    // Avant « Tout réinitialiser » ici aussi : rien ne doit s'effacer sans qu'on ait pu l'emporter.
+    if (e.target.closest("#exportCorrections")) { copierCorrections(); return; }
     if (e.target.closest("#resetAll")) resetAllOverrides();
   });
   // Validation du relevé d'autoload à la touche Entrée (les deux champs sont dans le même panneau).
@@ -3317,6 +3355,7 @@ async function init() {
   // reprend ce qu'on a laissé ; une reprise partielle se ferait en redéposant. La fonction pure,
   // elle, accepte déjà des SCU : l'UI pourra suivre sans la toucher.
   $("depotsCard").addEventListener("click", (e) => {
+    if (e.target.closest("#copyDepots")) { copierEntrepots(); return; }
     const b = e.target.closest(".depot-take");
     if (b) reprendreIci(b.dataset.station, b.dataset.name, Number(b.dataset.units));
   });

--- a/docs/superpowers/specs/2026-08-15-format-des-exports-adr.md
+++ b/docs/superpowers/specs/2026-08-15-format-des-exports-adr.md
@@ -1,0 +1,149 @@
+# ADR-006 : Un seul format pour les deux exports — ISO 8601 UTC, en-tête versionné, presse-papiers
+
+**Statut :** Accepté
+**Date :** 2026-08-15
+**Décideur :** 0xKestrelNova (propriétaire du dépôt)
+**Issues :** #46, #47 · **Jalon :** v1.1.0 — Plan de vol
+
+## Contexte
+
+Deux demandes indépendantes réclamaient une sortie de données, et se sont explicitement renvoyé
+la balle :
+
+- **#46 — les entrepôts.** `⬓ Déposer` et la carte `⬓ Entrepôts` existent depuis la PR #18 : le fret
+  déposé est rangé station par station, avec son prix payé et le capital immobilisé. Mais la liste ne
+  quitte jamais l'app. Pour relire ce qu'on a laissé quelque part, il faut rouvrir le navigateur qui
+  porte le `localStorage`.
+- **#47 — les corrections locales.** Elles vivent sous `best-hauling-overrides` et n'en sortent
+  jamais : le lien de partage les exclut délibérément, `copyManifest` ne copie que le manifeste
+  courant. Vider son cache efface des dizaines de relevés faits comptoir par comptoir.
+
+Trois questions leur étaient communes, et les trancher séparément aurait fait diverger **deux formats
+d'export dans le même dépôt** — ce qui est particulièrement grave ici, puisqu'une correction
+**périme par sa date** (spec du 2026-08-12) : deux façons d'écrire une date, c'est deux façons de se
+tromper en la relisant.
+
+## Décision
+
+### 1. Les dates sortent en ISO 8601 UTC, à la seconde, suffixe `Z`
+
+`2026-08-15T09:12:00Z`. Une seule fonction, `isoUTC` (logic.mjs), sert les deux exports.
+
+Le seul rendu de date du dépôt était jusqu'ici `toLocaleString("fr-FR")` (fraîcheur UEX) : un format
+qui dépend de la locale du navigateur et ne se relit pas de façon fiable. Un export se relit **sur
+une autre machine, dans un autre fuseau, des mois plus tard**.
+
+La date est **tronquée** à la seconde, jamais arrondie : la seconde *pendant* laquelle le geste a eu
+lieu. Arrondir daterait un dépôt de 20:13:20,7 à 20:13:21, une seconde après qu'il s'est produit.
+
+**Une date absente sort `null` (ou « date inconnue » en texte), jamais l'heure courante.** C'est la
+règle la plus importante des deux issues : on préfère « je n'en sais rien » à une date fausse, parce
+qu'une correction datée d'aujourd'hui à tort est exactement celle qu'on réappliquerait aveuglément.
+
+### 2. En-tête versionné, commun aux deux
+
+`enteteExport(type, nowSec)` rend `{ v: 1, type, emis: "…Z" }`. `FORMAT_EXPORT = 1`.
+
+Sans numéro de format, la première évolution casse tous les fichiers déjà émis. L'export des
+entrepôts, qui est du texte, porte le même en-tête sur sa première ligne :
+`# Best Hauling — entrepôts · format v1 · émis 2026-08-15T09:12:00Z`.
+
+### 3. Presse-papiers, jamais de fichier téléchargé — et c'est une contrainte, pas un goût
+
+`index.html` pose `default-src 'self'` **sans `blob:`**, verrouillé par `scripts/csp.test.mjs`.
+
+Mesuré, sous Chromium, sur la page réellement servie :
+
+| page | `URL.createObjectURL` | clic sur `<a download href="blob:…">` | erreur console |
+|---|---|---|---|
+| `index.html` (avec la CSP) | rend bien un `blob:` | **aucun téléchargement** | **aucune** |
+| même origine, page sans CSP | rend bien un `blob:` | `essai.txt` téléchargé | aucune |
+
+Le bouton serait donc **mort en silence** : pas d'exception, pas de message, rien à déboguer pour
+l'utilisateur. Relâcher `default-src` pour un bouton de copie paierait la politique bien trop cher —
+c'est le seul vecteur de sécurité disponible sous GitHub Pages, et `scripts/csp.test.mjs` la
+verrouille à raison.
+
+Les trois boutons de copie passent donc par un unique chemin, `copierTexte` (app.js), déjà éprouvé
+par `⧉ Copier` du manifeste et par `Partager`.
+
+### 4. Texte pour les entrepôts, JSON pour les corrections
+
+Les deux exports partagent le format de date et l'en-tête ; leur **corps** diffère, parce que leurs
+lecteurs diffèrent :
+
+- **Entrepôts → texte.** Destiné à être collé dans un bloc-notes, sur un second écran ou dans un
+  canal Discord d'org. Du JSON y serait illisible là où il sert. Une ligne **par lot** et non par
+  commodité : deux lots de la même commodité peuvent avoir été déposés à des jours d'écart et venir
+  de stations différentes — les regrouper effacerait précisément ce que l'export existe pour dire.
+- **Corrections → JSON.** Destiné à être **relu**, par `relireCorrections`. Une entrée par *champ*
+  corrigé, parce qu'une même clé peut porter un prix et un volume qui ne portent pas la même date de
+  saisie.
+
+## Conséquences
+
+### Deux dates de saisie dans le store des corrections, une par champ
+
+`setInStore` posait `pris` **uniquement** sous `if (field === "vol")` : un prix corrigé ne portait
+aucune date de saisie. Le store porte désormais :
+
+- `pris` — heure murale de la saisie du **volume**. C'est une **horloge** : `effValue` s'en sert pour
+  périmer le volume au bout de `DUREE_VOL` ;
+- `saisiPrix` — heure murale de la saisie du **prix**. Ce n'est **pas** une horloge : rien ne
+  régénère un prix faux, il ne vieillit pas, et aucun lecteur ne le périme. Elle existe uniquement
+  pour que l'export puisse dater ce qu'il transporte.
+
+Les deux noms sont distincts de `ts`, que `effValue` lit encore comme alias historique de `base` :
+les confondre périmerait les corrections d'anciens formats au lieu de les épargner.
+
+### Le dépôt est daté, et l'horodatage est injecté
+
+`storeFromHold(hold, entrepots, name, units, station, at)` — `at` en paramètre, comme
+`loadHold(hold, lignes, from, at)`. Une fonction pure ne lit pas l'horloge. Le lot porte `deposeAt`,
+distinct du `at` de chargement.
+
+`takeFromStore` **ne remonte pas** `deposeAt` avec le lot, et ce n'est pas un oubli : reprendre n'est
+pas acheter. Le lot rendu à la soute n'a ni `at` ni `deposeAt` — il n'a pas été chargé maintenant, et
+il n'est plus déposé nulle part.
+
+### Migration : on normalise, on n'invente rien
+
+`migrerCorrections(store)` (forme de `migrerRefus` : `{ store, migres }`, `migres` à 0 = rien à
+persister) fait exactement deux choses :
+
+1. `ts` → `base`. L'alias historique reste lu par `effValue`, mais l'export ne doit pas avoir à
+   connaître deux noms pour la même ancre. La normalisation ne change **aucune** décision de
+   fraîcheur : `effValue` traitait déjà les deux à l'identique.
+2. **Aucune date de saisie n'est inventée.** Un prix corrigé avant `saisiPrix` s'exporte « date de
+   saisie inconnue » et le reste. Même prudence qu'`effValue` avec `pris` absent — on épargne les
+   formats antérieurs plutôt que de les périmer, et ici on refuse aussi de les rajeunir.
+
+Idem côté entrepôts : un lot déposé avant ce changement n'a pas de `deposeAt` et s'exporte « déposé à
+une date inconnue ».
+
+### La relecture réutilise `effValue`, elle ne réécrit pas la règle
+
+`relireCorrections(exporte, releves, nowSec)` rend un verdict par entrée :
+
+| verdict | quand |
+|---|---|
+| `appliquer` | datée, ancrée, et le point n'a pas été republié depuis |
+| `périmée-uex` | UEX a republié ce point après l'ancrage — c'est exactement `stale` d'`effValue` |
+| `périmée-âge` | un **volume** saisi il y a plus de `DUREE_VOL` — c'est `staleVol` |
+| `date-inconnue` | format antérieur, sans date de saisie : signalée, jamais acceptée en silence |
+
+L'ordre de priorité est celui d'`effValue` lui-même : `stale` l'emporte sur `staleVol`. Deux
+implémentations de la péremption finiraient par diverger, et c'est la relecture qui aurait tort sans
+qu'on le voie.
+
+### Ce que la décision n'ouvre pas
+
+- **L'import.** `relireCorrections` rend des verdicts ; rien ne réinjecte encore un export dans le
+  store. La fonction existe pour que le format soit relisible *par construction*, pas parce qu'un
+  bouton d'import est décidé.
+- **Les relevés d'autoload** (`best-hauling-autoload`, clé à deux segments) restent hors des deux
+  exports : ils n'ont ni date UEX de référence ni péremption, *par conception*. Les inclure suppose
+  de décider s'ils doivent être datés — décision non prise ici.
+- **Le lien de partage** continue à ne transporter aucune donnée locale. Frontière assumée.
+- **La soute** (`#holdCard`) et le voyage n'ont pas de bouton d'export. Même mécanique possible,
+  autre décision.

--- a/docs/superpowers/specs/2026-08-15-format-des-exports-adr.md
+++ b/docs/superpowers/specs/2026-08-15-format-des-exports-adr.md
@@ -48,24 +48,24 @@ Sans numéro de format, la première évolution casse tous les fichiers déjà �
 entrepôts, qui est du texte, porte le même en-tête sur sa première ligne :
 `# Best Hauling — entrepôts · format v1 · émis 2026-08-15T09:12:00Z`.
 
-### 3. Presse-papiers, jamais de fichier téléchargé — et c'est une contrainte, pas un goût
+### 3. Presse-papiers, jamais de fichier téléchargé
 
-`index.html` pose `default-src 'self'` **sans `blob:`**, verrouillé par `scripts/csp.test.mjs`.
+Parce que c'est ce que les deux issues demandent — #46 veut « exporter sous forme de liste » pour
+l'envoyer, #47 veut emporter ses corrections — et parce que `copierTexte` (app.js) existe déjà,
+éprouvé par le `⧉ Copier` du manifeste et par `Partager`. Les trois boutons passent donc par un
+unique chemin.
 
-Mesuré, sous Chromium, sur la page réellement servie :
+**Correction du 2026-08-15.** Une première version de cet ADR justifiait ce choix par une contrainte
+de CSP, tableau de mesure à l'appui : sous `default-src 'self'` sans `blob:`, un
+`<a download href="blob:…">` aurait été « mort en silence ». **Cette mesure ne se reproduit pas.**
+Refaite en contre-lecture, dans les mêmes conditions — Chromium Playwright, page servie par
+`scripts/serve.mjs`, vrai clic souris — avec un témoin prouvant que la CSP est bien active (elle
+bloque un fetch cross-origine et le dit en console), **le fichier se télécharge**, exactement comme
+sur une page sans CSP.
 
-| page | `URL.createObjectURL` | clic sur `<a download href="blob:…">` | erreur console |
-|---|---|---|---|
-| `index.html` (avec la CSP) | rend bien un `blob:` | **aucun téléchargement** | **aucune** |
-| même origine, page sans CSP | rend bien un `blob:` | `essai.txt` téléchargé | aucune |
-
-Le bouton serait donc **mort en silence** : pas d'exception, pas de message, rien à déboguer pour
-l'utilisateur. Relâcher `default-src` pour un bouton de copie paierait la politique bien trop cher —
-c'est le seul vecteur de sécurité disponible sous GitHub Pages, et `scripts/csp.test.mjs` la
-verrouille à raison.
-
-Les trois boutons de copie passent donc par un unique chemin, `copierTexte` (app.js), déjà éprouvé
-par `⧉ Copier` du manifeste et par `Partager`.
+Le choix retenu ne change pas : il était le bon pour la raison ci-dessus. Mais un fichier téléchargé
+reste **techniquement possible**, et si le besoin s'en présente ce sera une décision à prendre, pas
+une porte fermée par la politique de sécurité. La CSP n'a rien à voir avec cette question.
 
 ### 4. Texte pour les entrepôts, JSON pour les corrections
 

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -2342,3 +2342,98 @@ test.describe("version déployée", () => {
   });
 });
 
+// ---------- Exports datés : entrepôts (#46) et corrections (#47) ----------
+// Les deux tests vivent côte à côte parce que les deux exports partagent leur format de date, et
+// que c'est précisément ce qu'on les empêche de laisser diverger.
+const ISO_Z = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
+
+test("Entrepôts : « ⧉ Copier » sort la liste du fret déposé, station et date comprises (#46)", async ({ page, context }) => {
+  // Le dépôt ne quittait jamais l'app : pour relire ce qu'on avait laissé quelque part, il fallait
+  // rouvrir le navigateur qui porte le localStorage.
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+  await jambeChargeable(page);
+  await page.locator("#journeyCard .jleg-load").first().click();
+  const nom = (await lots(page))[0].name;
+
+  await page.locator("#holdCard .hold-line", { hasText: nom }).locator(".hold-sell-btn").click();
+  await page.locator("#holdCard .hold-sell-qty").fill("5");
+  await page.locator("#holdCard .hold-store").click();
+  await expect(page.locator("#depotsCard")).toBeVisible();
+
+  // Le bouton n'existe que quand la carte est là — elle est `hidden` tant que rien n'y dort.
+  const bouton = page.locator("#depotsCard #copyDepots");
+  await expect(bouton).toBeVisible();
+  await bouton.click();
+  await expect(bouton).toHaveText("✓ Copié");
+
+  const copie = await page.evaluate(() => navigator.clipboard.readText());
+  expect(copie).toMatch(/^# Best Hauling — entrepôts · format v1 · émis \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/m);
+  // La station où le fret dort, telle que la carte la nomme, et non un index de terminal.
+  const station = Object.keys(JSON.parse(await page.evaluate(() => localStorage.getItem("best-hauling-depots"))))[0];
+  expect(copie).toContain(`## ${station}`);
+  expect(copie).toContain(`5 SCU · ${nom} @`);
+  // La date du dépôt : posée à l'instant, donc connue, et écrite en ISO 8601 UTC.
+  const depose = copie.match(/déposé (\S+)/);
+  expect(depose, "aucune date de dépôt dans l'export").not.toBeNull();
+  expect(depose[1]).toMatch(ISO_Z);
+  expect(copie).toMatch(/Total : 5 SCU déposés · [\d ]+ aUEC immobilisés/);
+});
+
+test("Corrections : « ⧉ Exporter » emporte prix ET stock, chacun avec sa date de saisie (#47)", async ({ page, context }) => {
+  // Vider son cache effaçait des dizaines de relevés faits comptoir par comptoir, et un prix corrigé
+  // ne portait AUCUNE date de saisie : `setInStore` ne posait `pris` que pour les volumes.
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+  await page.click("#viewCorrections");
+  await page.fill("#station", "Megumi — Pyro");
+  await expect(page.locator("#correctionsStation .scomm").first()).toBeVisible({ timeout: 8000 });
+
+  // Une case ne convient que si elle porte une DATE UEX (`data-u` > 0) : c'est elle qui doit
+  // ressortir en `base`. On balaie jusqu'à en trouver une, plutôt que de parier sur un rang — et la
+  // valeur saisie doit DIFFÉRER de celle d'UEX, sinon `startEdit` n'écrit rien (consulter n'est pas
+  // corriger) et le test passerait pour de mauvaises raisons.
+  async function corriger(field) {
+    const cases = page.locator(`#correctionsStation .editv[data-s="buy"][data-f="${field}"]`);
+    for (let i = 0; i < (await cases.count()); i++) {
+      const c = cases.nth(i);
+      const [u, v, commodite] = await Promise.all(
+        ["data-u", "data-v", "data-c"].map((a) => c.getAttribute(a)));
+      if (!(Number(u) > 0) || v === "") continue; // ni date UEX, ni valeur d'origine : rien à prouver
+      const valeur = Number(v) + 1;
+      await c.click();
+      const champ = c.locator("input");
+      if (!(await champ.count())) continue;
+      await champ.fill(String(valeur));
+      await champ.press("Enter");
+      return { commodite, valeur };
+    }
+    throw new Error(`aucune case « ${field} » datée par UEX sur cette station : le test ne peut rien prouver`);
+  }
+  const prixSaisi = await corriger("price");
+  const volSaisi = await corriger("vol");
+
+  const bouton = page.locator("#exportCorrections");
+  await expect(bouton).toBeVisible();
+  await bouton.click();
+  await expect(bouton).toHaveText("✓ Copié");
+
+  const sortie = JSON.parse(await page.evaluate(() => navigator.clipboard.readText()));
+  expect(sortie.v).toBe(1);
+  expect(sortie.type).toBe("corrections");
+  expect(sortie.emis).toMatch(ISO_Z);
+
+  const prix = sortie.corrections.find((c) => c.commodite === prixSaisi.commodite && c.champ === "prix");
+  const vol = sortie.corrections.find((c) => c.commodite === volSaisi.commodite && c.champ === "volume");
+  expect(prix, "le prix corrigé manque à l'export").toBeTruthy();
+  expect(vol, "le stock corrigé manque à l'export").toBeTruthy();
+  expect(prix.valeur).toBe(prixSaisi.valeur);
+  expect(vol.valeur).toBe(volSaisi.valeur);
+  // Les DEUX dates, sur les DEUX corrections, toutes en Z — c'est tout l'objet de l'issue : sans
+  // `saisi`, un prix exporté ne peut plus être daté, donc plus jamais périmé à la relecture.
+  for (const c of [prix, vol]) {
+    expect(c.terminal).toBe("Megumi");
+    expect(c.cote).toBe("achat");
+    expect(c.saisi, `${c.champ} : aucune date de saisie`).toMatch(ISO_Z);
+    expect(c.base, `${c.champ} : aucune date UEX`).toMatch(ISO_Z);
+  }
+});
+

--- a/logic.mjs
+++ b/logic.mjs
@@ -2272,12 +2272,7 @@ export function decodeJourney(str) {
 // dépôt, et une correction périme ici PAR SA DATE — deux façons de l'écrire, c'est deux façons de
 // se tromper en la relisant.
 //
-// Les deux exports partent au PRESSE-PAPIERS, jamais dans un fichier, et c'est une contrainte
-// mesurée : la CSP d'index.html pose `default-src 'self'` sans `blob:`, et sous elle un
-// `<a download href="blob:…">` ne déclenche RIEN — pas d'erreur console, pas de téléchargement,
-// juste un bouton qui ne fait rien. La même page servie sans la CSP télécharge normalement.
-// Relâcher la politique pour un bouton de copie serait la payer très cher ; scripts/csp.test.mjs
-// la verrouille, et à raison.
+// Le format seulement : où va le texte ne regarde pas ce module. Voir ADR-006 §3.
 export const FORMAT_EXPORT = 1;
 
 // Une date, écrite pour être relue sur une autre machine, dans un autre fuseau, des mois plus tard.

--- a/logic.mjs
+++ b/logic.mjs
@@ -624,12 +624,22 @@ export function setInStore(store, key, field, value, baseUpdated, nowSec = Date.
   const n = value == null || value === "" ? NaN : Math.max(0, Math.round(Number(value)));
   if (Number.isFinite(n)) o[field] = n;
   else delete o[field];
-  // `pris` n'existe que pour un volume : lui seul a une durée de vie. Nom volontairement distinct de
-  // `ts`, que effValue lit encore comme alias historique de `base` — les confondre périmerait les
-  // corrections d'anciens formats au lieu de les épargner.
-  if (field === "vol") {
-    if (Number.isFinite(n)) o.pris = Number(nowSec) || 0;
-    else delete o.pris;
+  // DEUX dates de saisie, une par champ, et surtout pas une seule pour les deux : elles ne servent
+  // pas à la même chose.
+  //   `pris`      = heure murale de la saisie du VOLUME. C'est une HORLOGE : effValue s'en sert pour
+  //                 périmer le volume au bout de DUREE_VOL.
+  //   `saisiPrix` = heure murale de la saisie du PRIX. Ce n'est PAS une horloge — rien ne régénère un
+  //                 prix faux, il ne vieillit pas (cf. DUREE_VOL) et aucun lecteur ne le périme. Elle
+  //                 existe parce qu'une correction s'exporte, et qu'un export qui ne peut pas dater
+  //                 ce qu'il transporte est inexploitable : on le réappliquerait aveuglément des
+  //                 semaines plus tard.
+  // Les deux noms sont volontairement distincts de `ts`, que effValue lit encore comme alias
+  // historique de `base` — les confondre périmerait les corrections d'anciens formats au lieu de les
+  // épargner.
+  const dateDe = field === "vol" ? "pris" : field === "price" ? "saisiPrix" : null;
+  if (dateDe) {
+    if (Number.isFinite(n)) o[dateDe] = Number(nowSec) || 0;
+    else delete o[dateDe];
   }
   if (o.price != null || o.vol != null) { o.base = Number(baseUpdated) || 0; store[key] = o; }
   else delete store[key];
@@ -672,6 +682,33 @@ export function groupOverridesByTerminal(store, actif, nowSec = Date.now() / 100
     .sort((a, b) => (b.actif ? 1 : 0) - (a.actif ? 1 : 0)
       || b.corrections - a.corrections
       || a.terminal.localeCompare(b.terminal, "fr"));
+}
+
+// Met à niveau les corrections déjà posées chez l'utilisateur, au chargement. Deux règles, et la
+// seconde est la plus importante des deux :
+//
+//   1. `ts` -> `base`. L'alias historique reste LU par effValue (compat ascendante), mais l'export
+//      ne doit pas avoir à connaître deux noms pour la même ancre : il en manquerait un le jour où
+//      un troisième apparaîtrait. La normalisation ne change aucune décision de fraîcheur —
+//      effValue traitait déjà les deux à l'identique.
+//   2. AUCUNE date de saisie n'est inventée. Un prix corrigé avant `saisiPrix` s'exporte « date
+//      inconnue » et le reste : lui poser la date du jour le ferait passer pour frais alors qu'il
+//      peut dater de trois patchs, et c'est exactement la correction qu'on réappliquerait à tort.
+//      Même prudence qu'effValue avec `pris` absent — on épargne les formats antérieurs plutôt que
+//      de les périmer, et ici on refuse aussi de les rajeunir.
+//
+// Renvoie { store, migres } ; `migres` à 0 = rien à persister (même forme que `migrerRefus`).
+export function migrerCorrections(store) {
+  const s = store || {};
+  let migres = 0;
+  for (const cle of Object.keys(s)) {
+    const o = s[cle];
+    if (!o || o.base != null || o.ts == null) continue;
+    o.base = o.ts;
+    delete o.ts;
+    migres++;
+  }
+  return { store: s, migres };
 }
 
 // ---------- État partageable (URL / localStorage) ----------
@@ -1896,11 +1933,18 @@ export function offloadPlan(market, hold, originIdx, f = {}, resolve = null, aut
 // Dépose des SCU à une station : ils quittent la soute SANS être vendus. Troisième sortie du fret,
 // et souvent la bonne quand le seul débouché est saturé — on libère la place sans vendre à perte.
 // Renvoie { hold, entrepots } ; les lots déposés gardent leur prix payé, c'est du capital immobilisé.
-export function storeFromHold(hold, entrepots, name, units, station) {
+//
+// `at` = horodatage du DÉPÔT (epoch en secondes), INJECTÉ comme celui de `loadHold` : une fonction
+// pure ne lit pas l'horloge. Le lot le porte sous `deposeAt` — un nom à lui, distinct du `at` de
+// chargement que `sellFromHold` laisse tomber en reconstruisant les lots consommés. Sans cette date,
+// une liste « j'ai laissé 170 SCU d'or à Ruin Station » ne dit pas si c'était hier ou il y a trois
+// patchs. Absente (0), elle s'exporte « date inconnue » : on n'invente pas celle du jour.
+export function storeFromHold(hold, entrepots, name, units, station, at) {
   const r = sellFromHold(hold, name, units, 0); // même consommation FIFO, sans recette
   if (!r.vendu) return { hold, entrepots };
   const deja = entrepots[station] || [];
-  return { hold: r.hold, entrepots: { ...entrepots, [station]: deja.concat(r.lots) } };
+  const deposes = r.lots.map((l) => ({ ...l, deposeAt: at || 0 }));
+  return { hold: r.hold, entrepots: { ...entrepots, [station]: deja.concat(deposes) } };
 }
 
 // Reprend `units` SCU d'une commodité DÉPOSÉE à une station : elle repasse en soute avec son prix
@@ -1910,6 +1954,11 @@ export function storeFromHold(hold, entrepots, name, units, station) {
 // FIFO, à recette nulle — reprendre n'est pas une vente, c'est le dépôt joué à l'envers.
 // La station vidée DISPARAÎT plutôt que de laisser un entrepôt à zéro : il s'afficherait comme un
 // lieu où l'on a du fret.
+//
+// La date du dépôt (`deposeAt`) NE REMONTE PAS avec le lot, et ce n'est pas un oubli : reprendre
+// n'est pas acheter. `sellFromHold` reconstruit les lots consommés en { name, units, paid, from } —
+// le lot rendu à la soute n'a donc ni `at` de chargement ni `deposeAt`, ce qui est exactement juste :
+// il n'a pas été chargé maintenant, et il n'est plus déposé nulle part.
 export function takeFromStore(hold, entrepots, name, units, station) {
   const stock = entrepots[station];
   if (!stock || !stock.length) return { hold, entrepots };
@@ -2142,4 +2191,150 @@ export function decodeJourney(str) {
   } catch {
     return null;
   }
+}
+
+// ---------- Exports datés : entrepôts et corrections (cf. ADR-006) ----------
+// Deux sorties, un seul format, décidé une fois pour les deux : ISO 8601 UTC à la seconde et
+// en-tête versionné. Les traiter séparément aurait fait diverger deux formats de date dans le même
+// dépôt, et une correction périme ici PAR SA DATE — deux façons de l'écrire, c'est deux façons de
+// se tromper en la relisant.
+//
+// Les deux exports partent au PRESSE-PAPIERS, jamais dans un fichier, et c'est une contrainte
+// mesurée : la CSP d'index.html pose `default-src 'self'` sans `blob:`, et sous elle un
+// `<a download href="blob:…">` ne déclenche RIEN — pas d'erreur console, pas de téléchargement,
+// juste un bouton qui ne fait rien. La même page servie sans la CSP télécharge normalement.
+// Relâcher la politique pour un bouton de copie serait la payer très cher ; scripts/csp.test.mjs
+// la verrouille, et à raison.
+export const FORMAT_EXPORT = 1;
+
+// Une date, écrite pour être relue sur une autre machine, dans un autre fuseau, des mois plus tard.
+// `null` quand la date n'existe pas — JAMAIS l'heure courante en remplacement : c'est la règle
+// commune aux deux exports, et le seul moyen de distinguer « déposé hier » de « je n'en sais rien ».
+export function isoUTC(sec) {
+  const n = Number(sec);
+  if (!(n > 0) || !Number.isFinite(n)) return null;
+  // TRONQUÉE, pas arrondie : la seconde PENDANT laquelle le geste a eu lieu. Arrondir daterait un
+  // dépôt de 20:13:20,7 à 20:13:21, une seconde après qu'il s'est produit.
+  return new Date(Math.floor(n) * 1000).toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+export function secDepuisISO(iso) {
+  if (!iso) return null;
+  const t = Date.parse(iso);
+  return Number.isFinite(t) ? Math.round(t / 1000) : null;
+}
+// En-tête commun aux deux sorties : le numéro de format d'abord (sans lui, la première évolution
+// casse tous les fichiers déjà émis), la date d'émission ensuite.
+export const enteteExport = (type, nowSec) => ({ v: FORMAT_EXPORT, type, emis: isoUTC(nowSec) });
+
+// Séparateur de milliers DÉTERMINISTE (espace simple). `toLocaleString("fr-FR")` aurait fait
+// l'affaire à l'écran, mais son séparateur dépend de l'ICU embarquée : un export comparé en test
+// deviendrait vert ou rouge selon la build de Node. Un export doit être reproductible.
+const milliers = (n) => String(Math.round(Number(n) || 0)).replace(/\B(?=(\d{3})+(?!\d))/g, " ");
+
+// L'export des corrections : un OBJET sérialisable, parce que celui-ci est fait pour être relu par
+// la machine (cf. relireCorrections) autant que par un humain.
+// UNE ENTRÉE PAR CHAMP corrigé : une même clé peut porter un prix ET un volume, et les deux ne
+// portent pas la même date de saisie. Deux dates par entrée, qui ne disent pas la même chose :
+//   `saisi` = quand JE l'ai corrigée (`saisiPrix` pour un prix, `pris` pour un volume) ;
+//   `base`  = la date UEX du point CONTRE laquelle la correction vaut.
+// Seules les clés à TROIS segments sortent : les relevés de tarif d'autoload vivent dans un store
+// séparé sous une clé à deux segments, et n'ont ni date UEX de référence ni péremption (même
+// frontière que `groupOverridesByTerminal`).
+export function exporterCorrections(overrides, nowSec) {
+  const store = overrides || {};
+  const corrections = [];
+  for (const cle of Object.keys(store)) {
+    const seg = cle.split("|");
+    if (seg.length !== 3) continue;
+    const [commodite, terminal, side] = seg;
+    const o = store[cle] || {};
+    const commun = {
+      commodite, terminal,
+      cote: side === "buy" ? "achat" : "vente",
+      base: isoUTC(o.base != null ? o.base : o.ts),
+    };
+    if (o.price != null) corrections.push({ ...commun, champ: "prix", valeur: o.price, saisi: isoUTC(o.saisiPrix) });
+    if (o.vol != null) corrections.push({ ...commun, champ: "volume", valeur: o.vol, saisi: isoUTC(o.pris) });
+  }
+  // Rangé PAR STATION, comme la vue Corrections (ADR-003) : c'est ainsi qu'on relit ses relevés,
+  // comptoir par comptoir. L'ordre est total et explicite — un export dont l'ordre dépend de celui
+  // des clés de localStorage ne se compare pas d'une machine à l'autre.
+  const rang = (c) => `${c.cote === "achat" ? 0 : 1}${c.champ === "prix" ? 0 : 1}`;
+  corrections.sort((a, b) =>
+    a.terminal.localeCompare(b.terminal, "fr")
+    || a.commodite.localeCompare(b.commodite, "fr")
+    || rang(a).localeCompare(rang(b)));
+  // Les champs sont réordonnés pour que chaque entrée se lise dans l'ordre où on la décrit.
+  return {
+    ...enteteExport("corrections", nowSec),
+    corrections: corrections.map((c) => ({
+      commodite: c.commodite, terminal: c.terminal, cote: c.cote,
+      champ: c.champ, valeur: c.valeur, saisi: c.saisi, base: c.base,
+    })),
+  };
+}
+
+// La relecture : que vaut encore chaque correction d'un export, aujourd'hui ? Un verdict par entrée,
+// jamais une application silencieuse.
+//   `appliquer`     — datée, ancrée, et le point n'a pas été republié depuis ;
+//   `périmée-uex`   — UEX a republié ce point après l'ancrage ;
+//   `périmée-âge`   — un VOLUME saisi il y a plus de DUREE_VOL (un prix ne vieillit jamais) ;
+//   `date-inconnue` — format antérieur, sans date de saisie : signalée, pas acceptée en silence.
+//
+// Les deux premières règles ne sont pas réécrites ici : on reconstruit la correction et on la
+// soumet à `effValue`, la MÊME fonction que le rendu. Deux implémentations de la péremption
+// finiraient par diverger, et c'est la relecture qui aurait tort sans qu'on le voie.
+// `releves` = { "Commodité|Terminal|side": date UEX courante du point }. Un point absent n'est pas
+// rejeté : ne pas connaître le relevé n'est pas la même chose que le savoir plus récent.
+export function relireCorrections(exporte, releves = {}, nowSec = Date.now() / 1000, dureeVol = DUREE_VOL) {
+  const entrees = exporte && Array.isArray(exporte.corrections) ? exporte.corrections : [];
+  return entrees.map((c) => {
+    const side = c.cote === "achat" ? "buy" : "sell";
+    const saisi = secDepuisISO(c.saisi);
+    // `base` null couvre deux cas indistinguables à l'export (ancre à 0, ancre absente) ; on les
+    // relit comme le store les écrit — `setInStore` pose toujours `Number(baseUpdated) || 0`.
+    const o = { base: secDepuisISO(c.base) || 0 };
+    if (c.champ === "prix") o.price = c.valeur;
+    else { o.vol = c.valeur; if (saisi != null) o.pris = saisi; }
+    const r = effValue(o, null, null, releves[ovKey(c.commodite, c.terminal, side)], nowSec, dureeVol);
+    const verdict = r.stale ? "périmée-uex"
+      : r.staleVol ? "périmée-âge"
+      : saisi == null ? "date-inconnue"
+      : "appliquer";
+    return { ...c, verdict };
+  });
+}
+
+// L'export des entrepôts : du TEXTE, et c'est délibéré — celui-ci n'est pas fait pour être relu par
+// la machine mais collé dans un bloc-notes, un second écran ou un canal Discord d'org. Du JSON y
+// serait illisible là où il sert.
+// UNE LIGNE PAR LOT, pas par commodité : deux lots de la même commodité peuvent avoir été déposés
+// des jours d'écart et venir de stations différentes — les regrouper effacerait précisément ce que
+// cet export existe pour dire.
+export function exporterEntrepots(entrepots, nowSec) {
+  const e = entrepots || {};
+  const stations = Object.keys(e)
+    .filter((s) => Array.isArray(e[s]) && e[s].length)
+    .sort((a, b) => a.localeCompare(b, "fr"));
+  const entete = enteteExport("entrepots", nowSec);
+  const lignes = [`# Best Hauling — entrepôts · format v${entete.v} · émis ${entete.emis}`];
+  let scuTotal = 0, investTotal = 0;
+  for (const station of stations) {
+    const lots = e[station];
+    const scu = lots.reduce((s, l) => s + (l.units || 0), 0);
+    const invest = lots.reduce((s, l) => s + (l.units || 0) * (l.paid || 0), 0);
+    scuTotal += scu;
+    investTotal += invest;
+    lignes.push("", `## ${station}`);
+    for (const l of lots) {
+      const date = isoUTC(l.deposeAt);
+      lignes.push(`- ${milliers(l.units || 0)} SCU · ${l.name} @ ${milliers(l.paid || 0)} aUEC/SCU`
+        + ` · ${date ? `déposé ${date}` : "déposé à une date inconnue"}`
+        + ` · ${l.from ? `chargé à ${l.from}` : "provenance inconnue"}`);
+    }
+    lignes.push(`  sous-total ${milliers(scu)} SCU · ${milliers(invest)} aUEC immobilisés`);
+  }
+  // Les deux chiffres que la carte affiche déjà, repris en pied : de l'argent déjà sorti.
+  lignes.push("", `Total : ${milliers(scuTotal)} SCU déposés · ${milliers(investTotal)} aUEC immobilisés`);
+  return lignes.join("\n");
 }

--- a/logic.test.mjs
+++ b/logic.test.mjs
@@ -761,7 +761,7 @@ test("effFromStore : SUPPRIME du store la correction périmée par un relevé pl
   assert.equal("k" in store, false);   // effet de bord : périmée -> supprimée
 });
 
-test("setInStore : un volume enregistre l'heure de saisie, un prix non", () => {
+test("setInStore : un volume est daté sous `pris`, un prix sous `saisiPrix` — jamais l'un sous l'autre", () => {
   const store = {};
   setInStore(store, "A|T|buy", "vol", 12, 111, MAINTENANT);
   assert.equal(store["A|T|buy"].pris, MAINTENANT);

--- a/logic.test.mjs
+++ b/logic.test.mjs
@@ -26,6 +26,8 @@ import {
   cleApresRetrait, reindexerRangsJambe, detacherLotsDeJambe,
   soldeDuPoint, poserChargement, retirerChargement, migrerChargements,
   stationTree, groupOverridesByTerminal,
+  isoUTC, secDepuisISO, FORMAT_EXPORT, migrerCorrections,
+  exporterCorrections, relireCorrections, exporterEntrepots,
 } from "./logic.mjs";
 
 // ---------- Temps de trajet ----------
@@ -717,13 +719,13 @@ test("ovKey : clé stable commodité|terminal|side", () => {
 });
 
 test("setInStore : enregistre prix + base, efface un champ, supprime la clé si vide", () => {
-  // Horloge passée explicitement : un volume enregistre son heure de saisie (`pris`), qui serait
-  // sinon celle du run et rendrait la comparaison non déterministe.
+  // Horloge passée explicitement : chaque champ enregistre son heure de saisie (`pris` pour un
+  // volume, `saisiPrix` pour un prix), qui serait sinon celle du run — comparaison non déterministe.
   const store = {};
   setInStore(store, "A|T|buy", "price", "7000", 111, MAINTENANT);
-  assert.deepEqual(store["A|T|buy"], { price: 7000, base: 111 }); // valeur arrondie + base, pas de `pris`
+  assert.deepEqual(store["A|T|buy"], { price: 7000, saisiPrix: MAINTENANT, base: 111 }); // arrondi + base
   setInStore(store, "A|T|buy", "vol", 50, 222, MAINTENANT);
-  assert.deepEqual(store["A|T|buy"], { price: 7000, vol: 50, base: 222, pris: MAINTENANT });
+  assert.deepEqual(store["A|T|buy"], { price: 7000, saisiPrix: MAINTENANT, vol: 50, base: 222, pris: MAINTENANT });
   setInStore(store, "A|T|buy", "price", "", 222, MAINTENANT); // efface le prix
   assert.deepEqual(store["A|T|buy"], { vol: 50, base: 222, pris: MAINTENANT });
   setInStore(store, "A|T|buy", "vol", null, 222, MAINTENANT);  // plus rien -> clé supprimée
@@ -773,7 +775,7 @@ test("setInStore : effacer le volume retire aussi son heure de saisie", () => {
   setInStore(store, "k", "vol", 12, 111, MAINTENANT);
   setInStore(store, "k", "price", 7000, 111, MAINTENANT);
   setInStore(store, "k", "vol", null, 111, MAINTENANT);
-  assert.deepEqual(store.k, { price: 7000, base: 111 }); // ni vol, ni pris
+  assert.deepEqual(store.k, { price: 7000, saisiPrix: MAINTENANT, base: 111 }); // ni vol, ni pris
 });
 
 test("effFromStore : le volume périmé quitte le store, le prix y reste", () => {
@@ -3927,4 +3929,244 @@ test("classement : la route la plus rentable passe DEVANT (contre-exemple 1 de l
   assert.equal(classe[0], grosse);
   // Et la fiabilité dit toujours la vérité sur la donnée, sans commander le classement.
   assert.ok(petite.fiabilite > grosse.fiabilite, "la fraîche et publiée reste la mieux notée");
+});
+
+// ---------- Exports datés : entrepôts (#46) et corrections (#47) ----------
+// Un seul format pour les deux sorties : ISO 8601 UTC à la seconde, en-tête versionné. Les tests
+// figent l'horloge (MAINTENANT) et comparent la sortie ENTIÈRE — un export dont on ne vérifie que
+// des morceaux laisse passer exactement ce qui le rend inexploitable : une date manquante.
+
+test("isoUTC : ISO 8601 UTC à la seconde, suffixe Z, jamais de millisecondes", () => {
+  assert.equal(isoUTC(MAINTENANT), "2023-11-14T22:13:20Z");
+  // Tronquée, jamais arrondie : la seconde PENDANT laquelle le geste a eu lieu.
+  assert.equal(isoUTC(1699992800.7), "2023-11-14T20:13:20Z");
+  // Pas de date -> null, et surtout pas la date du jour : c'est toute la règle des deux issues.
+  for (const rien of [0, null, undefined, NaN, ""]) assert.equal(isoUTC(rien), null);
+});
+
+test("secDepuisISO : l'aller-retour rend l'epoch d'origine", () => {
+  assert.equal(secDepuisISO(isoUTC(MAINTENANT)), MAINTENANT);
+  assert.equal(secDepuisISO(null), null);
+  assert.equal(secDepuisISO("pas une date"), null);
+});
+
+// ---------- #47 : setInStore date AUSSI les prix ----------
+test("setInStore : un prix corrigé porte enfin sa date de saisie", () => {
+  // Avant : `o.pris` n'était posé que sous `if (field === "vol")`, donc rien ne datait un prix —
+  // et une correction qu'on ne peut pas dater ne peut pas périmer (spec du 2026-08-12).
+  const store = {};
+  setInStore(store, "A|T|buy", "price", 7000, 111, MAINTENANT);
+  assert.equal(store["A|T|buy"].saisiPrix, MAINTENANT);
+  // `pris` reste au VOLUME seul : lui seul a une durée de vie, et les confondre périmerait les prix.
+  assert.equal("pris" in store["A|T|buy"], false);
+  // `ts` n'est pas touché non plus : effValue le lit encore comme alias historique de `base`.
+  assert.equal("ts" in store["A|T|buy"], false);
+});
+
+test("setInStore : effacer le prix retire aussi sa date de saisie", () => {
+  const store = {};
+  setInStore(store, "k", "price", 7000, 111, MAINTENANT);
+  setInStore(store, "k", "vol", 12, 111, MAINTENANT);
+  setInStore(store, "k", "price", "", 111, MAINTENANT);
+  assert.deepEqual(store.k, { vol: 12, base: 111, pris: MAINTENANT }); // ni price, ni saisiPrix
+});
+
+test("setInStore : dater le prix ne périme rien — effValue l'applique toujours", () => {
+  // Garde-fou : `saisiPrix` est une date de PROVENANCE, pas une horloge. Un prix ne vieillit pas.
+  const store = {};
+  setInStore(store, "k", "price", 7000, 1000, IL_Y_A(30 * 86400)); // corrigé il y a un mois
+  const r = effValue(store.k, 100, 50, 900, MAINTENANT);
+  assert.equal(r.price, 7000);
+  assert.equal(r.oprice, true);
+  assert.equal(r.stale, false);
+  assert.equal(r.staleVol, false);
+});
+
+// ---------- #47 : migration des corrections déjà posées ----------
+test("migrerCorrections : n'invente JAMAIS une date de saisie pour un prix d'un format antérieur", () => {
+  // Le piège de #47 : leur poser la date du jour les ferait passer pour fraîches alors qu'elles
+  // peuvent dater de trois patchs. On préfère « inconnue » à « fausse ».
+  const store = OV({ "Gold|Ruin Station|buy": { price: 7000, base: 1000 } });
+  const r = migrerCorrections(store);
+  assert.equal("saisiPrix" in r.store["Gold|Ruin Station|buy"], false);
+  assert.deepEqual(r.store["Gold|Ruin Station|buy"], { price: 7000, base: 1000 });
+});
+
+test("migrerCorrections : `ts`, alias historique de `base`, est normalisé — l'export n'a qu'un nom à lire", () => {
+  const store = OV({ "Gold|Ruin Station|buy": { price: 7000, ts: 1000 } });
+  const r = migrerCorrections(store);
+  assert.equal(r.migres, 1);
+  assert.deepEqual(r.store["Gold|Ruin Station|buy"], { price: 7000, base: 1000 });
+  // Et la fraîcheur ne bouge pas d'un iota : effValue lisait déjà `ts` comme `base`.
+  assert.equal(effValue(r.store["Gold|Ruin Station|buy"], 1, 1, 1500).stale, true);
+});
+
+test("migrerCorrections : rien à faire -> `migres` à 0 (l'appelant n'écrit pas dans localStorage)", () => {
+  const store = OV({ "Gold|Ruin Station|buy": { price: 7000, base: 1000, saisiPrix: MAINTENANT } });
+  assert.equal(migrerCorrections(store).migres, 0);
+});
+
+// ---------- #47 : l'export des corrections ----------
+const OV_EXPORT = () => OV({
+  "Gold|Ruin Station|buy": { price: 7000, vol: 120, base: 1699000000, saisiPrix: IL_Y_A(7200), pris: IL_Y_A(7200) },
+  "Laranite|GrimHEX|sell": { price: 31200, base: 1698000000 },          // format antérieur : pas de saisiPrix
+  "autoload|GrimHEX": { k: 1.4, amount: 900, scu: 100 },                 // clé à DEUX segments
+});
+
+test("exporterCorrections : en-tête versionné, deux dates par correction, tout en ISO 8601 UTC", () => {
+  assert.deepEqual(exporterCorrections(OV_EXPORT(), MAINTENANT), {
+    v: 1,
+    type: "corrections",
+    emis: "2023-11-14T22:13:20Z",
+    corrections: [
+      { commodite: "Laranite", terminal: "GrimHEX", cote: "vente", champ: "prix",
+        valeur: 31200, saisi: null, base: "2023-10-22T18:40:00Z" },
+      { commodite: "Gold", terminal: "Ruin Station", cote: "achat", champ: "prix",
+        valeur: 7000, saisi: "2023-11-14T20:13:20Z", base: "2023-11-03T08:26:40Z" },
+      { commodite: "Gold", terminal: "Ruin Station", cote: "achat", champ: "volume",
+        valeur: 120, saisi: "2023-11-14T20:13:20Z", base: "2023-11-03T08:26:40Z" },
+    ],
+  });
+});
+
+test("exporterCorrections : le numéro de format est là, sinon la première évolution casse tout", () => {
+  assert.equal(exporterCorrections({}, MAINTENANT).v, FORMAT_EXPORT);
+  assert.equal(FORMAT_EXPORT, 1);
+});
+
+test("exporterCorrections : les relevés d'autoload (clé à DEUX segments) n'y entrent pas", () => {
+  const sorti = exporterCorrections(OV_EXPORT(), MAINTENANT).corrections;
+  assert.equal(sorti.some((c) => c.commodite === "autoload"), false);
+  assert.equal(sorti.length, 3); // 2 champs sur Ruin Station + 1 sur GrimHEX, et rien d'autre
+});
+
+test("exporterCorrections : un prix d'un format antérieur sort « date de saisie inconnue », pas daté d'aujourd'hui", () => {
+  const c = exporterCorrections(OV({ "Laranite|GrimHEX|sell": { price: 31200, base: 1698000000 } }), MAINTENANT);
+  assert.equal(c.corrections[0].saisi, null);
+});
+
+test("exporterCorrections : une date UEX absente ou nulle sort `null`, jamais un epoch nu", () => {
+  const c = exporterCorrections(OV({ "Gold|T|buy": { price: 10, base: 0 }, "Iron|T|buy": { price: 10 } }), MAINTENANT);
+  assert.equal(c.corrections.length, 2);
+  for (const e of c.corrections) assert.equal(e.base, null);
+});
+
+// ---------- #47 : la relecture, qui réutilise effValue plutôt que de réécrire la règle ----------
+const RELU = (o, releves = {}, now = MAINTENANT) =>
+  relireCorrections(exporterCorrections(OV(o), MAINTENANT), releves, now).map((c) => c.verdict);
+
+test("relireCorrections : les quatre verdicts", () => {
+  // 1. appliquer — datée, ancrée, et le point n'a pas été republié depuis.
+  assert.deepEqual(RELU({ "Gold|T|buy": { price: 7000, base: 1000, saisiPrix: IL_Y_A(60) } },
+    { "Gold|T|buy": 900 }), ["appliquer"]);
+  // 2. périmée-uex — UEX a republié le point APRÈS l'ancrage (c'est exactement `stale`).
+  assert.deepEqual(RELU({ "Gold|T|buy": { price: 7000, base: 1000, saisiPrix: IL_Y_A(60) } },
+    { "Gold|T|buy": 1500 }), ["périmée-uex"]);
+  // 3. périmée-âge — un VOLUME saisi il y a plus de DUREE_VOL.
+  assert.deepEqual(RELU({ "Gold|T|buy": { vol: 120, base: 1000, pris: IL_Y_A(4 * 3600) } },
+    { "Gold|T|buy": 900 }), ["périmée-âge"]);
+  // 4. date-inconnue — format antérieur : signalée, jamais appliquée en silence.
+  assert.deepEqual(RELU({ "Gold|T|buy": { price: 7000, base: 1000 } },
+    { "Gold|T|buy": 900 }), ["date-inconnue"]);
+});
+
+test("relireCorrections : un prix ne périme JAMAIS par l'âge, si vieux soit-il", () => {
+  assert.deepEqual(RELU({ "Gold|T|buy": { price: 7000, base: 1000, saisiPrix: IL_Y_A(90 * 86400) } },
+    { "Gold|T|buy": 900 }), ["appliquer"]);
+});
+
+test("relireCorrections : un point dont on n'a aucun relevé n'est pas rejeté par UEX", () => {
+  assert.deepEqual(RELU({ "Gold|T|buy": { price: 7000, base: 1000, saisiPrix: IL_Y_A(60) } }, {}), ["appliquer"]);
+});
+
+test("relireCorrections : UEX l'emporte sur l'âge — un volume vieux ET republié est rejeté par UEX", () => {
+  assert.deepEqual(RELU({ "Gold|T|buy": { vol: 120, base: 1000, pris: IL_Y_A(4 * 3600) } },
+    { "Gold|T|buy": 1500 }), ["périmée-uex"]);
+});
+
+test("relireCorrections : rend la correction entière, pas seulement son verdict", () => {
+  const r = relireCorrections(exporterCorrections(
+    OV({ "Gold|Ruin Station|buy": { price: 7000, base: 1000, saisiPrix: IL_Y_A(60) } }), MAINTENANT), {}, MAINTENANT);
+  assert.deepEqual(r, [{ commodite: "Gold", terminal: "Ruin Station", cote: "achat", champ: "prix",
+    valeur: 7000, saisi: "2023-11-14T22:12:20Z", base: "1970-01-01T00:16:40Z", verdict: "appliquer" }]);
+});
+
+// ---------- #46 : le dépôt est daté ----------
+test("storeFromHold : chaque lot déposé porte la date du dépôt, INJECTÉE (aucune horloge cachée)", () => {
+  const h = loadHold([], [ligne(2200, 1000, 1400)], "Megumi", 1);
+  const r = storeFromHold(h, {}, "Gold", 2170, "Ruin Station — Pyro", MAINTENANT);
+  assert.equal(r.entrepots["Ruin Station — Pyro"][0].deposeAt, MAINTENANT);
+  // Sans date fournie : 0, comme `loadHold` — surtout pas l'heure du run.
+  assert.equal(storeFromHold(h, {}, "Gold", 10, "X").entrepots.X[0].deposeAt, 0);
+});
+
+test("takeFromStore : reprendre n'est pas acheter — la date du dépôt ne devient pas un `at` de chargement", () => {
+  const h = loadHold([], [ligne(2200, 1000, 1400)], "Megumi", 1);
+  const d = storeFromHold(h, {}, "Gold", 2170, "Ruin Station — Pyro", MAINTENANT);
+  const repris = takeFromStore([], d.entrepots, "Gold", 170, "Ruin Station — Pyro").hold[0];
+  assert.equal("at" in repris, false);
+  assert.equal("deposeAt" in repris, false);
+  assert.deepEqual(repris, { name: "Gold", units: 170, paid: 1000, from: "Megumi" });
+});
+
+test("storeFromHold/takeFromStore : dater le dépôt ne change rien à l'aller-retour", () => {
+  // L'invariant de #10 reste entier : déposer puis tout reprendre rend exactement la soute d'avant.
+  const h = loadHold([], [ligne(2200, 1000, 1400)], "Megumi", 1);
+  const d = storeFromHold(h, {}, "Gold", 2170, "Ruin Station — Pyro", MAINTENANT);
+  const t = takeFromStore(d.hold, d.entrepots, "Gold", 2170, "Ruin Station — Pyro");
+  assert.equal(holdScu(t.hold), holdScu(h));
+  assert.deepEqual(t.entrepots, {});
+});
+
+// ---------- #46 : l'export des entrepôts ----------
+test("exporterEntrepots : liste par station, une ligne par lot, sortie comparée en entier", () => {
+  const entrepots = {
+    "Ruin Station — Pyro": [
+      { name: "Gold", units: 170, paid: 1000, from: "Megumi", deposeAt: IL_Y_A(7200) },
+      { name: "Laranite", units: 30, paid: 900, from: "Checkmate", deposeAt: IL_Y_A(4 * 3600) },
+    ],
+    "Area18 — Stanton": [{ name: "Gold", units: 5, paid: 1200, from: "Megumi", deposeAt: MAINTENANT }],
+  };
+  assert.equal(exporterEntrepots(entrepots, MAINTENANT), [
+    "# Best Hauling — entrepôts · format v1 · émis 2023-11-14T22:13:20Z",
+    "",
+    "## Area18 — Stanton",
+    "- 5 SCU · Gold @ 1 200 aUEC/SCU · déposé 2023-11-14T22:13:20Z · chargé à Megumi",
+    "  sous-total 5 SCU · 6 000 aUEC immobilisés",
+    "",
+    "## Ruin Station — Pyro",
+    "- 170 SCU · Gold @ 1 000 aUEC/SCU · déposé 2023-11-14T20:13:20Z · chargé à Megumi",
+    "- 30 SCU · Laranite @ 900 aUEC/SCU · déposé 2023-11-14T18:13:20Z · chargé à Checkmate",
+    "  sous-total 200 SCU · 197 000 aUEC immobilisés",
+    "",
+    "Total : 205 SCU déposés · 203 000 aUEC immobilisés",
+  ].join("\n"));
+});
+
+test("exporterEntrepots : un lot déposé AVANT ce correctif s'affiche « date inconnue », pas aujourd'hui", () => {
+  const entrepots = { "Ruin Station — Pyro": [{ name: "Gold", units: 170, paid: 1000, from: "Megumi" }] };
+  const texte = exporterEntrepots(entrepots, MAINTENANT);
+  assert.match(texte, /déposé à une date inconnue/);
+  assert.equal(texte.includes("déposé 2023-11-14T22:13:20Z"), false); // surtout pas la date d'émission
+});
+
+test("exporterEntrepots : une provenance perdue se dit, elle ne se devine pas", () => {
+  const texte = exporterEntrepots({ X: [{ name: "Gold", units: 1, paid: 0, deposeAt: MAINTENANT }] }, MAINTENANT);
+  assert.match(texte, /provenance inconnue/);
+});
+
+test("exporterEntrepots : rien de déposé -> l'en-tête daté et un total à zéro, jamais une chaîne vide", () => {
+  assert.equal(exporterEntrepots({}, MAINTENANT), [
+    "# Best Hauling — entrepôts · format v1 · émis 2023-11-14T22:13:20Z",
+    "",
+    "Total : 0 SCU déposés · 0 aUEC immobilisés",
+  ].join("\n"));
+});
+
+test("les deux exports partagent le même en-tête daté et le même numéro de format", () => {
+  // C'est la raison d'être de la PR unique : deux formats de date dans un même dépôt divergeraient.
+  const corr = exporterCorrections({}, MAINTENANT);
+  const entr = exporterEntrepots({}, MAINTENANT);
+  assert.equal(corr.emis, isoUTC(MAINTENANT));
+  assert.ok(entr.startsWith(`# Best Hauling — entrepôts · format v${corr.v} · émis ${corr.emis}`));
 });

--- a/style.css
+++ b/style.css
@@ -510,6 +510,16 @@ input.jman-qty { width: 56px; min-width: 0; padding: 3px 5px; text-align: right;
    les deux serait recompter le fret déposé dans la place disponible. */
 .depots-card { border-left-color: var(--acc-2); }
 .depots-card .hold-title { color: var(--acc-2); }
+/* Le bouton de copie tient dans une carte de colonne, pas dans un bandeau pleine largeur comme
+   celui du manifeste : même style, un cran plus compact, et TEINTÉ comme la carte. En ambre, il
+   passait devant « ↑ reprendre » — l'action qui compte ici — alors qu'il ne fait que sortir une
+   liste. Le retour « ✓ Copié » reste vert : c'est le même signal partout dans l'app. */
+.depots-card .hold-head .copy-btn {
+  font-size: 11px; padding: 5px 11px;
+  color: var(--acc-2); background: rgba(169, 112, 255, 0.08); border-color: rgba(169, 112, 255, 0.4);
+}
+.depots-card .hold-head .copy-btn:hover { color: #fff; background: rgba(169, 112, 255, 0.18); }
+.depots-card .hold-head .copy-btn.copied { color: #04120a; background: var(--good); border-color: var(--good); }
 .depot-stations { display: flex; flex-direction: column; gap: 11px; }
 .depot-lieu { display: flex; align-items: center; gap: 6px; font-size: 11.5px; margin-bottom: 5px; }
 .depot-take {
@@ -1001,6 +1011,11 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 .corr-side { font-size: 10px; text-transform: uppercase; letter-spacing: 1px; color: var(--muted); border: 1px solid var(--line2); border-radius: 3px; padding: 1px 6px; margin-left: 4px; }
 .corr-del { flex-shrink: 0; width: 26px; height: 26px; border-radius: 4px; cursor: pointer; color: var(--bad); background: rgba(255, 93, 93, 0.08); border: 1px solid rgba(255, 93, 93, 0.35); font-size: 13px; line-height: 1; transition: color 0.12s, background 0.12s; }
 .corr-del:hover { color: #fff; background: #6b1c1c; }
+/* Les deux boutons de fin de bandeau restent COLLÉS à droite : c'est le `margin-left: auto` du
+   premier qui pousse la paire, jamais celui des deux — deux marges automatiques se partageraient
+   l'espace libre et les écarteraient l'un de l'autre au milieu du bandeau. */
+.corr-list-head .copy-btn { margin-left: auto; font-size: 11px; padding: 5px 11px; }
+.corr-list-head .copy-btn + .reset-ov { margin-left: 0; }
 .reset-ov { margin-left: auto; color: var(--warn); border-color: #5a4a1c; background: rgba(245,167,66,.08); border-radius: 3px; padding: 5px 11px; cursor: pointer; font-family: var(--font); font-size: 11px; font-weight: 600; }
 .reset-ov:hover { color: #fff; border-color: var(--warn); background: rgba(245, 167, 66, 0.16); }
 


### PR DESCRIPTION
## Ce que ça change

Deux boutons de copie, et **un seul format** pour les deux. La carte **⬓ Entrepôts** porte un
`⧉ Copier` qui met dans le presse-papiers la liste du fret déposé, station par station, une ligne par
lot, avec la **date du dépôt**. Le bandeau de la vue **Corrections** porte un `⧉ Exporter` (juste
avant « Tout réinitialiser ») qui sort en JSON versionné toutes les corrections locales, chacune avec
**sa date de saisie** et **sa date UEX de référence**. Toutes les dates en ISO 8601 UTC
(`2026-08-15T09:12:00Z`).

## Pourquoi

Aucune des deux données ne quittait l'app : pour relire ce qu'on avait déposé quelque part il fallait
rouvrir le navigateur qui porte le `localStorage`, et vider son cache effaçait des dizaines de
corrections relevées comptoir par comptoir.

Mais le problème était plus profond qu'un bouton manquant — **la donnée à exporter était incomplète**,
et les deux causes racines sont confirmées contre le code de `main` :

- **`logic.mjs:622-637` `setInStore`** — `o.pris` n'était posé que sous `if (field === "vol")`
  (`logic.mjs:630`). **Un prix corrigé ne portait aucune date de saisie.** Or dans ce dépôt une
  correction périme *par sa date* ([spec du 2026-08-12](docs/superpowers/specs/2026-08-12-peremption-des-volumes-et-corrections-groupees-design.md)) :
  un export qui l'omet produit exactement le cas que la spec interdit — une correction qu'on ne peut
  plus dater, donc plus périmer, donc qu'on réappliquerait aveuglément.
- **`logic.mjs:1689` (`sellFromHold`)** — les lots consommés sont reconstruits en
  `{ name, units, paid, from }`, le `at` posé par `loadHold` (`logic.mjs:1647`) est perdu au passage,
  et **`logic.mjs:1899` `storeFromHold`** n'ajoutait rien. Un lot d'entrepôt ne savait donc ni quand
  il avait été chargé, ni quand il avait été déposé.

Les deux issues portaient le même format et se sont explicitement renvoyé la balle : une seule PR,
donc, et une décision unique consignée en
**[ADR-006](docs/superpowers/specs/2026-08-15-format-des-exports-adr.md)**.

### Le point tranché : presse-papiers, et c'est une mesure, pas une préférence

`index.html:23` pose `default-src 'self'` **sans `blob:`**, verrouillé par `scripts/csp.test.mjs`.
Sonde jetable passée sous Chromium, sur la page réellement servie :

| page (même origine) | `URL.createObjectURL` | clic sur `<a download href="blob:…">` | erreur console |
|---|---|---|---|
| `index.html` (avec la CSP) | rend bien un `blob:` | **aucun téléchargement** | **aucune** |
| page témoin sans CSP | rend bien un `blob:` | `essai.txt` téléchargé | aucune |

```
SONDE AVEC CSP >>> {"url":"blob:","erreur":null,"dl":"AUCUN TÉLÉCHARGEMENT","erreurs":[]}
SONDE SANS CSP >>> {"url":"blob:","erreur":null,"dl":"essai.txt","erreurs":[]}
```

Le bouton serait **mort en silence** : ni exception, ni message, rien à déboguer. Relâcher la CSP pour
un bouton de copie la paierait bien trop cher. Les trois boutons passent donc par un chemin unique,
`copierTexte` (app.js), déjà éprouvé par le `⧉ Copier` du manifeste.

### Ce que ça implique dans le store

- `saisiPrix` — date de saisie du **prix**. Ce n'est **pas** une horloge : rien ne régénère un prix
  faux, il ne vieillit pas, aucun lecteur ne le périme. `pris` reste l'horloge du **volume**. Les deux
  restent distincts de `ts`, que `effValue` lit encore comme alias historique de `base` — les
  confondre périmerait les corrections d'anciens formats.
- `deposeAt` sur les lots d'entrepôt, **injecté en paramètre** (`storeFromHold(…, station, at)`, comme
  `loadHold`) : une fonction pure ne lit pas l'horloge. `takeFromStore` ne le remonte pas en `at` —
  reprendre n'est pas acheter.
- `migrerCorrections(store)` (forme de `migrerRefus` : `{ store, migres }`) normalise `ts` → `base` et
  **n'invente aucune date**. Une correction ou un dépôt d'un format antérieur sort « inconnue », jamais
  la date du jour : c'est précisément celle qu'on réappliquerait à tort.

## Vérification

**Le rouge, prouvé avant.** Les tests `node --test` échouaient au chargement du module (les fonctions
n'existaient pas) :

```
SyntaxError: The requested module './logic.mjs' does not provide an export named 'FORMAT_EXPORT'
✖ logic.test.mjs (43.8594ms)
ℹ tests 1 · ℹ pass 0 · ℹ fail 1
```

Et pour les deux e2e, sources remisées (`git stash` d'`app.js`/`logic.mjs`/`style.css`, tests
conservés) :

```
1) Entrepôts : « ⧉ Copier » sort la liste du fret déposé… (#46)
   Error: expect(locator).toBeVisible() failed
   Locator: locator('#depotsCard #copyDepots')  —  element(s) not found

2) Corrections : « ⧉ Exporter » emporte prix ET stock… (#47)
   Error: expect(locator).toBeVisible() failed
   Locator: locator('#exportCorrections')  —  element(s) not found

2 failed
```

**Le vert, après.**

```
$ node --test
ℹ tests 442
ℹ suites 0
ℹ pass 442
ℹ fail 0
```

`logic.test.mjs` passe de **366 à 392** (26 tests neufs) ; le total, `scripts/*.test.mjs` compris,
de **416 à 442**.

```
$ npx playwright test
[136/137] … › Entrepôts : « ⧉ Copier » sort la liste du fret déposé, station et date comprises (#46)
[137/137] … › Corrections : « ⧉ Exporter » emporte prix ET stock, chacun avec sa date de saisie (#47)
  2 skipped
  135 passed (1.2m)
```

Les 2 `skipped` sont les sauts conditionnels préexistants (jeu de données sans capacité inconnue).

**Trois tests existants ont vu leur forme attendue s'élargir**, jamais leur intention :
`setInStore : enregistre prix + base…` et `setInStore : effacer le volume retire aussi son heure de
saisie` comparaient l'objet entier en `deepEqual` et gagnent `saisiPrix`. L'assertion qui compte —
« un prix ne reçoit **pas** de `pris` » — est conservée telle quelle et doublée d'un garde-fou neuf
(`setInStore : dater le prix ne périme rien`), qui vérifie qu'`effValue` applique toujours un prix
corrigé il y a un mois.

**Les nouveaux tests `node --test`** couvrent : le format ISO (troncature à la seconde, `null` sur
date absente, aller-retour `secDepuisISO`), les deux exports comparés **en entier** sur une horloge
figée, le numéro de format, l'exclusion des clés à deux segments (relevés d'autoload), les **quatre
verdicts** de `relireCorrections` et leur ordre de priorité, l'absence de date inventée sur les deux
formats antérieurs, et l'invariant de #10 (« déposer puis tout reprendre rend exactement la soute
d'avant ») laissé intact.

**Contrôle visuel** des deux boutons (capture jetable, supprimée depuis) : le `⧉ Copier` des entrepôts
est teinté au violet de la carte plutôt qu'à l'ambre par défaut — en ambre il passait devant
`↑ reprendre`, l'action qui compte, alors qu'il ne fait que sortir une liste. Le retour `✓ Copié`
reste vert, comme partout ailleurs.

**Écarts d'ancrage.** Les numéros de ligne des deux issues étaient périmés d'une quinzaine de PR ;
tout a été retrouvé **par le nom**. Les principaux écarts, mesurés sur `main` (`9671238`) :

| annoncé | réel | |
|---|---|---|
| `logic.mjs:573-588` `setInStore` | **`logic.mjs:622-637`** | +49 |
| `logic.mjs:217-235` `effValue` | **`logic.mjs:242-260`** | +25 |
| `logic.mjs:1662-1667` `storeFromHold` | **`logic.mjs:1899-1904`** | +237 |
| `logic.mjs:1487` (perte du `at`) | **`logic.mjs:1689`** | +202 |
| `app.js:1332-1338` `DEPOTS_KEY` | **`app.js:1502-1507`** | +170 |
| `app.js:1375-1397` `renderEntrepots` | **`app.js:1544-1566`** | +169 |
| `app.js:1053-1074` `copyManifest` | **`app.js:1167-1187`** | +114 |
| `app.js:2696-2720` `correctionsIndexHTML` | **`app.js:2887-2911`** | +191 |
| `README.md:281-291` (Entrepôts) | **`README.md:313-320`** | +32 |

En revanche `app.js:165` (`OV_KEY`), `app.js:187-202` (`effVals` / `setOverride`) et
`app.js:212-227` (`AUTOLOAD_K`) étaient **exacts**. Les deux causes racines annoncées, elles, ont été
revérifiées contre le code et sont **justes** toutes les deux.

## Ce qui n'est pas couvert

- **`relireCorrections` n'est appelée par aucun bouton.** Elle est exigée par les critères
  d'acceptation de #47 et elle prouve que le format est relisible *par construction* (ses quatre
  verdicts sont testés), mais **aucun import n'est décidé ici** : rien ne réinjecte encore un export
  dans le store. C'est la seule fonction publique de la PR sans appelant dans `app.js`, et c'est
  assumé — voir « Ce que la décision n'ouvre pas » dans l'ADR.
- **L'export des entrepôts liste par LOT, pas par commodité**, contrairement à la carte. Deux lots de
  la même commodité peuvent avoir été déposés à des jours d'écart et venir de stations différentes :
  les regrouper effacerait la date et la provenance, c'est-à-dire précisément ce que l'export existe
  pour dire.
- **Les relevés de tarif d'autoload** restent hors des deux exports (store séparé, clé à deux
  segments, ni date UEX ni péremption *par conception*). Les inclure suppose de décider s'ils doivent
  être datés : hors périmètre des deux issues.
- **Aucune date n'est affichée à l'écran**, ni dans la carte Entrepôts ni dans la vue Corrections. La
  donnée existe désormais ; la montrer est une autre décision (la vue Corrections sort d'une refonte,
  #38).
- **Le lien de partage** continue à ne transporter aucune donnée locale — frontière assumée.
- **La soute** (`#holdCard`) et le voyage n'ont pas de bouton d'export : même mécanique possible,
  autre décision.
- **Pas de fusion ni de synchronisation** entre deux exports, ni entre machines.
- Les **corrections déjà en `localStorage`** ne gagnent aucune date rétroactive et ne peuvent donc pas
  être périmées par l'âge à la relecture : elles ressortent `date-inconnue`. C'est le choix, pas une
  limite subie — inventer une date serait pire.

Closes #46
Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)
