### PR TITLE
feat(chaine): chaque saut remplit la soute avec plusieurs commodités, pas une seule

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Six vues, un même moteur de calcul (soute SCU + budget aUEC → unités, coût,
 | **Trajets simples** | Meilleures routes A→B, triables, triées par **profit net** par défaut. Une colonne **Fiabilité** dit ce qu'on sait de la donnée — fraîcheur du relevé × part du volume publiée par UEX — **sans entrer dans le tri** ([ADR-005](docs/superpowers/specs/2026-08-14-refonte-du-score-adr.md)). Coche **Multi commodité** : liste plutôt les **chargements combinés** (plusieurs commodités d'un même A vers un même B), dépliables (📦) pour voir le détail par commodité |
 | **Boucles ⇄** | Meilleures boucles A⇄B (une commodité à l'aller, une autre au retour) pour ne jamais repartir à vide |
 | **En route 🧭** | Depuis un terminal de départ : le fret rentable + un **manifeste optimal** qui remplit la soute avec **plusieurs commodités** vers une même destination (avec suggestions pour combler l'espace libre) |
-| **Chaîne ⛓️** | Trajets **multi-sauts A→B→C…** (2 à 4 sauts) : achète, vends, rachète sur place, revends plus loin — recherche par faisceau du circuit le plus rentable. Chaque saut retient la commodité qui **rapporte** le plus une fois plafonnée par le stock et la demande, pas celle à la plus forte marge affichée |
+| **Chaîne ⛓️** | Trajets **multi-sauts A→B→C…** (2 à 4 sauts) : achète, vends, rachète sur place, revends plus loin — recherche par faisceau du circuit le plus rentable. Chaque saut transporte un **manifeste multi-commodités** détaillé sur la carte : quand le stock au départ ou la demande à l'arrivée ne suffit pas à remplir la soute, le reste se comble avec d'autres commodités, exactement comme « En route » |
 | **Corrections ✎** | Ses corrections locales **rangées par station** (bande de vignettes), et de quoi en créer via un sélecteur groupé `système › zone › station` (voir plus bas) |
 | **Commodités 📊** | *Big board* type « salle des marchés », en deux modes. **◈ Marché** : toutes les commodités échangeables avec leur **code officiel UEX** (AGRI, QUAN…), triables (marge / code / catégorie), et au clic **tous leurs points d'achat et de vente** — pratique pour trouver **où écouler** une commodité quand une station n'a plus de demande. **💰 Butin** : le board bascule sur le **prix de revente au SCU** et fait entrer les commodités qu'on **ne peut pas acheter** (minerais raffinés, salvage, drogues de wreck) — la réponse à « j'ai trouvé ça, ça vaut combien et où je l'écoule ? » |
 
@@ -78,8 +78,10 @@ Tous les filtres ne s'appliquent pas à toutes les vues — comportement **garan
 | Stock & demande | ✅ | ✅ | ✅ | ✅⁴ | — | — |
 | Frais d'autoload | ✅ | ✅ | ✅ | ✅ | — | —⁵ |
 
-¹ Le budget se reconstitue à chaque vente → non pertinent pour une chaîne.
-² Une chaîne est multi-commodité par nature.
+¹ Le budget se reconstitue à chaque vente → non pertinent pour une chaîne. Le **remplissage** de
+chaque saut l'ignore donc lui aussi : reprise dans le Voyage, qui le consomme, une jambe peut
+charger moins que ce que la carte Chaîne annonçait.
+² Chaque saut charge **déjà** plusieurs commodités : le filtre n'aurait rien à réduire.
 ³ Le terminal de départ est déjà choisi → le menu « système d'achat » serait redondant.
 ⁴ La chaîne plafonne **toujours** au stock/demande de chaque saut.
 ⁵ Pas de quantité → pas de caisses → pas de frais : le board raisonne au SCU, et Corrections n'affiche aucun profit (elle ne fait qu'**héberger** les tarifs relevés, [voir plus bas](#frais-dautoload)).
@@ -199,7 +201,7 @@ Chaque jambe porte son propre manifeste, recalculé au marché et ajustable à l
 |--------|-------|-----------------------|
 | Trajets, Trajets multi, En route (tableaux) | `▶` sur une ligne | la route de cette ligne |
 | Boucles | `▶` sur une boucle | ses **deux** jambes, entrées par le bout qui touche le parcours |
-| Chaîne | `▶ Ajouter au voyage` | tous les sauts de la chaîne |
+| Chaîne | `▶ Ajouter au voyage` | tous les sauts de la chaîne, **avec le chargement de chacun** |
 | **En route** (carte Manifeste) | `▶ Ajouter au voyage` | le **chargement composé**, tes ajustements compris |
 
 **La règle de raccord** : une jambe s'ajoute si elle **part de la dernière station** du parcours,

--- a/app.js
+++ b/app.js
@@ -4,7 +4,7 @@
 import {
   tripMinutes, ageDays, pairAge,
   scoreBarWidth, bySort, addableUnits, scuBoxes, cargoBoxes, bestChain,
-  AUTOLOAD, autoloadFee, autoloadPoint, haulFee, lineHaulFee, lineNet, kFromReading, kPlausible,
+  AUTOLOAD, autoloadFee, autoloadPoint, lineHaulFee, lineNet, kFromReading, kPlausible,
   ovKey, effFromStore, setInStore, DUREE_VOL, groupOverridesByTerminal, safeKey, encodeState, decodeState,
   routePasses, loopPasses,
   routeMetrics, loopMetrics, enRouteDeals, bestManifest, buildChainAdjacency, suggestionsFrom, netMarginRoi,
@@ -1283,32 +1283,48 @@ function resolveChainOrigin() {
 
 function chainCardHTML(chain, f) {
   const T = (idx) => MARKET.terminals[idx];
-  const invest = chain.legs[0] ? chain.legs[0].units * chain.legs[0].buyPrice : 0;
+  // Un saut transporte un MANIFESTE (#56), que bestChain pose sur `leg.lines` — une seule ligne
+  // quand l'arc n'avait pas de remplissage à composer. Les totaux se lisent donc comme ceux
+  // d'« En route » : une base d'autoload PAR COMMODITÉ (manifestTotals), jamais un `haulFee` unique
+  // par saut, qui sous-facturait de plusieurs bases et affichait un profit que bestChain, lui,
+  // n'avait pas retenu pour choisir l'itinéraire.
+  const totaux = chain.legs.map((leg) => manifestTotals(leg.lines || [], leg.fee));
+  const invest = totaux[0] ? totaux[0].invest : 0;
   let minutes = 0;
   for (let i = 0; i < chain.legs.length; i++) {
     minutes += tripMinutes(0, T(chain.path[i]).system !== T(chain.path[i + 1]).system);
   }
-  // Deux opérations par saut. bestChain a déjà retranché ces frais (il les reçoit par `leg.fee`) :
-  // on ne fait ici que les rendre lisibles, jamais les recalculer autrement.
-  const totalFees = chain.legs.reduce((s, leg) => s + haulFee(leg.units, leg.fee), 0);
+  const totalFees = totaux.reduce((s, t) => s + t.fees, 0);
+  const totalScu = totaux.reduce((s, t) => s + t.scu, 0);
   const nodes = chain.path
     .map((idx) => `<span class="snode term">${esc(T(idx).name)}</span>${sysBadge(T(idx).system)}`)
     .join('<span class="chain-arrow">→</span>');
   const legs = chain.legs
     .map((leg, i) => {
       const a = T(chain.path[i]), b = T(chain.path[i + 1]);
-      const fees = haulFee(leg.units, leg.fee);
-      const fc = feeCell(feeCtx(f, a.name, b.name, a, b), fees, () => feeLoadText(leg.units, a.maxBox), leg.units > 0);
+      const t = totaux[i], lignes = leg.lines || [];
+      const fc = feeCell(feeCtx(f, a.name, b.name, a, b), t.fees, () => feeCargoText(lignes, a.maxBox), t.scu > 0);
+      // Une ligne par commodité chargée, aux mêmes colonnes que le manifeste d'« En route » : la
+      // somme des lignes affichées DOIT faire le total du saut affiché à droite, d'où le même
+      // décompte de frais des deux côtés (lineProfitText / manifestTotals).
+      const detail = lignes.map((l) =>
+        `<div class="chain-line"><div class="commodity-cell">${commodityIcon(l.kind)}<span>${esc(l.name)}${illegalTag(l.illegal)}</span></div>` +
+        `<span class="chain-line-scu"><b>${fmt(l.units)}</b> SCU</span>` +
+        `<span class="chain-line-price">${fmt(l.buyPrice)} → ${fmt(l.sellPrice)} <span class="muted">(marge ${fmt(l.margin)}/SCU)</span></span>` +
+        `<span class="chain-line-profit ${classeProfit(lineNet(l.units, l, leg.fee))}">${lineProfitText(l.units, l, leg.fee)}</span></div>`
+      ).join("");
       return `<div class="chain-leg"><span class="chain-step">${i + 1}</span><div class="chain-leg-main">` +
-        `<div class="commodity-cell">${commodityIcon(leg.kind)}<span><b>${esc(leg.commodity)}</b>${illegalTag(leg.illegal)} · ${fmt(leg.units)} SCU</span></div>` +
-        `<div class="loc-sub">${esc(a.name)} → ${esc(b.name)} · ${fmt(leg.buyPrice)} → ${fmt(leg.sellPrice)} (marge ${fmt(leg.margin)}/SCU)</div>` +
-        `</div><span class="chain-leg-profit profit"${fc.attr}>+${fmtFee(leg.profit, fees)}${fc.mark}</span></div>`;
+        // `.loc-sub` est un flex à gouttière : sans ce span, le volume chargé et son plafond
+        // deviennent deux éléments séparés par 6 px, et la barre de fraction se lit « 96 /96 ».
+        `<div class="loc-sub">${esc(a.name)} → ${esc(b.name)} · <span><b class="chain-leg-scu">${fmt(t.scu)}</b>/${fmt(f.cargo)} SCU</span> · ${lignes.length} commodité${lignes.length > 1 ? "s" : ""}</div>` +
+        `<div class="chain-lines">${detail}</div>` +
+        `</div><span class="chain-leg-profit profit"${fc.attr}>+${fmtFee(leg.profit, t.fees)}${fc.mark}</span></div>`;
     })
     .join("");
   return `<div class="chain">
       <div class="chain-head">
         <span class="chain-path">${nodes}</span>
-        <span class="chain-tot">Profit <b class="profit">${fmtFee(chain.profit, totalFees)}</b> aUEC${totalFees > 0 ? ` · frais ≈ ${fmt(totalFees)}` : ""} · ${chain.legs.length} saut${chain.legs.length > 1 ? "s" : ""} · capital de départ ${fmt(invest)} · ~${Math.round(minutes)} min</span>
+        <span class="chain-tot">Profit <b class="profit">${fmtFee(chain.profit, totalFees)}</b> aUEC${totalFees > 0 ? ` · frais ≈ ${fmt(totalFees)}` : ""} · ${chain.legs.length} saut${chain.legs.length > 1 ? "s" : ""} · ${fmt(totalScu)} SCU chargés · capital de départ ${fmt(invest)} · ~${Math.round(minutes)} min</span>
         <button id="chainToJourney" class="chain-pick" title="Ajouter cette chaîne au voyage en cours">▶ Ajouter au voyage</button>
       </div>
       <div class="chain-legs">${legs}</div>

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -264,6 +264,84 @@ test("Chaîne : le filtre « même système » contraint la chaîne (régression
   expect(new Set(systems).size).toBe(1);
 });
 
+// Pose la vue Chaîne sur un terminal de départ dont AU MOINS UN saut charge plusieurs commodités,
+// et rend son rang. Balayer plutôt que prendre « le premier » : ce que la chaîne compose dépend du
+// relevé du jour, et un test adossé à une origine précise décrirait le jeu de données plutôt que la
+// propriété. Il échoue franchement si aucune des origines essayées ne convient.
+async function chaineAvecSautMultiCommodites(page, essais = 12) {
+  await page.click("#viewChain");
+  await expect(page.locator("#chainControls")).toBeVisible();
+  // `market.json` est chargé À LA DEMANDE : les contrôles de la vue sont visibles bien avant que la
+  // liste des terminaux ne soit peuplée. `evaluateAll` n'attend rien et rendrait `[]` — le balayage
+  // sortirait alors sans avoir essayé la moindre origine, sur une machine seulement plus chargée.
+  await page.locator("#originList option").first().waitFor({ state: "attached", timeout: 15000 });
+  const origines = await page.locator("#originList option").evaluateAll((os) => os.map((o) => o.value));
+  for (const origine of origines.slice(0, essais)) {
+    await page.fill("#chainOrigin", origine);
+    // Attendre que la carte parle bien de CETTE origine. Le rendu est débouncé et la carte de
+    // l'origine précédente reste à l'écran entre-temps : un simple `isVisible` ne retient rien et
+    // ferait compter les lignes de la chaîne d'avant. Sans chaîne rentable, le fil d'Ariane n'existe
+    // pas -> on passe à l'origine suivante.
+    const depart = page.locator("#chainOut .chain-path .snode").first();
+    const vue = await expect(depart).toHaveText(origine.split(" — ")[0], { timeout: 5000 }).then(() => true).catch(() => false);
+    if (!vue) continue;
+    const sauts = page.locator("#chainOut .chain-leg");
+    const n = await sauts.count();
+    for (let i = 0; i < n; i++) {
+      if ((await sauts.nth(i).locator(".chain-line").count()) > 1) return i;
+    }
+  }
+  throw new Error(`aucune des ${essais} premières origines ne donne un saut à plusieurs commodités`);
+}
+
+const nombreDe = (t) => Number(t.replace(/\D/g, ""));
+
+test("Chaîne : un saut détaille les commodités qu'il transporte (#56)", async ({ page }) => {
+  const i = await chaineAvecSautMultiCommodites(page);
+  const saut = page.locator("#chainOut .chain-leg").nth(i);
+  const lignes = saut.locator(".chain-line");
+  const n = await lignes.count();
+  expect(n).toBeGreaterThan(1);
+  // Chaque ligne dit sa commodité, son volume et ce qu'elle rapporte : un saut se lit comme un
+  // manifeste d'« En route », pas comme une commodité unique.
+  let scu = 0;
+  for (let l = 0; l < n; l++) {
+    await expect(lignes.nth(l).locator(".commodity-cell")).not.toBeEmpty();
+    const u = nombreDe(await lignes.nth(l).locator(".chain-line-scu").innerText());
+    expect(u).toBeGreaterThan(0);
+    await expect(lignes.nth(l).locator(".chain-line-profit")).not.toBeEmpty();
+    scu += u;
+  }
+  // Le total du saut annonce la somme de ses lignes : c'est ce volume-là qui dit que la soute ne
+  // repart plus avec la seule meilleure commodité.
+  expect(nombreDe(await saut.locator(".chain-leg-scu").innerText())).toBe(scu);
+});
+
+const aPlat = (t) => t.replace(/\s+/g, " ").trim();
+
+test("Chaîne : « ▶ Ajouter au voyage » pousse le chargement RÉEL du saut (#56)", async ({ page }) => {
+  // Le budget est coupé pour la durée du test : la chaîne l'ignore par construction (README, note ¹)
+  // là où la jambe de voyage le consomme, donc sous un budget bornant les deux chargements peuvent
+  // légitimement différer. C'est le seul écart connu, et il ne touche pas ce que ce test prouve.
+  await page.uncheck("#useBudget");
+  const i = await chaineAvecSautMultiCommodites(page);
+  const nSauts = await page.locator("#chainOut .chain-leg").count();
+  const saut = page.locator("#chainOut .chain-leg").nth(i);
+  const attendu = (await saut.locator(".chain-line").evaluateAll((ls) => ls.map((l) =>
+    `${l.querySelector(".commodity-cell").innerText} ${l.querySelector(".chain-line-scu").innerText}`))).map(aPlat);
+  const profitChaine = aPlat(await saut.locator(".chain-leg-profit").innerText());
+
+  await page.click("#chainToJourney");
+  await expect(page.locator("#journeyCard .jleg")).toHaveCount(nSauts);
+  const jambe = page.locator("#journeyCard .jleg").nth(i);
+  await expect(jambe.locator(".jcargo-item").first()).toBeVisible({ timeout: 8000 });
+  const obtenu = (await jambe.locator(".jcargo-item").evaluateAll((ls) => ls.map((l) => l.innerText))).map(aPlat);
+  // Mêmes commodités, mêmes SCU, même profit : la carte Chaîne et la vue Voyage chiffraient deux
+  // chargements différents pour le MÊME saut — l'une mono, l'autre multi — et l'affichaient.
+  expect(obtenu).toEqual(attendu);
+  expect(aPlat(await jambe.locator(".jleg-profit").innerText())).toBe(profitChaine);
+});
+
 // Pose la vue « En route » sur le premier terminal de départ proposé et rend la carte Manifeste.
 async function enrouteSurLePremierTerminal(page) {
   await page.click("#viewEnroute");

--- a/logic.mjs
+++ b/logic.mjs
@@ -541,20 +541,38 @@ export function lineNet(units, line, pair) {
 // payées. Exporté parce que buildChainAdjacency doit classer les candidates d'une paire sur le
 // profit que bestChain leur donnera vraiment : un autre plafond de volume et le classement
 // porterait sur un saut qui n'existe pas.
+// Le chargement mono se dit dans la MÊME forme qu'un manifeste — une liste de lignes : la vue
+// Chaîne et le voyage n'ont ainsi qu'un seul format de saut à lire, que l'arc porte le manifeste
+// pré-calculé par buildChainAdjacency ou ce repli à une commodité.
+const ligneDuSaut = (leg, units) => (units <= 0 ? [] : [{
+  name: leg.commodity, kind: leg.kind, illegal: leg.illegal,
+  buyPrice: leg.buyPrice, sellPrice: leg.sellPrice, margin: leg.margin,
+  stock: leg.stock, demand: leg.demand, demandKnown: leg.demandKnown,
+  buyUpdated: leg.buyUpdated || 0, sellUpdated: leg.sellUpdated || 0,
+  units, cap: units,
+}]);
 export function chainLegNet(leg, cargo) {
+  // Chargement PRÉ-CALCULÉ à la construction de l'adjacence : on le rend tel quel, c'est ce qui
+  // tient le coût du faisceau (cf. estampillerManifestes). La soute fait partie de la clé parce que
+  // rien n'oblige l'appelant à passer à bestChain celle qui a bâti le graphe : un chargement composé
+  // pour 96 SCU ne dit rien de ce qu'on emporte dans 32, et retomber sur le chiffrage mono vaut
+  // mieux qu'un chiffre faux rendu en silence.
+  if (leg.net && leg.net.cargo === cargo) return leg.net;
   let u = cargo;
   u = Math.min(u, leg.stock);                     // stock 0 = terminal vide -> saut exclu
   if (leg.demand != null || leg.demandKnown) u = Math.min(u, leg.demand); // null = inconnu ; 0 = saturé
   const units = isFinite(u) ? Math.max(0, u) : 0; // sans borne de volume : rien (chaîne = soute finie)
-  return { units, profit: units * leg.margin - haulFee(units, leg.fee) };
+  return { units, profit: units * leg.margin - haulFee(units, leg.fee), lines: ligneDuSaut(leg, units), cargo };
 }
 
 // Le faisceau tronque à chaque saut sur le profit CUMULÉ : un premier saut modeste qui ouvre sur un
 // circuit énorme est décapité avant d'avoir pu le montrer. Mesuré sur data/market.json (96 SCU,
 // 3 sauts) : à 40, 39 origines sur 107 rendaient plus de 5 % sous l'optimum du graphe, jusqu'à ×4,53
 // (Sunset Mesa, 582 816 -> 2 637 576). À 400, plus aucune. Le coût est payé une fois par action
-// utilisateur — l'app ne calcule qu'UNE chaîne — soit 7 ms sur le pire cas de l'UI (4 sauts) contre
-// 0,8 ms : imperceptible, là où la sous-optimalité, elle, se voyait.
+// utilisateur — l'app ne calcule qu'UNE chaîne — soit 8 à 12 ms sur le pire cas de l'UI (4 sauts)
+// contre 0,9 ms à faisceau 40 : imperceptible, là où la sous-optimalité, elle, se voyait. Depuis
+// #56 le chargement de chaque saut est pré-calculé (`leg.net`) : le prix du manifeste se paie une
+// fois, à la construction de l'adjacence, et le faisceau n'y touche plus.
 export function bestChain(adj, start, hops, { cargo = Infinity, beam = 400 } = {}) {
   let paths = [{ path: [start], visited: new Set([start]), profit: 0, legs: [] }];
   let best = null;
@@ -568,7 +586,7 @@ export function bestChain(adj, start, hops, { cargo = Infinity, beam = 400 } = {
         // les frais mangent la marge fait PERDRE de l'argent : on l'écarte, exactement comme un
         // saut de marge nulle plus haut — sans quoi l'invariant « chaque saut ajoute un profit
         // positif » tomberait et la meilleure chaîne pourrait être plus courte que la retenue.
-        const { units, profit: legProfit } = chainLegNet(leg, cargo);
+        const { units, profit: legProfit, lines } = chainLegNet(leg, cargo);
         if (units <= 0 || legProfit <= 0) continue;
         const visited = new Set(p.visited);
         visited.add(leg.to);
@@ -576,7 +594,10 @@ export function bestChain(adj, start, hops, { cargo = Infinity, beam = 400 } = {
           path: [...p.path, leg.to],
           visited,
           profit: p.profit + legProfit,
-          legs: [...p.legs, { ...leg, units, profit: legProfit }],
+          // `lines` = le chargement du saut, plusieurs commodités comprises. Les champs scalaires
+          // hérités du leg (commodity, margin…) restent ceux du REPLI mono : ils nomment l'arc et
+          // servent à le classer, ils ne décrivent plus à eux seuls ce qui voyage.
+          legs: [...p.legs, { ...leg, units, profit: legProfit, lines }],
         });
       }
     }
@@ -1073,9 +1094,56 @@ export function buildChainAdjacency(market, f, resolve, autoloadFor = null) {
       });
     });
   });
+  // Sans soute bornée il n'y a pas de remplissage à composer (manifestsFrom rend [] et chainLegNet
+  // ne chiffre aucun volume) : le graphe reste strictement celui d'avant, une commodité par arc.
+  if (isFinite(cargo)) estampillerManifestes(market, best, f, resolve, autoloadFor, cargo);
   const adj = new Map();
   for (const [u, m] of best) adj.set(u, [...m.values()]);
   return adj;
+}
+
+// Le CHARGEMENT de chaque arc, composé une fois pour toutes ici (#56). Un saut ne transportait
+// qu'une commodité et la soute repartait à moitié vide dès que son stock ou la demande à l'arrivée
+// ne suffisait pas à la remplir — 32 % des arcs de l'instantané, alors que « En route » sait déjà
+// combler la place sur le MÊME couple de terminaux.
+//
+// Pourquoi ici, et pas dans la boucle du faisceau : le chargement d'un saut ne dépend PAS du chemin
+// qui y mène. bestChain ne thread aucun budget (il se reconstitue à la vente) et passe `cargo`
+// inchangé à chaque saut, la soute se vidant à chaque arrivée — le manifeste de u -> v est donc
+// entièrement déterminé par (u, v, cargo, filtres). Composé par arc il coûte ≈ 6 ms sur
+// l'instantané ; appelé depuis les ≈ 33 000 expansions du faisceau, ≈ 1 s. Qui voudra un jour
+// suivre un budget le long de la chaîne devra d'abord renoncer à ce pré-calcul, et en payer le prix.
+//
+// On n'estampille QUE des arcs déjà retenus par le balayage mono ci-dessus, jamais l'inverse : la
+// clé `m.get(destIdx)` est ce qui réapplique les deux filtres que `pairEligible` ne pose pas —
+// `sameOnly`, et l'avant-poste d'ORIGINE (celui de vente, lui, est bien testé). Sans elle la chaîne
+// se remettrait à proposer des départs d'avant-poste et des sauts inter-systèmes.
+//
+// Un arc dont le manifeste est vide GARDE son chiffrage mono : `fillCargo` ne retient rien là où le
+// balayage produit encore un segment (demande publiée à 0, stock épuisé), 71 arcs sur 4 355 dans
+// l'instantané, 136 une fois les frais actifs. Remplacer l'arc par son manifeste les ferait
+// disparaître du graphe.
+//
+// Ce qu'on ne modélise toujours pas, et qu'il ne faut pas croire oublié : la DÉPLÉTION du stock
+// entre les sauts d'une même chaîne. Deux sauts peuvent acheter la même commodité à deux terminaux
+// différents, et le multi-commodités multiplie ces croisements — c'était déjà le cas avant #56, et
+// rien dans les données d'UEX ne dit à quel rythme un terminal se recharge.
+function estampillerManifestes(market, best, f, resolve, autoloadFor, cargo) {
+  // Budget neutralisé : la chaîne l'ignore par construction (README, matrice des filtres, note ¹),
+  // et le laisser borner le remplissage ferait dire à la vue l'inverse de ce qu'elle annonce.
+  const sansBudget = { ...f, useBudget: false };
+  for (const [u, m] of best) {
+    for (const trip of manifestsFrom(market, u, "", sansBudget, resolve, null, autoloadFor)) {
+      const leg = m.get(trip.destIdx);
+      if (!leg) continue;
+      // Le profit du saut est celui du manifeste : une base d'autoload PAR LIGNE (hypothèse 2 de la
+      // spec), là où `haulFee` n'en facturait qu'une par saut. Un saut de 4 lignes en paie 4, sans
+      // quoi bestChain arbitrerait entre les sauts sur des montants surévalués.
+      const { profit, scu } = manifestTotals(trip.lines, leg.fee);
+      leg.lines = trip.lines;
+      leg.net = { units: scu, profit, lines: trip.lines, cargo };
+    }
+  }
 }
 
 // ---------- Panneau « Commodités » : résumé global + points d'achat/vente ----------
@@ -1317,10 +1385,15 @@ export function legsFromLoop(l, startAt) {
   return startAt === l.b.terminal && startAt !== l.a.terminal ? [back, out] : [out, back];
 }
 // N jambes depuis une chaîne (bestChain) : `terminals` résout les index -> noms/systèmes.
+// Un saut transporte un MANIFESTE (#56) que le format de jambe ne sait pas porter — comme pour un
+// trajet multi-commodité (legFromTrip), la jambe ne retient donc que la ligne de TÊTE en libellé, et
+// la vue Voyage recompose le chargement complet à l'affichage (legManifest). Prendre la tête du
+// manifeste plutôt que le repli mono de l'arc est ce qui fait dire la même commodité aux deux vues.
 export function legsFromChain(chain, terminals) {
   return chain.legs.map((leg, i) => {
     const from = terminals[chain.path[i]], to = terminals[chain.path[i + 1]];
-    return { from: from.name, fromSystem: from.system, to: to.name, toSystem: to.system, commodity: leg.commodity, buyPrice: leg.buyPrice, sellPrice: leg.sellPrice, margin: leg.margin };
+    const tete = (leg.lines && leg.lines[0]) || { name: leg.commodity, buyPrice: leg.buyPrice, sellPrice: leg.sellPrice, margin: leg.margin };
+    return { from: from.name, fromSystem: from.system, to: to.name, toSystem: to.system, commodity: tete.name, buyPrice: tete.buyPrice, sellPrice: tete.sellPrice, margin: tete.margin };
   });
 }
 

--- a/logic.test.mjs
+++ b/logic.test.mjs
@@ -3733,25 +3733,36 @@ test("chaîne : sur les 4 355 arcs réels, aucun ne rapporte moins qu'avant et a
 });
 
 test("chaîne : garde de performance — le manifeste se compose par ARC, jamais dans le faisceau", () => {
-  // Composer un manifeste par arc coûte ≈ 6 ms sur l'instantané ; l'appeler depuis les ≈ 33 000
-  // expansions du faisceau, ≈ 1 s — un gel visible sous le clic. Les plafonds sont donc LARGES
-  // devant la mesure locale (8,5 ms pour l'adjacence, 8,2 ms pour 4 sauts, contre 2,4 et 9,9 avant
-  // #56) et étroits devant la version naïve : ils attrapent le facteur 100, pas les 30 % d'écart
-  // d'une machine à l'autre. Ne pas les resserrer sur la mesure d'un poste : la CI est plus lente.
-  const t0 = performance.now();
+  // Composer un manifeste par arc coûte ≈ 6 ms sur l'instantané ; le composer depuis les ≈ 33 000
+  // expansions du faisceau, ≈ 1 s — un gel visible sous le clic.
+  // La garde est un RAPPORT, mesuré dans le même processus, et pas un plafond en millisecondes : le
+  // runner de la CI est ~20× plus lent que le poste où ceci s'écrit (190 ms contre 8 pour 4 sauts),
+  // si bien qu'un plafond calé sur l'un est soit rouge sur l'autre, soit trop lâche pour rien voir.
+  // Le meilleur de deux tours, parce qu'un runner partagé se fait désordonnancer, jamais accélérer.
+  const meilleurDe = (fn, n = 2) => {
+    let min = Infinity;
+    for (let i = 0; i < n; i++) { const t = performance.now(); fn(); min = Math.min(min, performance.now() - t); }
+    return min;
+  };
+  // L'adjacence contre elle-même sans soute bornée : même balayage du marché, zéro manifeste à
+  // composer. Mesuré ×4 à ×11 selon les tours ; au-delà de ×20, `manifestsFrom` n'est plus appelé
+  // une fois par ORIGINE mais une fois par arc (ce serait ×40) — l'erreur que ce rapport attrape.
+  const tSans = meilleurDe(() => buildChainAdjacency(REAL, { ...F_REEL, useCargo: false }, idResolve, fraisReels));
+  const tAvec = meilleurDe(() => buildChainAdjacency(REAL, F_REEL, idResolve, fraisReels));
+  assert.ok(tAvec < 20 * tSans, `adjacence : ${tAvec.toFixed(1)} ms avec manifestes contre ${tSans.toFixed(1)} ms sans`);
+
+  // Le faisceau sur chargements pré-calculés contre le MÊME faisceau sur la même adjacence privée de
+  // ses manifestes — le chiffrage mono, O(1) par expansion, celui d'avant #56. Mesuré ×0,5 à ×0,8 :
+  // lire `leg.net` coûte moins que recalculer. Composer le manifeste dans la boucle donnerait ×100.
   const adj = buildChainAdjacency(REAL, F_REEL, idResolve, fraisReels);
-  const tAdjacence = performance.now() - t0;
-  // Les origines les plus chargées du graphe, choisies sur leur degré SORTANT — c'est lui qui décide
-  // du nombre d'expansions. Prendre « la première » désignerait une ligne de données, pas un pire cas.
-  const lourdes = [...adj.keys()].sort((a, b) => adj.get(b).length - adj.get(a).length).slice(0, 3);
-  let tChaine = 0;
-  for (const u of lourdes) {
-    const t = performance.now();
-    assert.ok(bestChain(adj, u, 4, { cargo: 96 }), "une origine à fort degré doit rendre une chaîne");
-    tChaine = Math.max(tChaine, performance.now() - t);
-  }
-  assert.ok(tAdjacence < 100, `buildChainAdjacency : ${tAdjacence.toFixed(1)} ms`);
-  assert.ok(tChaine < 100, `bestChain 4 sauts : ${tChaine.toFixed(1)} ms`);
+  const mono = new Map([...adj].map(([u, legs]) => [u, legs.map((l) => ({ ...l, lines: undefined, net: undefined }))]));
+  // L'origine la plus chargée du graphe, choisie sur son degré SORTANT — c'est lui qui décide du
+  // nombre d'expansions. Prendre « la première » désignerait une ligne de données, pas un pire cas.
+  const u = [...adj.keys()].sort((a, b) => adj.get(b).length - adj.get(a).length)[0];
+  const quatreSauts = (graphe) => meilleurDe(() => assert.ok(bestChain(graphe, u, 4, { cargo: 96 }), "une origine à fort degré doit rendre une chaîne"), 1);
+  quatreSauts(mono); quatreSauts(adj);              // chauffe : on mesure le code, pas la compilation
+  const tMono = quatreSauts(mono), tManifeste = quatreSauts(adj);
+  assert.ok(tManifeste < 3 * tMono, `4 sauts : ${tManifeste.toFixed(1)} ms sur chargements pré-calculés contre ${tMono.toFixed(1)} ms en mono`);
 });
 
 // Chaîne : deux itinéraires A->…->D aux profits BRUTS proches, dont le mieux payé transite par une

--- a/logic.test.mjs
+++ b/logic.test.mjs
@@ -5,7 +5,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import {
   tripMinutes, loopMinutes, ageDays, pairAge, freshnessFactor, tighterVolume,
-  scoreBarWidth, certitudeVolume, fiabiliteDe, CERTITUDE_PLANCHER, bySort, computeUnits, effValue, fillCargo, addableUnits, scuBoxes, cargoBoxes, bestChain,
+  scoreBarWidth, certitudeVolume, fiabiliteDe, CERTITUDE_PLANCHER, bySort, computeUnits, effValue, fillCargo, addableUnits, scuBoxes, cargoBoxes, bestChain, chainLegNet,
   AUTOLOAD, autoloadFee, autoloadPoint, haulFee, lineHaulFee, lineNet, kFromReading, kPlausible, K_PLAUSIBLE,
   manifestTotals, freeAddUnits, manifestLine, stationLabel, parseStationLabel,
   ovKey, effFromStore, setInStore, safeKey, encodeState, decodeState,
@@ -1416,6 +1416,21 @@ test("legsFromChain : chaîne (index) -> jambes nommées", () => {
   const legs = legsFromChain(chain, terminals);
   assert.deepEqual(legs.map((l) => [l.from, l.to]), [["A", "B"], ["B", "D"]]);
   assert.equal(legs[1].toSystem, "Pyro");
+});
+
+test("legsFromChain : la jambe est nommée par la ligne de TÊTE du manifeste du saut", () => {
+  // Un saut transporte plusieurs commodités (#56) et le format de jambe n'en porte qu'une : c'est
+  // la tête du manifeste qui la nomme, comme pour un trajet multi-commodité — sans quoi la vue
+  // Voyage, qui recompose le chargement complet, afficherait une commodité de tête différente de
+  // celle du libellé venu de la chaîne.
+  const terminals = [{ name: "A", system: "Stanton" }, { name: "B", system: "Stanton" }];
+  const chain = { path: [0, 1], legs: [{
+    commodity: "Repli", buyPrice: 1, sellPrice: 3, margin: 2,   // le repli mono de l'arc
+    lines: [{ name: "Tête", buyPrice: 10, sellPrice: 30, margin: 20, units: 60 },
+            { name: "Appoint", buyPrice: 5, sellPrice: 8, margin: 3, units: 36 }],
+  }] };
+  const [jambe] = legsFromChain(chain, terminals);
+  assert.deepEqual([jambe.commodity, jambe.buyPrice, jambe.sellPrice, jambe.margin], ["Tête", 10, 30, 20]);
 });
 
 test("startJourney + journeyStations : stations = legs.length + 1", () => {
@@ -3571,21 +3586,172 @@ test("buildChainAdjacency : les frais peuvent renverser le choix de commodité d
   // Non vacuisant : les frais doivent VRAIMENT inverser l'ordre, sinon le test ne prouve rien.
   assert.ok(brutGrosse > brutPetite && netGrosse < netPetite, "la fixture doit inverser le classement");
 
-  // Sans frais : le gain réalisable départage, donc la grosse cargaison.
+  // Sans frais : le gain réalisable départage, donc la grosse cargaison NOMME l'arc.
   assert.equal(buildChainAdjacency(mkt(), f, idResolve).get(0)[0].commodity, "Grosse");
-  assert.equal(bestChain(buildChainAdjacency(mkt(), f, idResolve), 0, 1, { cargo: 96 }).profit, brutGrosse);
+  // Le saut, lui, emporte les deux depuis #56 : les 8 SCU de « Petite » comblent une soute que la
+  // « Grosse » remplissait déjà — le classement de l'arc ne dit plus à lui seul ce qui voyage.
+  const sans = bestChain(buildChainAdjacency(mkt(), f, idResolve), 0, 1, { cargo: 96 });
+  assert.deepEqual(sans.legs[0].lines.map((l) => [l.name, l.units]), [["Petite", 8], ["Grosse", 88]]);
+  assert.equal(sans.profit, 8 * 400 + 88 * 60);
+  assert.ok(sans.profit > brutGrosse, "le manifeste doit battre la meilleure commodité seule");
   // Avec frais : la manutention renverse le classement.
   const avec = buildChainAdjacency(mkt(), f, idResolve, feeNet);
   assert.equal(avec.get(0)[0].commodity, "Petite");
   const chaine = bestChain(avec, 0, 1, { cargo: 96 });
   assert.ok(chaine, "un saut rentable ne doit pas disparaître du graphe");
-  assert.equal(chaine.profit, netPetite);
+  assert.equal(chaine.profit, manifestTotals(chaine.legs[0].lines, chaine.legs[0].fee).profit);
+  assert.ok(chaine.profit > netPetite, "le manifeste doit rester au-dessus du repli mono");
 });
 
 test("buildChainAdjacency : sans soute bornée, le classement reste la marge (aucun volume calculable)", () => {
   const f = { legalOnly: false, noOutpost: false }; // ni useCargo ni cargo
   const adj = buildChainAdjacency(MKT(), f, idResolve, feeNet);
   assert.equal(adj.get(0).find((l) => l.to === 1).commodity, "Gold"); // marge 50 > Drug 30
+});
+
+// ---------- Chaîne : un MANIFESTE par saut (#56) ----------
+// « Rare » est ce qui paie le mieux SEUL sur cet arc (20 SCU × 1 000 = 20 000, contre 96 × 200 =
+// 19 200 pour « Vrac ») : c'est donc elle que le chiffrage mono retient, et le saut repartait avec
+// 20 SCU sur 96. Les 76 SCU restants tiennent du « Vrac », que le stock ne borne pas.
+const MKT_SOUTE_VIDE = () => ({
+  terminals: [TERM_NET("Depart"), TERM_NET("Arrivee")],
+  commodities: [
+    { name: "Rare", kind: "metal", illegal: false, buys: [[0, 100, 20, NOW, 5]], sells: [[1, 1100, 999, NOW, 3]] },
+    { name: "Vrac", kind: "metal", illegal: false, buys: [[0, 100, 500, NOW, 5]], sells: [[1, 300, 999, NOW, 3]] },
+  ],
+});
+const F96 = { legalOnly: false, noOutpost: false, useCargo: true, cargo: 96 };
+
+test("chaîne : un saut transporte un manifeste, et la soute ne repart plus à moitié vide", () => {
+  const adj = buildChainAdjacency(MKT_SOUTE_VIDE(), F96, idResolve);
+  const [arc] = adj.get(0);
+  // Non vacuisant : la fixture doit bien faire gagner la commodité qui NE remplit PAS la soute,
+  // sinon le manifeste n'aurait rien à rattraper.
+  assert.ok(20 * 1_000 > 96 * 200, "la fixture doit faire gagner la commodité plafonnée");
+  assert.equal(arc.commodity, "Rare");                       // le repli mono reste identifié sur l'arc
+  assert.deepEqual(arc.lines.map((l) => [l.name, l.units]), [["Rare", 20], ["Vrac", 76]]);
+  const chaine = bestChain(adj, 0, 1, { cargo: 96 });
+  assert.equal(chaine.legs[0].units, 96);                    // 20 avant : 76 SCU voyageaient à vide
+  assert.deepEqual(chaine.legs[0].lines.map((l) => [l.name, l.units]), [["Rare", 20], ["Vrac", 76]]);
+  assert.equal(chaine.profit, 20 * 1_000 + 76 * 200);
+  assert.equal(chaine.profit, 35_200);                       // 20 000 avant
+});
+
+test("chaîne : un saut de N lignes paie N bases d'autoload, pas une", () => {
+  // Hypothèse 2 de la spec : une transaction PAR COMMODITÉ. Chiffrer le saut comme un chargement
+  // mono (une seule base pour les 96 SCU) lui prêterait 420 aUEC qu'il ne gagne pas, et fausserait
+  // l'arbitrage entre sauts — c'est bestChain qui compare ces montants.
+  const adj = buildChainAdjacency(MKT_SOUTE_VIDE(), F96, idResolve, frais41);
+  const chaine = bestChain(adj, 0, 1, { cargo: 96 });
+  const parLigne = 2 * autoloadFee(20, 32, 1) + 2 * autoloadFee(76, 32, 1);
+  const enBloc = 2 * autoloadFee(96, 32, 1);
+  assert.ok(parLigne > enBloc, "la fixture doit facturer plus par ligne qu'en bloc");
+  assert.equal(chaine.legs[0].profit, 35_200 - parLigne);
+  assert.equal(chaine.legs[0].profit, manifestTotals(chaine.legs[0].lines, chaine.legs[0].fee).profit);
+  assert.notEqual(chaine.legs[0].profit, 35_200 - enBloc);
+});
+
+test("chaîne : un arc sans manifeste garde son chiffrage mono et reste dans le graphe", () => {
+  // Sur l'instantané réel, 71 arcs n'ont aucun manifeste : `fillCargo` ne retient rien là où le
+  // chiffrage mono produit encore un segment (demande publiée à 0, stock épuisé). Remplacer l'arc
+  // par son manifeste les ferait disparaître du graphe — et avec eux les chaînes qui les traversent.
+  const mkt = () => ({
+    terminals: [TERM_NET("Depart"), TERM_NET("Ouvert"), TERM_NET("Sature")],
+    commodities: [
+      { name: "Fret", kind: "metal", illegal: false,
+        buys: [[0, 100, 500, NOW, 5]],
+        sells: [[1, 300, 999, NOW, 3], [2, 400, 0, NOW, 3]] },   // « Sature » ne demande plus rien
+    ],
+  });
+  const legs = buildChainAdjacency(mkt(), F96, idResolve).get(0);
+  assert.equal(legs.length, 2, "l'arc sans manifeste a disparu du graphe");
+  const sature = legs.find((l) => l.to === 2);
+  assert.equal(sature.lines, undefined);                     // aucun manifeste : le mono reste seul
+  assert.equal(sature.commodity, "Fret");
+  assert.deepEqual(legs.find((l) => l.to === 1).lines.map((l) => [l.name, l.units]), [["Fret", 96]]);
+});
+
+test("chaîne : le manifeste par arc reste soumis à « même système » et à l'exclusion des avant-postes", () => {
+  // `pairEligible`, que manifestsFrom applique, ne teste QUE l'avant-poste de VENTE : ni `sameOnly`
+  // ni l'avant-poste d'ORIGINE. Sans réapplication, la chaîne se remettrait à proposer des départs
+  // d'avant-poste et des sauts inter-systèmes que ses propres filtres écartent.
+  const ici = (name, o = {}) => ({ ...TERM_NET(name), system: "Stanton", ...o });
+  const mkt = () => ({
+    terminals: [ici("Base"), ici("Relais"), ici("Poste", { outpost: true }), ici("Lointain", { system: "Pyro" })],
+    commodities: [
+      { name: "Fret", kind: "metal", illegal: false,
+        buys: [[0, 100, 500, NOW, 5], [2, 100, 500, NOW, 5]],
+        sells: [[1, 300, 999, NOW, 3], [3, 400, 999, NOW, 3]] },
+    ],
+  });
+  const dests = (adj, u) => (adj.get(u) || []).map((l) => l.to).sort();
+  const tout = buildChainAdjacency(mkt(), F96, idResolve);
+  assert.deepEqual([dests(tout, 0), dests(tout, 2)], [[1, 3], [1, 3]]);
+  assert.ok(tout.get(2)[0].lines, "sans manifeste sur l'arc, le test ne prouverait rien");
+  const sansPoste = buildChainAdjacency(mkt(), { ...F96, noOutpost: true }, idResolve);
+  assert.deepEqual(dests(sansPoste, 2), [], "un avant-poste ne peut pas être un départ de chaîne");
+  assert.deepEqual(dests(sansPoste, 0), [1, 3]);
+  const memeSysteme = buildChainAdjacency(mkt(), { ...F96, sameOnly: true }, idResolve);
+  assert.deepEqual(dests(memeSysteme, 0), [1], "« Lointain » est dans Pyro : le saut est inter-systèmes");
+  assert.ok(memeSysteme.get(0)[0].lines, "l'arc survivant doit bien porter son manifeste");
+});
+
+// La non-régression MESURÉE, pas supposée : sur l'instantané entier, frais actifs, le chargement de
+// chaque arc doit rapporter au moins autant que le chiffrage mono d'avant #56 — le repli que le
+// joueur a toujours sous la main. C'est l'invariant que le SCU perdu de #41 cassait sur 20 arcs ;
+// il tient depuis que `manifestsFrom` réalloue la place d'une ligne écartée, et cette chaîne en
+// dépend directement.
+const F_REEL = { legalOnly: false, noOutpost: false, maxAge: 0, useCargo: true, cargo: 96 };
+const fraisReels = (t) => autoloadPoint(t, 1);
+
+test("chaîne : sur les 4 355 arcs réels, aucun ne rapporte moins qu'avant et aucun ne disparaît", () => {
+  const adj = buildChainAdjacency(REAL, F_REEL, idResolve, fraisReels);
+  let arcs = 0, sansManifeste = 0, multi = 0, scuMono = 0, scuManifeste = 0;
+  const pertes = [];
+  for (const [u, legs] of adj) {
+    for (const leg of legs) {
+      arcs++;
+      const mono = chainLegNet({ ...leg, lines: undefined, net: undefined }, 96); // le chiffrage d'avant
+      const saut = chainLegNet(leg, 96);
+      if (!leg.lines) {                       // aucun manifeste : le repli mono, au chiffre près
+        sansManifeste++;
+        assert.equal(saut.profit, mono.profit);
+        continue;
+      }
+      if (leg.lines.length > 1) multi++;
+      if (saut.profit < mono.profit) pertes.push(`${REAL.terminals[u].name} -> ${REAL.terminals[leg.to].name} : ${saut.profit} < ${mono.profit}`);
+      scuMono += mono.units;
+      scuManifeste += saut.units;
+    }
+  }
+  assert.equal(arcs, 4_355, "l'instantané a changé : le compte d'arcs n'est plus celui qui a mesuré le gain");
+  assert.deepEqual(pertes, []);
+  assert.equal(sansManifeste, 136, "arcs sans manifeste (frais actifs) : ils doivent RESTER dans le graphe");
+  // Non vacuisant : l'invariant serait trivialement vrai si les arcs étaient tous restés mono.
+  assert.ok(multi > 700, `chargements multi-commodité tombés à ${multi}`);
+  assert.ok(scuManifeste > scuMono * 1.04, `SCU emportés : ${scuManifeste} contre ${scuMono} avant`);
+});
+
+test("chaîne : garde de performance — le manifeste se compose par ARC, jamais dans le faisceau", () => {
+  // Composer un manifeste par arc coûte ≈ 6 ms sur l'instantané ; l'appeler depuis les ≈ 33 000
+  // expansions du faisceau, ≈ 1 s — un gel visible sous le clic. Les plafonds sont donc LARGES
+  // devant la mesure locale (8,5 ms pour l'adjacence, 8,2 ms pour 4 sauts, contre 2,4 et 9,9 avant
+  // #56) et étroits devant la version naïve : ils attrapent le facteur 100, pas les 30 % d'écart
+  // d'une machine à l'autre. Ne pas les resserrer sur la mesure d'un poste : la CI est plus lente.
+  const t0 = performance.now();
+  const adj = buildChainAdjacency(REAL, F_REEL, idResolve, fraisReels);
+  const tAdjacence = performance.now() - t0;
+  // Les origines les plus chargées du graphe, choisies sur leur degré SORTANT — c'est lui qui décide
+  // du nombre d'expansions. Prendre « la première » désignerait une ligne de données, pas un pire cas.
+  const lourdes = [...adj.keys()].sort((a, b) => adj.get(b).length - adj.get(a).length).slice(0, 3);
+  let tChaine = 0;
+  for (const u of lourdes) {
+    const t = performance.now();
+    assert.ok(bestChain(adj, u, 4, { cargo: 96 }), "une origine à fort degré doit rendre une chaîne");
+    tChaine = Math.max(tChaine, performance.now() - t);
+  }
+  assert.ok(tAdjacence < 100, `buildChainAdjacency : ${tAdjacence.toFixed(1)} ms`);
+  assert.ok(tChaine < 100, `bestChain 4 sauts : ${tChaine.toFixed(1)} ms`);
 });
 
 // Chaîne : deux itinéraires A->…->D aux profits BRUTS proches, dont le mieux payé transite par une

--- a/style.css
+++ b/style.css
@@ -886,10 +886,30 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 .chain-tot b { color: var(--text); }
 .chain-tot b.profit { color: var(--good); }
 .chain-legs { display: flex; flex-direction: column; }
-.chain-leg { display: grid; grid-template-columns: auto 1fr auto; align-items: center; gap: 14px; padding: 12px 20px; border-bottom: 1px solid var(--line); }
+.chain-leg { display: grid; grid-template-columns: auto 1fr auto; align-items: start; gap: 14px; padding: 12px 20px; border-bottom: 1px solid var(--line); }
 .chain-leg:last-child { border-bottom: none; }
+.chain-leg-main { min-width: 0; }
 .chain-step { width: 26px; height: 26px; flex-shrink: 0; display: grid; place-items: center; font-family: var(--mono); font-weight: 700; font-size: 12px; border-radius: 50%; color: #0a0410; background: var(--acc-2); }
 .chain-leg-profit { font-family: var(--mono); white-space: nowrap; color: var(--good); }
+/* Le chargement d'un saut, ligne par ligne (#56) : un saut transporte un manifeste, pas une
+   commodité. Mêmes colonnes que le manifeste d'« En route » — commodité, volume, prix, ce que la
+   ligne rapporte — pour qu'on lise les deux vues de la même façon.
+   La grille porte les LIGNES du saut (`.chain-line` passe en display:contents) et non chaque ligne
+   prise à part : sans ça chacune dimensionne ses colonnes toute seule, et volumes, prix et profits
+   d'un même saut ne s'alignent sur rien — trois colonnes de chiffres en escalier. */
+.chain-lines { display: grid; grid-template-columns: minmax(0, 1fr) auto auto auto; align-items: baseline; gap: 4px 14px; margin-top: 6px; font-size: 12px; }
+.chain-line { display: contents; }
+.chain-line .commodity-cell { min-width: 0; }
+.chain-line-scu { font-family: var(--mono); white-space: nowrap; justify-self: end; }
+.chain-line-price { font-family: var(--mono); color: var(--text); white-space: nowrap; }
+.chain-line-profit { font-family: var(--mono); white-space: nowrap; justify-self: end; }
+/* Écran étroit : les trois colonnes de chiffres ne tiennent plus à côté du nom -> il passe seul
+   sur sa ligne, les chiffres dessous, plutôt que de pousser la carte en débordement horizontal. */
+@media (max-width: 720px) {
+  .chain-lines { grid-template-columns: auto minmax(0, 1fr) auto; row-gap: 2px; }
+  .chain-line .commodity-cell { grid-column: 1 / -1; }
+  .chain-line-scu { justify-self: start; }
+}
 
 /* ---------- Vue Corrections ---------- */
 .corrections-wrap { margin: 20px 0 0; }


### PR DESCRIPTION
## Ce que ça change

Chaque saut de la vue **Chaîne ⛓️** transporte maintenant un **manifeste multi-commodités** au lieu
d'une seule : quand le stock au départ ou la demande à l'arrivée ne suffit pas à remplir la soute, le
reste se comble avec d'autres commodités, exactement comme « En route 🧭 ». La carte détaille les
lignes de chaque saut (commodité, SCU, prix, ce que la ligne rapporte), et **▶ Ajouter au voyage**
pousse ce chargement-là — la vue Voyage annonce désormais le **même chargement et le même profit** que
la carte Chaîne.

## Pourquoi

`buildChainAdjacency` ne gardait qu'**un leg par paire de terminaux** (`logic.mjs:1072` sur `main`,
`logic.mjs:1093` ici : `if (!cur || mieux(cand, cur)) m.set(s[0], cand);`), et `chainLegNet`
(`logic.mjs:544` sur `main`, `:554` ici) remplissait toute la soute avec cette unique commodité. Dès
qu'elle était plafonnée par le stock ou la demande, la place restante était perdue.

Mesuré sur `data/market.json` (114 terminaux, soute 96 SCU, `resolve` identité, frais k = 1) :

| | avant | après |
|---|---|---|
| SCU emportés en moyenne par arc | 76,4 / 96 | **80,6 / 96** |
| Profit moyen par arc | 85 056 aUEC | **91 129 aUEC** (+7,1 %) |
| Arcs à plusieurs commodités | 0 | **789** |
| Arcs qui rapportent MOINS qu'avant | — | **0 / 4 355** |

Sur une chaîne réelle, Rod's Fuel en 4 sauts : **4 083 264 → 4 268 392 aUEC**, et son dernier saut
passe de 4 SCU d'Osoian Hides à 96 SCU en trois lignes.

**Le manifeste se compose par ARC, jamais dans le faisceau** (`estampillerManifestes`,
`logic.mjs:1131`). L'invariant qui l'autorise est vérifié dans le code et écrit noir sur blanc en
commentaire : `bestChain` ne thread aucun budget et passe `cargo` inchangé à chaque saut, la soute se
vidant à chaque arrivée — le chargement de `u → v` ne dépend donc pas du chemin qui y mène. Appelé
depuis les ≈ 33 000 expansions du faisceau, il aurait coûté ≈ 1 s ; composé par arc, ≈ 6 ms.

Trois points que l'issue signalait, tranchés :

- **`sameOnly` et l'avant-poste d'ORIGINE**, que `pairEligible` (`logic.mjs:789`) n'applique pas : on
  n'estampille que des arcs **déjà retenus** par le balayage mono, qui les applique tous les deux.
  Un manifeste sans arc n'entre pas dans le graphe.
- **Les 71 arcs sans manifeste** (136 avec les frais actifs) gardent leur chiffrage mono : `fillCargo`
  ne retient rien là où le balayage produit encore un segment. Aucun arc ne disparaît, le compte reste
  de 4 355.
- **La régression de #41** (20 arcs, jusqu'à −3,2 %) : elle est corrigée en amont, la réallocation de
  la place libérée étant déjà sur `main`. Vérifiée ici plutôt que supposée, au niveau de la chaîne
  cette fois : 0 arc sur 4 355 rapporte moins qu'avant. Pas de `max(mono, manifeste)`, donc.

**Pourquoi pas d'ADR** : l'issue en suggérait un pour quatre décisions, mais aucune ne renverse quoi
que ce soit de documenté. (1) le pré-calcul par arc est un choix d'implémentation dont l'invariant est
écrit à l'endroit où on le casserait ; (2) la régression est traitée en amont et mesurée ; (3) le
budget reste **ignoré** par la chaîne, comme le dit déjà la note ¹ du README — l'honorer, ça, aurait
demandé un ADR ; (4) la déplétion du stock entre sauts n'est toujours pas modélisée, et le commentaire
le dit explicitement pour qu'on ne la croie pas oubliée. Le faisceau reste à 400, la mesure qui l'a
fixé n'est pas touchée.

## Vérification

```
$ node --test
ℹ tests 423    ℹ pass 423    ℹ fail 0    ℹ duration_ms 321.5
```

**Le rouge avant le vert** — les quatre tests écrits d'abord, sur `main` :

```
ℹ tests 420   ℹ pass 416   ℹ fail 4
✖ chaîne : un saut transporte un manifeste, et la soute ne repart plus à moitié vide
    TypeError: Cannot read properties of undefined (reading 'map')   (arc.lines n'existait pas)
✖ chaîne : un saut de N lignes paie N bases d'autoload, pas une
✖ chaîne : un arc sans manifeste garde son chiffrage mono et reste dans le graphe
✖ chaîne : le manifeste par arc reste soumis à « même système » et à l'exclusion des avant-postes
    AssertionError: sans manifeste sur l'arc, le test ne prouverait rien
```

Puis, une fois `logic.mjs` corrigé, un seul test existant tombait — `buildChainAdjacency : les frais
peuvent renverser le choix de commodité d'un saut`, `8480 !== 5760` : le saut emporte désormais les
deux commodités. Il est **réécrit, pas supprimé**, et garde ce qu'il prouvait (les frais renversent le
classement de l'arc) en disant en plus ce que le saut charge.

Nouveaux tests unitaires : les 4 ci-dessus, plus
- `chaîne : sur les 4 355 arcs réels, aucun ne rapporte moins qu'avant et aucun ne disparaît` — la
  non-régression balayée sur l'instantané entier, frais actifs ;
- `chaîne : garde de performance — le manifeste se compose par ARC, jamais dans le faisceau` ;
- `legsFromChain : la jambe est nommée par la ligne de TÊTE du manifeste du saut`.

**Garde de performance**, mesurée ici (et non recopiée de l'issue), `data/market.json`, 96 SCU,
frais k = 1, moyenne de 5 à 20 exécutions :

| | avant | après |
|---|---|---|
| `buildChainAdjacency` | 2,39 ms | **8,50 ms** |
| `bestChain` 4 sauts (pire origine) | 9,86 ms | **8,20 ms** |
| pire cas de l'UI (les deux) | 12,2 ms | **15,6 ms** |

Le faisceau est plus rapide **après** : `chainLegNet` rend le chargement pré-calculé au lieu de le
recalculer 33 000 fois.

La garde du test, elle, est un **rapport** et non un chronomètre — et c'est la CI qui l'a exigé. Un
premier jet plafonnait à 100 ms : rouge sur le runner GitHub, qui met **190 ms** là où ce poste met
8 (`bestChain 4 sauts : 190.0 ms`, run 31853581885). Un plafond calé sur une machine est soit rouge
sur l'autre, soit trop lâche pour rien voir. Le test compare donc deux mesures prises dans le même
processus :

- le faisceau sur chargements pré-calculés contre le **même faisceau sur la même adjacence privée de
  ses manifestes** (le chiffrage mono d'avant) — mesuré ×0,5 à ×0,8, plafond ×3 ;
- l'adjacence contre **elle-même sans soute bornée**, donc sans aucun manifeste à composer — mesuré
  ×4 à ×11, plafond ×20 (appeler `manifestsFrom` une fois par arc au lieu d'une fois par origine
  donnerait ×40).

Les deux rapports attrapent toujours le facteur 100 d'un manifeste composé dans la boucle, et ne
dépendent plus de la machine. CI au vert : `unit` 11 s, `e2e` 5 min 19 s (run 31854080658).

```
$ npx playwright test
135 passed, 2 skipped (1.4m)
```

Deux e2e ajoutés : `Chaîne : un saut détaille les commodités qu'il transporte (#56)` (les lignes du
saut, et leur somme = le volume annoncé) et `Chaîne : « ▶ Ajouter au voyage » pousse le chargement RÉEL
du saut (#56)` (mêmes commodités, mêmes SCU, même profit dans la vue Voyage). Tous deux **balaient**
les origines jusqu'à en trouver une qui charge plusieurs commodités et échouent franchement sinon —
aucun ne s'adosse à une ligne du jeu de données.

## Ce qui n'est pas couvert

- **Le budget.** La chaîne l'ignore toujours (README, note ¹), là où une jambe de voyage le consomme :
  sous un budget bornant, la jambe reprise dans le Voyage peut charger **moins** que ce que la carte
  Chaîne annonçait. La note ¹ le dit maintenant, et l'e2e d'égalité coupe le budget pour la durée du
  test. L'honorer serait un changement de sens de la vue, à trancher en ADR.
- **La déplétion du stock entre sauts** : toujours pas modélisée, et le multi-commodités multiplie les
  croisements. Aucune donnée UEX ne dit à quel rythme un terminal se recharge.
- **L'optimum exact du sac à dos à deux contraintes** : `fillCargo` reste glouton, avec ses deux
  ordres d'essai.
- **La vue Boucles ⇄**, bridée exactement de la même façon (`loopMetrics`) : même symptôme, issue
  distincte.
- **L'édition à la main du manifeste d'un saut** depuis la carte Chaîne : elle existe côté Voyage, la
  carte Chaîne reste en lecture seule.
- Les champs scalaires d'un arc (`commodity`, `margin`…) restent ceux du **repli mono** : ils nomment
  l'arc et servent à le classer. C'est `leg.lines` qui dit ce qui voyage.

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)
