### PR TITLE
feat(voyage): le Plan de vol récapitule le voyage, et devient la seule vue à porter la carte

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ reconstruites/redéployées **quand UEX a réellement changé** — et le site e
 
 ## Fonctionnalités
 
-Six vues, un même moteur de calcul (soute SCU + budget aUEC → unités, coût, profit/voyage, profit/heure) :
+Sept vues, un même moteur de calcul (soute SCU + budget aUEC → unités, coût, profit/voyage, profit/heure) :
 
 | Vue | Ce qu'elle fait |
 |-----|-----------------|
@@ -33,6 +33,7 @@ Six vues, un même moteur de calcul (soute SCU + budget aUEC → unités, coût,
 | **Chaîne ⛓️** | Trajets **multi-sauts A→B→C…** (2 à 4 sauts) : achète, vends, rachète sur place, revends plus loin — recherche par faisceau du circuit le plus rentable. Chaque saut transporte un **manifeste multi-commodités** détaillé sur la carte : quand le stock au départ ou la demande à l'arrivée ne suffit pas à remplir la soute, le reste se comble avec d'autres commodités, exactement comme « En route » |
 | **Corrections ✎** | Ses corrections locales **rangées par station** (bande de vignettes), et de quoi en créer via un sélecteur groupé `système › zone › station` (voir plus bas) |
 | **Commodités 📊** | *Big board* type « salle des marchés », en deux modes. **◈ Marché** : toutes les commodités échangeables avec leur **code officiel UEX** (AGRI, QUAN…), triables (marge / code / catégorie), et au clic **tous leurs points d'achat et de vente** — pratique pour trouver **où écouler** une commodité quand une station n'a plus de demande. **💰 Butin** : le board bascule sur le **prix de revente au SCU** et fait entrer les commodités qu'on **ne peut pas acheter** (minerais raffinés, salvage, drogues de wreck) — la réponse à « j'ai trouvé ça, ça vaut combien et où je l'écoule ? » |
+| **Plan de vol 🗺️** | La **conclusion** : une fois tout paramétré, le récapitulatif de ce qui est engagé — la **carte du parcours en grand** (elle ne vit plus que là), la soute commodité par commodité avec la place libre et le capital engagé, le parcours étape par étape, la jambe en cours et son manifeste, ce qu'il reste à faire. **On n'y change rien** : la barre de filtres y est masquée, et les quatre réglages qui donnent leur sens aux chiffres (vaisseau, soute, budget, frais d'autoload) y sont **repris en texte, en lecture seule** — une conclusion énonce ses hypothèses au lieu de les offrir à la modification. Un bouton **⧉ Copier le récapitulatif** en sort le texte, à coller dans un salon ([ADR-004](docs/superpowers/specs/2026-08-14-plan-de-vol-adr.md)) |
 
 Autres éléments :
 
@@ -56,7 +57,7 @@ signe et **en rouge**, jamais dans le vert des gains.
 - **Fiabilité des données** : pastille d'âge par relevé, filtre de fraîcheur (< 24 h / 3 j / 7 j), point de statut d'inventaire, tag « à vérifier », bandeau global « données d'il y a X h ».
 - **Filtres** : commodité, système, même système uniquement, exclure les avant-postes, commodités légales uniquement, limiter au stock & à la demande UEX. Ils ne s'appliquent pas tous à toutes les vues — voir la **[matrice ci-dessous](#portée-des-filtres-par-vue)**.
 - **Permaliens & persistance** : l'état (filtres, tri, vue, vaisseau) est mémorisé (localStorage) et encodé dans l'URL → bouton **Partager**.
-- **Copier le manifeste**, **raccourcis clavier** (`/` recherche, `1`–`6` vues) ; tout ce qui s'active
+- **Copier le manifeste**, **raccourcis clavier** (`/` recherche, `1`–`7` vues) ; tout ce qui s'active
   au clic s'active aussi à **Entrée/Espace** (en-têtes de tri, escales de la carte, valeurs
   corrigeables, en-tête d'une jambe), et les raccourcis se taisent tant que le focus est sur l'un d'eux.
 - Systèmes couverts : **Stanton**, **Pyro**, **Nyx**.
@@ -64,6 +65,10 @@ signe et **en rouge**, jamais dans le vert des gains.
 ### Portée des filtres par vue
 
 Tous les filtres ne s'appliquent pas à toutes les vues — comportement **garanti par des tests** ([voir Tests](#tests)) :
+
+Le **Plan de vol** n'a pas de colonne : il n'affiche aucun filtre (ADR-004). Les chiffres qu'il
+récapitule restent ceux calculés sous les réglages en cours — c'est précisément pourquoi il les
+énonce en tête, en toutes lettres.
 
 | Filtre | Trajets | Boucles | En route | Chaîne | Corrections | Commodités |
 |--------|:-:|:-:|:-:|:-:|:-:|:-:|
@@ -257,7 +262,7 @@ en prend l'instantané **au prix qu'elle venait d'afficher** — donc sans rien 
 **Deux entrées, pas une.** `✓ chargé` suppose un voyage, une jambe et un terminal qui vend la
 commodité : rien n'y rentre du butin ramassé au sol, d'un vaisseau rangé plein la semaine dernière,
 ni d'une cargaison achetée hors du site. Le bouton **`+ déclarer ce que j'ai à bord`** — présent
-dans **les six vues**, y compris soute vide — ouvre trois champs : la commodité (nom ou code UEX),
+dans **les six vues de recherche**, y compris soute vide — ouvre trois champs : la commodité (nom ou code UEX),
 les SCU, et le **prix payé au SCU**. Ce dernier est facultatif : laissé vide, c'est du **butin** au
 coût nul, et la ligne porte alors l'étiquette `butin`, parce que ce zéro fait compter *tout*
 l'encaissement comme profit dans « où écouler ».
@@ -381,7 +386,7 @@ le plus souvent constater qu'on vient soi-même de vider la station — le traje
 décidé. Les jambes qui **touchent ce point** (le terminal corrigé est leur départ pour un stock,
 leur arrivée pour une demande, et leur chargement porte cette commodité) **figent donc leurs SCU**
 et prennent le marqueur `🔒`. Elles continuent de suivre les prix ; seules leurs quantités sont
-gelées. Tout ce qui est calculé **ensuite** — les autres jambes, les six vues, un arrêt ajouté plus
+gelées. Tout ce qui est calculé **ensuite** — les autres jambes, les sept vues, un arrêt ajouté plus
 tard — voit le stock tel que tu l'as corrigé. `↺ optimal` lève le gel.
 
 `🔒` et `✎` se distinguent : le premier vient d'une correction, le second de ta main. Toucher au

--- a/app.js
+++ b/app.js
@@ -2428,20 +2428,171 @@ function renderJourneyRecap({ n, totalProfit, totalScu, totalFees, systems }) {
      </div>`;
 }
 
-// Bascule intelligente : si la carte Voyage est bien plus haute que TOUT ce qui l'accompagne
+// ---------- Plan de vol : la vue de conclusion (ADR-004) ----------
+// Une CONCLUSION, pas un tableau de bord : on y arrive une fois tout paramétré, pour REGARDER le
+// résultat. Rien n'y est actionnable — pas un bouton de vente, pas un ✕, pas un champ. Les gestes
+// vivent dans les six vues de recherche, et le bandeau (masqué ici, et ici seulement) les y porte.
+
+// Les quatre réglages qui ne FILTRENT pas mais changent le SENS des chiffres (ADR-004 §6). La soute
+// donne la place libre ; l'autoload décide si les profits sont nets ou bruts, et son état n'est
+// autrement lisible que sur une case à cocher — masquée ici. Les taire rendrait la conclusion
+// silencieusement ambiguë : on lirait un profit sans savoir s'il est net.
+function planHypotheses(f) {
+  return [
+    $("ship").value.trim() || "aucun vaisseau",
+    f.useCargo && f.cargo > 0 ? `soute ${fmt(f.cargo)} SCU` : "soute non limitée",
+    f.useBudget && f.budget > 0 ? `budget ${fmt(f.budget)} aUEC` : "budget non limité",
+    f.autoload ? `profits nets (k = ${String(globalK()).replace(".", ",")})` : "profits bruts",
+  ];
+}
+
+// Tout ce que la vue montre, calculé UNE fois : le rendu et la copie lisent la même chose, sinon
+// le texte collé dans un salon dériverait de l'écran qui l'a produit.
+// Aucun calcul neuf (ADR-004 : « C'est un déménagement d'interface, les chiffres ne changent pas ») :
+// les manifestes par jambe passent par legEffectiveLines, exactement comme le compagnon de voyage.
+function planData() {
+  const f = readFilters();
+  const groupes = holdByCommodity(SOUTE);
+  const stations = JOURNEY ? journeyStations(JOURNEY) : [];
+  const jambes = (JOURNEY && MARKET ? JOURNEY.legs : []).map((leg, i) => {
+    const lines = legEffectiveLines(leg, i, f) || [];
+    const t = lines.length ? manifestTotals(lines, (legFeeCtx(leg, f) || {}).pair) : { profit: 0, fees: 0 };
+    return {
+      i, from: leg.from, to: leg.to, lines,
+      scu: lines.reduce((s, l) => s + l.units, 0),
+      profit: t.profit, fees: t.fees,
+      courante: i === JOURNEY.current,
+      faite: i < JOURNEY.current,
+      chargee: jambeChargee(leg, i),
+    };
+  });
+  return {
+    f, groupes, stations, jambes,
+    scu: holdScu(SOUTE),
+    libre: f.useCargo && f.cargo > 0 ? freeCargo(SOUTE, f.cargo) : null,
+    invest: groupes.reduce((s, g) => s + g.invest, 0),
+    totalProfit: jambes.reduce((s, j) => s + j.profit, 0),
+    totalFees: jambes.reduce((s, j) => s + j.fees, 0),
+    totalScu: jambes.reduce((s, j) => s + j.scu, 0),
+    reste: JOURNEY ? Math.max(0, JOURNEY.legs.length - JOURNEY.current) : 0,
+  };
+}
+
+// La soute EN GRAND : ce qu'il y a à bord commodité par commodité, la place libre, ce qui a été
+// payé. Le #holdCard du bandeau dit la même chose dans un encart latéral — mais il porte la vente,
+// le dépôt et le retrait de lot. Ici, aucun bouton : c'est la même donnée, en lecture.
+function planHoldHTML(d) {
+  if (!d.groupes.length) {
+    return `<div class="plan-card" id="planHold"><div class="plan-card-head">◈ Soute</div>
+      <p class="plan-muted">Rien à bord. Charge un manifeste depuis une jambe, ou déclare ce que tu transportes depuis le bandeau d'une vue de recherche.</p></div>`;
+  }
+  const icone = (nom) => { const c = MARKET && findCommodity(nom); return c ? commodityIcon(c.kind) : ""; };
+  const lignes = d.groupes.map((g) => {
+    // Part de la soute occupée par cette commodité : c'est le « visuel » que l'encart latéral, trop
+    // étroit, ne pouvait pas porter. Rapportée à la CAPACITÉ quand elle est connue, au chargement
+    // sinon — une barre sans dénominateur ne voudrait rien dire.
+    const base = d.f.useCargo && d.f.cargo > 0 ? d.f.cargo : d.scu;
+    const part = base > 0 ? Math.min(100, (g.units / base) * 100) : 0;
+    return `<div class="plan-hold-line">
+        <span class="plan-hold-name">${icone(g.name)}<span>${esc(g.name)}</span></span>
+        <span class="plan-hold-bar" aria-hidden="true"><i style="width:${part.toFixed(1)}%"></i></span>
+        <span class="plan-hold-scu"><b>${fmt(g.units)}</b> SCU</span>
+        <span class="plan-hold-paid" title="Prix payé au SCU${g.lots.length > 1 ? " (moyenne des lots)" : ""}">@ ${fmt(Math.round(g.paidMoyen))}</span>
+      </div>`;
+  }).join("");
+  return `<div class="plan-card" id="planHold">
+      <div class="plan-card-head">◈ Soute</div>
+      <div class="plan-hold-lines">${lignes}</div>
+      <div class="plan-card-meta"><b>${fmt(d.scu)}</b> SCU à bord${d.libre != null ? ` · <b>${fmt(d.libre)}</b> SCU libres` : ""} · capital engagé <b>${fmt(d.invest)}</b> aUEC</div>
+    </div>`;
+}
+
+// Le parcours étape par étape, la jambe en cours et son manifeste, et ce qu'il reste à faire.
+function planRouteHTML(d) {
+  if (!JOURNEY) {
+    return `<div class="plan-card" id="planRoute"><div class="plan-card-head">◈ Parcours</div>
+      <p class="plan-muted">Aucun voyage engagé. Démarre-en un depuis <b>Trajets</b> — le ▶ d'une ligne — ou de zéro en posant un point de départ dans le bandeau.</p></div>`;
+  }
+  const chemin = d.stations
+    .map((s, i) => `<span class="plan-step${i === JOURNEY.current ? " here" : ""}"><span class="sys ${esc(s.system.toLowerCase())}">${esc(s.name)}</span></span>`)
+    .join('<span class="plan-sep">→</span>');
+  const jambes = d.jambes.map((j) => {
+    const cargo = j.lines.length
+      ? j.lines.map((l) => `<span class="plan-cargo-item">${commodityIcon(l.kind)}${esc(l.name)} <b>${fmt(l.units)} SCU</b></span>`).join("")
+      : '<span class="plan-muted">aucun fret rentable</span>';
+    const etat = j.faite ? "faite" : j.courante ? "courante" : "à venir";
+    return `<div class="plan-leg ${j.courante ? "current" : j.faite ? "done" : ""}">
+        <div class="plan-leg-head"><span class="plan-leg-n">${j.i + 1}</span>
+          <span class="plan-leg-route">${esc(j.from)} → ${esc(j.to)}</span>
+          <span class="plan-leg-state">${etat}${j.chargee ? " · chargée" : ""}</span>
+          <span class="plan-leg-profit ${classeProfit(j.profit)}">${signe(j.profit, fmtFee(j.profit, j.fees))}</span></div>
+        <div class="plan-leg-cargo">${cargo}</div>
+      </div>`;
+  }).join("");
+  const n = JOURNEY.legs.length;
+  return `<div class="plan-card" id="planRoute">
+      <div class="plan-card-head">◈ Parcours</div>
+      <div class="plan-path">${chemin}</div>
+      ${MARKET ? `<div class="plan-legs">${jambes}</div>` : '<p class="plan-muted">Calcul des manifestes…</p>'}
+      <div class="plan-card-meta"><b>${n}</b> saut${n > 1 ? "s" : ""} · <b>${d.reste}</b> à faire · <b>${fmt(d.totalScu)}</b> SCU transportés ·
+        profit ${MARKET ? `<b class="${classeProfit(d.totalProfit)}">${signe(d.totalProfit, fmtFee(d.totalProfit, d.totalFees))}</b> aUEC` : "…"}</div>
+    </div>`;
+}
+
+function renderPlan() {
+  const head = $("planHead"), body = $("planBody");
+  if (!head || !body) return;
+  // Les manifestes par jambe vivent dans le graphe d'échange, que la vue par défaut ne charge pas.
+  // On passe `refresh` et non `renderPlan` : c'est la règle de withMarket — le fetch dure, et
+  // l'utilisateur peut avoir changé de vue entre-temps.
+  if (JOURNEY && !MARKET) withMarket(refresh);
+  const d = planData();
+  head.innerHTML =
+    `<div class="plan-title"><span class="plan-kicker">◈ Plan de vol</span>
+       <button id="planCopy" class="plan-copy" type="button" title="Copier le récapitulatif en texte, à coller dans un salon">⧉ Copier le récapitulatif</button></div>
+     <div class="plan-hyp" id="planHypotheses" title="Ces quatre réglages changent le sens des chiffres ci-dessous. Pour les modifier, retourne dans une vue de recherche.">${planHypotheses(d.f).map(esc).join(" · ")}</div>`;
+  body.innerHTML = `<div class="plan-grid">${planHoldHTML(d)}${planRouteHTML(d)}</div>`;
+}
+
+// Le récapitulatif EN TEXTE (ADR-004 §8). Pas une image : la CSP pose `img-src 'self' https:` sans
+// `data:`, ce qui bloque le procédé habituel (<foreignObject> sérialisé en data: URI). Et le texte
+// se colle partout, se cite ligne par ligne dans un salon, et survit aux thèmes.
+function copierPlan() {
+  const d = planData();
+  const lignes = [`Plan de vol — ${planHypotheses(d.f).join(" · ")}`];
+  if (d.stations.length) {
+    lignes.push(`Parcours : ${d.stations.map((s) => `${s.name} (${s.system})`).join(" → ")}`);
+    d.jambes.forEach((j) => {
+      lignes.push(`${j.i + 1}. ${j.from} → ${j.to}  ${fmt(j.scu)} SCU  ${signe(j.profit, fmtFee(j.profit, j.fees))} aUEC${j.courante ? "  <- ici" : ""}`);
+      j.lines.forEach((l) => lignes.push(`     ${fmt(l.units)} SCU  ${l.name}`));
+    });
+  } else {
+    lignes.push("Parcours : aucun voyage engagé.");
+  }
+  if (d.groupes.length) {
+    lignes.push(`Soute : ${d.groupes.map((g) => `${fmt(g.units)} SCU ${g.name}`).join(" · ")}`);
+    lignes.push(`        ${fmt(d.scu)} SCU à bord${d.libre != null ? ` · ${fmt(d.libre)} libres` : ""} · capital engagé ${fmt(d.invest)} aUEC`);
+  }
+  const n = JOURNEY ? JOURNEY.legs.length : 0;
+  lignes.push(`Total : ${n} saut${n > 1 ? "s" : ""} · ${fmt(d.totalScu)} SCU · ${signe(d.totalProfit, fmtFee(d.totalProfit, d.totalFees))} aUEC`);
+  copierTexte(lignes.join("\n"), $("planCopy"), "⧉ Copier le récapitulatif");
+}
+
+// Bascule intelligente : si la carte Voyage est bien plus haute que ce qui l'accompagne
 // (voyage long / jambe dépliée), on empile en pleine largeur pour supprimer le grand vide.
-// On mesure la plus haute des AUTRES colonnes, pas seulement celle de gauche : depuis que la carte
-// du parcours est la troisième colonne, c'est souvent ELLE qui remplit le vide, et ne regarder
-// qu'à gauche empilait la rangée dès que la colonne du vaisseau était vide.
-// À appeler APRÈS le rendu de la carte : mesurée avant, elle est encore masquée (ou à sa taille du
-// rendu précédent) et la rangée s'empilait sur une hauteur qui n'existait plus.
+// La carte du parcours ne compte PLUS dans cette mesure : elle a quitté la rangée pour le Plan de
+// vol (ADR-004 §4), où elle occupe toute la largeur. Tant qu'elle était la troisième colonne, il
+// fallait la mesurer — c'était souvent elle qui remplissait le vide. Il ne reste que la colonne de
+// gauche, et le bandeau est de toute façon masqué dans la vue où vit désormais la carte.
+// À appeler APRÈS le rendu des cartes : mesurées avant, elles sont encore masquées (ou à leur
+// taille du rendu précédent) et la rangée s'empilait sur une hauteur qui n'existait plus.
 // Mesure synchrone (getBoundingClientRect force le reflow) -> fiable même onglet non peint.
 function ajusterRangeeVoyage() {
-  const row = $("shipJourneyRow"), jc = $("journeyCard"), vl = $("voyageLeft"), jm = $("journeyMap");
+  const row = $("shipJourneyRow"), jc = $("journeyCard"), vl = $("voyageLeft");
   if (!row || !jc || !vl || jc.hidden) return;
   row.classList.remove("stacked"); // mesure toujours dans la disposition côte-à-côte de base
   const h = (el) => (el && !el.hidden ? el.getBoundingClientRect().height : 0);
-  if (h(jc) > Math.max(h(vl), h(jm)) + 140) row.classList.add("stacked");
+  if (h(jc) > h(vl) + 140) row.classList.add("stacked");
 }
 
 // Bascule entre les vues et rafraîchit la bonne.
@@ -2457,6 +2608,7 @@ function refresh() {
   else if (view === "chain") renderChain();
   else if (view === "corrections") renderCorrections();
   else if (view === "commodities") renderCommodities();
+  else if (view === "plan") renderPlan();
   else render();
   // La carte Voyage est affichée À CÔTÉ des tableaux, dans toutes les vues : la laisser hors du
   // cycle de rendu la figeait sur l'état d'avant. Corriger un prix ne mettait donc pas à jour les
@@ -2484,6 +2636,7 @@ function switchView(v) {
   $("viewChain").classList.toggle("active", v === "chain");
   $("viewCorrections").classList.toggle("active", v === "corrections");
   $("viewCommodities").classList.toggle("active", v === "commodities");
+  $("viewPlan").classList.toggle("active", v === "plan");
   $("routes").hidden = v !== "routes";
   $("loops").hidden = v !== "loops";
   $("enroute").hidden = v !== "enroute";
@@ -2494,8 +2647,16 @@ function switchView(v) {
   $("corrections").hidden = v !== "corrections";
   $("commoditiesControls").hidden = v !== "commodities";
   $("commodities").hidden = v !== "commodities";
+  $("plan").hidden = v !== "plan";
+  // Les deux blocs jusqu'ici PERMANENTS, que seule la vue de conclusion masque (ADR-004 §4 et §6).
+  // La barre de filtres : on ne change rien au voyage depuis le Plan de vol, l'y laisser ferait
+  // croire le contraire. Le bandeau : ses cartes sont éditables (✕ du parcours, vente en soute) et
+  // c'est tout ce que cette vue n'est pas — le Plan de vol le remplace par un récapitulatif inerte.
+  // Aucune valeur n'est touchée : les deux reviennent intacts au retour dans une vue de recherche.
+  $("controls").hidden = v === "plan";
+  $("shipJourneyRow").hidden = v === "plan";
   if (v !== "enroute") $("manifest").hidden = true;
-  if (v === "chain" || v === "corrections" || v === "commodities") $("empty").hidden = true;
+  if (v === "chain" || v === "corrections" || v === "commodities" || v === "plan") $("empty").hidden = true;
   refresh();
 }
 
@@ -2799,7 +2960,10 @@ function applyState(s) {
   STATE_CHECKS.forEach((id) => { if (s[id] != null) $(id).checked = s[id] === "1"; });
   if (safeKey(s.sk)) { sortKey = s.sk; sortDir = Number(s.sd) === 1 ? 1 : -1; }
   if (safeKey(s.lk)) { loopSortKey = s.lk; loopSortDir = Number(s.ld) === 1 ? 1 : -1; }
-  if (["routes", "loops", "enroute", "chain", "corrections", "commodities"].includes(s.v)) view = s.v;
+  // Liste blanche des vues restaurables. Y OUBLIER une vue neuve est le piège documenté par
+  // l'ADR-004 : elle s'ouvre au clic, mais ne revient ni d'un permalien ni du localStorage — et
+  // l'oubli ne se voit qu'au rechargement suivant.
+  if (["routes", "loops", "enroute", "chain", "corrections", "commodities", "plan"].includes(s.v)) view = s.v;
   if (s.cb === "loot") commBoard = "loot";
   if (s.j) JOURNEY = decodeJourney(s.j); // compagnon de voyage restauré (les champs sont déjà repris ci-dessus)
   applySortIndicators();
@@ -3332,6 +3496,14 @@ async function init() {
   $("viewChain").addEventListener("click", () => switchView("chain"));
   $("viewCorrections").addEventListener("click", () => switchView("corrections"));
   $("viewCommodities").addEventListener("click", () => switchView("commodities"));
+  $("viewPlan").addEventListener("click", () => switchView("plan"));
+  // La marque ramène à TRAJETS, la vue principale — pas au Plan de vol (ADR-004 §5). Un <button>
+  // natif : Entrée et Espace y viennent sans rien ajouter.
+  $("brandHome").addEventListener("click", () => switchView("routes"));
+  // Copie du récapitulatif : écouteur DÉLÉGUÉ sur l'en-tête, que renderPlan réécrit à chaque rendu.
+  $("planHead").addEventListener("click", (e) => {
+    if (e.target.closest("#planCopy")) copierPlan();
+  });
   $("share").addEventListener("click", copyShareLink);
   // Contrôles « Commodités » : modes de tri + sélection d'une tuile.
   $("commSortModes").addEventListener("click", (e) => { const b = e.target.closest("button[data-sort]"); if (b) setCommSort(b.dataset.sort); });
@@ -3604,13 +3776,13 @@ async function init() {
       startEdit(e.target);
     }
   });
-  // Raccourcis clavier : / (recherche), 1/2/3 (vues). Ignorés pendant la saisie.
+  // Raccourcis clavier : / (recherche), 1 à 7 (vues). Ignorés pendant la saisie.
   document.addEventListener("keydown", (e) => {
     if (e.ctrlKey || e.metaKey || e.altKey) return;
     const el = document.activeElement;
     // `role="button"` couvre d'un coup tout ce que l'app rend activable sans être un <button> :
     // l'en-tête d'une jambe, une escale de la carte, une valeur corrigeable. Sans lui, tabuler
-    // jusqu'à l'un d'eux puis taper « 1 »…« 6 » changeait de vue — l'utilisateur clavier perdait son
+    // jusqu'à l'un d'eux puis taper « 1 »…« 7 » changeait de vue — l'utilisateur clavier perdait son
     // contexte au moment précis où il essayait d'agir dessus.
     if (el && (el.tagName === "INPUT" || el.tagName === "SELECT" || el.tagName === "TEXTAREA" ||
                el.getAttribute("role") === "button" || el.classList.contains("editv"))) return;
@@ -3621,6 +3793,7 @@ async function init() {
     else if (e.key === "4") switchView("chain");
     else if (e.key === "5") switchView("corrections");
     else if (e.key === "6") switchView("commodities");
+    else if (e.key === "7") switchView("plan");
   });
   loadOverrides();
   loadAutoloadK();

--- a/app.js
+++ b/app.js
@@ -1192,13 +1192,23 @@ function copyManifest() {
 // première version de l'ADR affirmait, la CSP ne l'interdit pas — la mesure qui le prétendait ne
 // s'est pas reproduite en contre-lecture.
 // `libelle` est le texte à remettre après le retour visuel : chaque bouton a le sien.
+// Un échec de copie DOIT se voir. Il se taisait deux fois (#91) :
+//   - `navigator.clipboard` est absent hors contexte sécurisé (http:// sur un LAN). Le `?.` rendait
+//     alors `undefined`, et le `.then` qui suivait levait une TypeError — la copie ne se faisait pas
+//     et emportait au passage le reste du gestionnaire de clic ;
+//   - un refus de permission tombait dans un `.catch(() => {})` vide, donc sans un mot.
+// Dans les deux cas l'utilisateur repartait en croyant avoir son texte dans le presse-papiers, et
+// collait le contenu précédent. Deux causes, deux messages : « indisponible » et « refusé » ne
+// demandent pas la même chose à qui les lit.
 function copierTexte(texte, btn, libelle) {
-  navigator.clipboard?.writeText(texte).then(() => {
+  const copie = navigator.clipboard?.writeText(texte);
+  if (!copie) { showToast("⚠ Presse-papiers indisponible — copie impossible depuis cette page"); return; }
+  copie.then(() => {
     if (!btn) return;
     btn.textContent = "✓ Copié";
     btn.classList.add("copied");
     setTimeout(() => { btn.textContent = libelle; btn.classList.remove("copied"); }, 1500);
-  }).catch(() => {});
+  }).catch(() => showToast("⚠ Presse-papiers refusé — la copie n'a pas eu lieu"));
 }
 
 function renderManifest(origin, destSystem, f, destTerminal) {

--- a/e2e/plan.pw.mjs
+++ b/e2e/plan.pw.mjs
@@ -1,0 +1,250 @@
+import { test, expect } from "@playwright/test";
+
+// Plan de vol : la septième vue, celle de CONCLUSION (#61, ADR-004).
+// Ces tests encodent les huit décisions de l'ADR. Trois d'entre elles ne se voient qu'en NÉGATIF —
+// ce qui doit disparaître ici, et surtout REVENIR ailleurs : la carte, la barre de filtres, le
+// bandeau. C'est le second sens qui casse en silence, il est donc testé à chaque fois.
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/index.html");
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+});
+
+// Les six vues de RECHERCHE, avec un témoin visible propre à chacune. Le Plan de vol n'y est pas :
+// c'est justement ce qui les sépare de lui.
+const VUES = [
+  ["#viewRoutes", "#routes"],
+  ["#viewLoops", "#loops"],
+  ["#viewEnroute", "#enrouteControls"],
+  ["#viewChain", "#chainControls"],
+  ["#viewCorrections", "#correctionsControls"],
+  ["#viewCommodities", "#commoditiesControls"],
+];
+
+// Un voyage minimal : ▶ sur la première ligne pose deux arrêts et une jambe. Aucun test d'ici ne
+// dépend du CLASSEMENT (contrairement à ceux qu'a cassés l'ADR-005) : n'importe quelle ligne fait
+// l'affaire, seule compte l'existence d'un parcours.
+async function voyageSimple(page) {
+  await page.locator("#rows tr").first().locator(".journey-pick").click();
+  await expect(page.locator("#journeyCard .jstep")).toHaveCount(2);
+}
+
+// Ouvre un lien en CHARGEMENT COMPLET, sans attendre le tableau : en Plan de vol, #routes est
+// masqué — l'attente habituelle sur #rows expirerait au lieu de vérifier quoi que ce soit.
+async function ouvrirPlanPermalien(page, hash) {
+  await page.goto("about:blank");
+  await page.goto("/index.html" + hash);
+}
+
+test("Plan de vol : une septième entrée au rail, au clic comme au raccourci « 7 » (#61)", async ({ page }) => {
+  await expect(page.locator("#viewPlan")).toBeVisible();
+  await page.click("#viewPlan");
+  await expect(page.locator("#plan")).toBeVisible();
+  await expect(page.locator("#viewPlan")).toHaveClass(/active/);
+  await expect(page.locator("#routes")).toBeHidden();
+
+  await page.click("#viewRoutes");
+  await expect(page.locator("#plan")).toBeHidden();
+  await page.keyboard.press("7"); // le raccourci, dans la continuité de 1…6
+  await expect(page.locator("#plan")).toBeVisible();
+  await page.keyboard.press("1");
+  await expect(page.locator("#routes")).toBeVisible();
+});
+
+test("Plan de vol : la vue revient d'un rechargement ET d'un permalien (liste blanche, #61)", async ({ page }) => {
+  // LE piège de l'ADR-004 : sans ajout dans la liste blanche d'applyState, la vue s'ouvre au clic
+  // mais ne revient d'aucun état sauvé — et l'oubli ne se voit qu'au rechargement suivant.
+  await page.click("#viewPlan");
+  await expect(page.locator("#plan")).toBeVisible();
+  expect(page.url()).toContain("v=plan");
+
+  await page.reload();
+  await expect(page.locator("#plan")).toBeVisible();
+  await expect(page.locator("#viewPlan")).toHaveClass(/active/);
+
+  await ouvrirPlanPermalien(page, "#v=plan");
+  await expect(page.locator("#plan")).toBeVisible();
+  await expect(page.locator("#viewPlan")).toHaveClass(/active/);
+});
+
+test("Plan de vol : la carte du parcours ne vit QUE dans cette vue (#61)", async ({ page }) => {
+  await voyageSimple(page);
+  await page.click("#viewPlan");
+  await expect(page.locator("#journeyMap")).toBeVisible();
+  await expect(page.locator("#journeyMap .jm-svg")).toBeVisible({ timeout: 10_000 });
+
+  // C'est la décision 4, et c'est ce qui justifie l'existence de la vue : ailleurs, plus de carte.
+  for (const [bouton, temoin] of VUES) {
+    await page.click(bouton);
+    await expect(page.locator(temoin)).toBeVisible();
+    await expect(page.locator("#journeyMap")).toBeHidden();
+  }
+});
+
+test("Plan de vol : la carte y est NETTEMENT plus large que sa colonne d'avant (#61)", async ({ page }) => {
+  // Avant : troisième colonne à `flex 1 1 460px`, dessin plafonné à 760 px. La vue existe pour
+  // qu'on la voie en grand — un plafond inchangé ferait un déménagement sans bénéfice.
+  await page.setViewportSize({ width: 1600, height: 900 });
+  await voyageSimple(page);
+  await page.click("#viewPlan");
+  const svg = page.locator("#journeyMap .jm-svg");
+  await expect(svg).toBeVisible({ timeout: 10_000 });
+  const box = await svg.boundingBox();
+  expect(box.width).toBeGreaterThan(900);
+});
+
+test("Plan de vol : le bandeau (résumé + soute) reste dans les six autres vues (#61)", async ({ page }) => {
+  // Décision 3, et non-régression pure : une refonte de disposition casse ça sans le vouloir.
+  await voyageSimple(page);
+  await page.locator("#holdAddOpen").click();
+  await expect(page.locator("#holdAddName")).toBeVisible();
+  await page.fill("#holdAddName", "Titanium");
+  await page.fill("#holdAddScu", "20");
+  await page.locator("#holdAddOk").click();
+  await expect(page.locator("#holdCard")).toBeVisible();
+
+  for (const [bouton] of VUES) {
+    await page.click(bouton);
+    await expect(page.locator("#journeyCard")).toBeVisible();
+    await expect(page.locator("#journeyRecap")).toBeVisible();
+    await expect(page.locator("#holdCard")).toBeVisible();
+    // Le chemin vers « changer d'étape » que la carte portait ailleurs : il reste au bandeau.
+    await expect(page.locator("#journeyCard .jstep").first()).toBeVisible();
+  }
+});
+
+test("Plan de vol : Trajets reste la vue par défaut au premier chargement (#61)", async ({ page }) => {
+  // Décision 2. Une conclusion n'est pas un point d'entrée : y atterrir sans état sauvé montrerait
+  // un parcours vide et une soute vide, soit l'écran le moins parlant de l'app.
+  await expect(page.locator("#routes")).toBeVisible();
+  await expect(page.locator("#viewRoutes")).toHaveClass(/active/);
+  await expect(page.locator("#plan")).toBeHidden();
+});
+
+test("la marque HAULR ramène à Trajets, à la souris et au clavier (#61)", async ({ page }) => {
+  // Décision 5 : « retour au début » mène à la vue principale, pas à la conclusion.
+  const marque = page.locator("#brandHome");
+  await expect(marque).toHaveAccessibleName(/Trajets/i);
+
+  await page.click("#viewPlan");
+  await expect(page.locator("#plan")).toBeVisible();
+  await marque.click();
+  await expect(page.locator("#routes")).toBeVisible();
+
+  await page.click("#viewLoops");
+  await expect(page.locator("#loops")).toBeVisible();
+  await marque.press("Enter");
+  await expect(page.locator("#routes")).toBeVisible();
+
+  // Contrainte de voisinage de l'ADR : le bouton de tuto (#62) viendra en FRÈRE dans .brand.
+  // Deux éléments interactifs imbriqués sont invalides en ARIA (règle appliquée par #38).
+  expect(await marque.locator("button, a, [role='button']").count()).toBe(0);
+});
+
+test("Plan de vol : les filtres de recherche sont masqués, et REVIENNENT au retour (#61)", async ({ page }) => {
+  await expect(page.locator("#controls")).toBeVisible();
+  await page.click("#viewPlan");
+  await expect(page.locator("#controls")).toBeHidden();
+  await expect(page.locator("#search")).toBeHidden();
+  await expect(page.locator("#multiCommodity")).toBeHidden();
+
+  // Le second sens : c'est celui qui casse en silence.
+  await page.click("#viewRoutes");
+  await expect(page.locator("#controls")).toBeVisible();
+  await expect(page.locator("#search")).toBeVisible();
+});
+
+test("Plan de vol : masquer n'est pas désactiver — les filtres survivent au passage (#61)", async ({ page }) => {
+  await page.fill("#search", "Titanium");
+  // La recherche est DEBOUNCÉE : compter les lignes tout de suite compterait le tableau NON filtré,
+  // et le test se comparerait ensuite à un chiffre qui n'a jamais correspondu au filtre. L'état
+  // sauvé dans le hash n'est écrit qu'en FIN de refresh : c'est le signal que le rendu a eu lieu.
+  await page.waitForFunction(() => location.hash.includes("search=Titanium"));
+  const avant = await page.locator("#rows tr").count();
+
+  await page.click("#viewPlan");
+  await page.click("#viewRoutes");
+  await expect(page.locator("#search")).toHaveValue("Titanium");
+  await expect(page.locator("#rows tr")).toHaveCount(avant);
+});
+
+test("Plan de vol : les quatre réglages sont repris en TEXTE, en lecture seule (#61)", async ({ page }) => {
+  // Décision 6. Ces quatre-là ne filtrent pas : ils changent le SENS des chiffres affichés. Les
+  // masquer sans rien mettre à la place ferait lire un profit sans savoir s'il est net.
+  await page.fill("#ship", "railen");
+  await page.locator("#shipList li").first().click();
+  const soute = await page.locator("#cargo").inputValue();
+
+  await page.click("#viewPlan");
+  const hyp = page.locator("#planHypotheses");
+  await expect(hyp).toContainText(/Railen/i);
+  await expect(hyp).toContainText(new RegExp(`${soute}\\s*SCU`));
+  await expect(hyp).toContainText(/bruts/i); // l'interrupteur d'autoload est inactif par défaut
+  // Lecture seule : le contrôle lui-même n'est pas actionnable ici.
+  await expect(page.locator("#autoload")).toBeHidden();
+  await expect(page.locator("#ship")).toBeHidden();
+
+  // Cocher depuis une AUTRE vue change le texte affiché ici : c'est un miroir, pas une copie figée.
+  await page.click("#viewRoutes");
+  await page.check("#autoload");
+  await page.click("#viewPlan");
+  await expect(hyp).toContainText(/nets/i);
+  await expect(hyp).toContainText(/k\s*=\s*1,2/);
+});
+
+test("Plan de vol : la soute a un vrai visuel — à bord, place libre, capital engagé (#61)", async ({ page }) => {
+  await page.locator("#holdAddOpen").click();
+  await expect(page.locator("#holdAddName")).toBeVisible();
+  await page.fill("#holdAddName", "Titanium");
+  await page.fill("#holdAddScu", "20");
+  await page.fill("#holdAddPaid", "100");
+  await page.locator("#holdAddOk").click();
+  await expect(page.locator("#holdCard")).toBeVisible();
+
+  await page.click("#viewPlan");
+  const soute = page.locator("#planHold");
+  await expect(soute).toContainText("Titanium");
+  await expect(soute).toContainText("20");
+  await expect(soute).toContainText(/libre/i);
+  await expect(soute).toContainText(/2\s*000/); // 20 SCU × 100 aUEC : le capital engagé
+  // On ne change RIEN depuis cette vue : ni vente, ni retrait de lot.
+  expect(await soute.locator("button").count()).toBe(0);
+});
+
+test("Plan de vol : la carte garde ses écouteurs directs après un re-rendu (#61)", async ({ page }) => {
+  // #journeyMap porte ses écouteurs EN DIRECT, une seule fois, hors du HTML réécrit par innerHTML.
+  // Le déménager dans un conteneur re-rendu reproduirait #24 : un geste qui cesse de répondre.
+  await voyageSimple(page);
+  await page.click("#viewPlan");
+  const arrets = page.locator("#journeyMap .jm-arret");
+  await expect(arrets.first()).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator("#journeyMap .jm-arret.ici")).toHaveCount(1);
+
+  await page.click("#viewRoutes"); // un cycle de rendu complet, ailleurs
+  await page.click("#viewPlan");
+  // `.jm-cible` et non le <g> : c'est le disque transparent qui porte la cible de clic, le centre
+  // du groupe tombant entre le point et son libellé (idiome déjà en place dans smoke.pw.mjs).
+  await arrets.nth(1).locator(".jm-cible").click(); // « je suis ici » sur le second arrêt
+  await expect(arrets.nth(1)).toHaveClass(/ici/);
+});
+
+test("Plan de vol : sans voyage, un état vide utile plutôt qu'une page blanche (#61)", async ({ page }) => {
+  await page.click("#viewPlan");
+  await expect(page.locator("#plan")).toBeVisible();
+  await expect(page.locator("#planBody")).toContainText(/Trajets/);
+  await expect(page.locator("#journeyMap")).toBeHidden();
+});
+
+test("Plan de vol : le bouton de capture copie le récapitulatif en texte (#61)", async ({ page, context }) => {
+  // Décision 8 : du TEXTE, pas une image — la CSP interdit le procédé habituel (img-src sans data:).
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+  await voyageSimple(page);
+  await page.click("#viewPlan");
+  await page.click("#planCopy");
+  await expect(page.locator("#planCopy")).toHaveText(/Copié/);
+
+  const texte = await page.evaluate(() => navigator.clipboard.readText());
+  expect(texte).toContain("Plan de vol");
+  expect(texte).toContain("→"); // le parcours, étape par étape
+  expect(texte).toMatch(/soute/i); // les hypothèses voyagent avec le récapitulatif
+});

--- a/e2e/plan.pw.mjs
+++ b/e2e/plan.pw.mjs
@@ -248,3 +248,31 @@ test("Plan de vol : le bouton de capture copie le récapitulatif en texte (#61)"
   expect(texte).toContain("→"); // le parcours, étape par étape
   expect(texte).toMatch(/soute/i); // les hypothèses voyagent avec le récapitulatif
 });
+
+// Les deux causes d'échec de `copierTexte`, chacune la sienne (#91). Elles valent pour les trois
+// autres boutons de copie du dépôt : le point de sortie est partagé.
+test("Plan de vol : un presse-papiers INDISPONIBLE le dit, jamais en silence (#91)", async ({ page }) => {
+  await voyageSimple(page);
+  await page.click("#viewPlan");
+  // Le cas d'un contexte non sécurisé (http:// sur un LAN) : Chrome ne pose pas navigator.clipboard.
+  await page.evaluate(() => {
+    Object.defineProperty(navigator, "clipboard", { configurable: true, get: () => undefined });
+  });
+  await page.click("#planCopy");
+  await expect(page.locator("#toast")).toContainText(/presse-papiers indisponible/i);
+  await expect(page.locator("#planCopy")).not.toHaveText(/Copié/); // surtout pas un faux succès
+});
+
+test("Plan de vol : un presse-papiers REFUSÉ le dit, jamais en silence (#91)", async ({ page }) => {
+  await voyageSimple(page);
+  await page.click("#viewPlan");
+  await page.evaluate(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      get: () => ({ writeText: () => Promise.reject(new Error("permission refusée")) }),
+    });
+  });
+  await page.click("#planCopy");
+  await expect(page.locator("#toast")).toContainText(/presse-papiers refusé/i);
+  await expect(page.locator("#planCopy")).not.toHaveText(/Copié/);
+});

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -1218,43 +1218,66 @@ test("Soute : une commodité inconnue ne crée pas un lot que l'app ne saurait p
   expect(await lots(page)).toEqual([]);
 });
 
+// La carte du parcours ne vit plus QUE dans le Plan de vol (ADR-004, décision 4) : les tests qui la
+// regardent y passent. Ils en REVIENNENT pour agir sur le parcours — ajouter un arrêt, effacer,
+// lire le fil d'étapes : ces commandes vivent au bandeau, que la conclusion n'affiche pas.
+async function auPlanDeVol(page) {
+  await page.click("#viewPlan");
+  await expect(page.locator("#plan")).toBeVisible();
+}
+
 test("Carte : absente sans voyage, dessinée dès qu'il y en a un", async ({ page }) => {
+  await auPlanDeVol(page);
   await expect(page.locator("#journeyMap")).toBeHidden();
+
+  await page.click("#viewRoutes");
   await page.locator("#rows tr").first().locator(".journey-pick").click();
+  await auPlanDeVol(page);
   await expect(page.locator("#journeyMap")).toBeVisible({ timeout: 8000 });
   await expect(page.locator("#journeyMap .jm-arret")).toHaveCount(2); // un arrêt par étape
   await expect(page.locator("#journeyMap .jm-vaisseau")).toBeVisible();
+
   // Purement décoratif : effacer le voyage retire le panneau.
+  await page.click("#viewRoutes");
   await page.locator("#journeyClear").click();
+  await auPlanDeVol(page);
   await expect(page.locator("#journeyMap")).toBeHidden();
 });
 
 test("Carte : cliquer une escale déplace « je suis ici », comme le fil d'étapes", async ({ page }) => {
   await page.locator("#rows tr").first().locator(".journey-pick").click();
-  await expect(page.locator("#journeyMap .jm-arret")).toHaveCount(2);
+  // Les deux libellés se lisent ICI, tant que le bandeau est à l'écran : `innerText` rend une
+  // chaîne vide sur un élément non rendu, et le fil d'étapes n'est pas peint dans la conclusion.
   const depart = (await page.locator("#journeyCard .jstep").nth(0).innerText()).trim();
+  const arrivee = (await page.locator("#journeyCard .jstep").nth(1).innerText()).trim();
   await expect(page.locator("#journeyCard .jstep.here")).toHaveText(memeStation(depart)); // on part du 1er arrêt
 
+  await auPlanDeVol(page);
+  await expect(page.locator("#journeyMap .jm-arret")).toHaveCount(2);
   const avant = await page.locator("#journeyMap .jm-vaisseau").getAttribute("style");
   await page.locator("#journeyMap .jm-arret").nth(1).locator(".jm-cible").click();
 
-  // Les DEUX chemins mènent à la même commande : le vaisseau bouge et le fil d'étapes suit.
+  // Les DEUX chemins mènent à la même commande : le vaisseau bouge sur la carte…
   await expect(page.locator("#journeyMap .jm-vaisseau")).not.toHaveAttribute("style", avant);
-  const arrivee = (await page.locator("#journeyCard .jstep").nth(1).innerText()).trim();
+  // …et le fil d'étapes du bandeau a suivi, là où il vit.
+  await page.click("#viewRoutes");
   await expect(page.locator("#journeyCard .jstep.here")).toHaveText(memeStation(arrivee));
 });
 
 test("Carte : un saut inter-système dessine deux disques et un corridor", async ({ page }) => {
   await manifesteDepuis(page, "Megumi — Pyro");
   await page.click("#manifestToJourney");
+  await auPlanDeVol(page);
   await expect(page.locator("#journeyMap")).toBeVisible({ timeout: 8000 });
   await expect(page.locator("#journeyMap .jm-saut")).toHaveCount(0); // intra-système : aucun saut
 
+  await page.click("#viewEnroute"); // ajouter un arrêt se fait au bandeau, pas dans la conclusion
   await page.fill("#journeyAddStop", "Stanton Gateway (Pyro) — Pyro");
   await page.click("#journeyAddBtn");
   await page.fill("#journeyAddStop", "Pyro Gateway (Stanton) — Stanton");
   await page.click("#journeyAddBtn");
 
+  await auPlanDeVol(page);
   await expect(page.locator("#journeyMap .jm-saut")).toHaveCount(1);
   await expect(page.locator("#journeyMap .jm-sys")).toHaveCount(2); // Pyro et Stanton côte à côte
   // `allInnerTexts` rend `undefined` sur du <text> SVG : ces nœuds n'ont pas d'innerText.
@@ -1267,13 +1290,14 @@ test("Carte : un saut est routé par les passerelles, et chaque jambe porte son 
   // de là-bas. Ici le parcours ne les mentionne PAS — c'est la carte qui les intercale.
   await manifesteDepuis(page, "Megumi — Pyro");
   await page.click("#manifestToJourney");
-  await expect(page.locator("#journeyMap")).toBeVisible({ timeout: 8000 });
+  await expect(page.locator("#journeyCard .jstep")).toHaveCount(2); // le parcours est posé
   await page.fill("#journeyAddStop", "TDD Area 18 — Stanton");
   await page.click("#journeyAddBtn");
-  await expect(page.locator("#journeyMap .jm-saut")).toHaveCount(1);
-
   // 3 étapes -> 2 jambes, dont une inter-système routée en 3 segments : 4 au total.
   await expect(page.locator("#journeyCard .jstep")).toHaveCount(3);
+
+  await auPlanDeVol(page);
+  await expect(page.locator("#journeyMap .jm-saut")).toHaveCount(1);
   expect(await page.locator("#journeyMap .jm-jambe, #journeyMap .jm-saut").count()).toBe(4);
 
   // Chaque segment intra-système porte un chevron de sens ; le corridor a son nœud ⚡.

--- a/index.html
+++ b/index.html
@@ -39,12 +39,22 @@
 
     <!-- ===================== NAV RAIL ===================== -->
     <nav class="rail">
+      <!-- La marque RAMÈNE À TRAJETS (ADR-004, décision 5) : « retour au début » doit mener à la vue
+           principale, jamais à la conclusion qu'est le Plan de vol. Le bouton est un ENFANT de
+           .brand et non .brand elle-même : #62 y posera son « rejouer le tuto » en FRÈRE, et deux
+           éléments interactifs imbriqués sont invalides en ARIA — c'est la règle que le dépôt vient
+           d'appliquer en sortant .scomm-undo du .editv (#38).
+           Contenu en <span> et non en <div> : le modèle de contenu d'un <button> est du contenu de
+           phrasé, et .brand-name / .brand-sub reprennent leur passage à la ligne en CSS. -->
       <div class="brand">
-        <div class="logo" aria-hidden="true"><span class="logo-diamond"></span></div>
-        <div class="brand-text">
-          <div class="brand-name">HAULR</div>
-          <div class="brand-sub">Flight&nbsp;Ops</div>
-        </div>
+        <button id="brandHome" class="brand-home" type="button"
+                aria-label="HAULR Flight Ops — retour aux Trajets simples" title="Retour aux Trajets simples">
+          <span class="logo" aria-hidden="true"><span class="logo-diamond"></span></span>
+          <span class="brand-text">
+            <span class="brand-name">HAULR</span>
+            <span class="brand-sub">Flight&nbsp;Ops</span>
+          </span>
+        </button>
       </div>
 
       <button class="rail-toggle" id="railToggle" title="Rétracter / déplier le menu" aria-label="Rétracter le menu" aria-expanded="true">«</button>
@@ -63,6 +73,10 @@
         <button id="viewChain" class="vbtn" data-view="chain" aria-label="Chaîne multi-sauts" title="Chaîne multi-sauts (raccourci : 4)"><span class="rn">04</span><span class="rl">Chaîne</span></button>
         <button id="viewCorrections" class="vbtn" data-view="corrections" title="Corrections locales (raccourci : 5)"><span class="rn">05</span><span class="rl">Corrections</span></button>
         <button id="viewCommodities" class="vbtn" data-view="commodities" aria-label="Commodités : tous les points d'achat/vente" title="Commodités : tous les points d'achat/vente (raccourci : 6)"><span class="rn">06</span><span class="rl">Commodités</span></button>
+        <!-- EN DERNIER, et c'est une décision (ADR-004 §7) : une conclusion se lit après ce qui la
+             produit, et la placer en tête renuméroterait des raccourcis déjà appris pour un gain
+             nul. Révisable par #45, qui refond la hiérarchie du rail dans le même jalon. -->
+        <button id="viewPlan" class="vbtn" data-view="plan" aria-label="Plan de vol" title="Plan de vol : le récapitulatif du voyage engagé (raccourci : 7)"><span class="rn">07</span><span class="rl">Plan&nbsp;de&nbsp;vol</span></button>
       </div>
 
       <!-- Le libellé visible « Partager » OUVRE l'aria-label : sinon le nom accessible ne le
@@ -94,7 +108,12 @@
       </header>
 
       <main>
-        <section class="controls">
+        <!-- L'`id` n'est pas décoratif : cette section était la SEULE section de contrôles que
+             switchView ne basculait pas, donc permanente par construction. Le Plan de vol la masque
+             (ADR-004 §6) — on n'y change rien au voyage, et une barre de filtres y laisserait croire
+             qu'agir dessus modifie ce qu'on regarde. Masquer n'est pas désactiver : les valeurs
+             survivent au passage et au retour. -->
+        <section class="controls" id="controls">
           <div class="field ship-field">
             <label for="ship">◈ Vaisseau</label>
             <input id="ship" type="text" placeholder="Tape un nom (ex : Railen)" autocomplete="off" role="combobox" aria-autocomplete="list" aria-expanded="false" aria-controls="shipList" />
@@ -189,15 +208,27 @@
           </div>
 
           <aside id="journeyCard" class="journey-card" hidden></aside>
-
-          <!-- Carte 2D du parcours : TROISIÈME COLONNE, à côté du voyage en cours (ADR-001).
-               Elle vivait en bandeau pleine largeur, où le dessin plafonné à 760 px laissait deux
-               bandes vides sur un grand écran. Purement décorative — absente tant qu'il n'y a pas
-               de voyage, et son échec de chargement ne doit rien casser d'autre. La géométrie
-               vient de data/starmap.json. Sous ~1100 px, `flex-wrap` la renvoie sur sa
-               propre ligne : c'est le repli, et il redonne exactement l'ancien bandeau. -->
-          <aside id="journeyMap" class="journey-map" hidden></aside>
         </div>
+
+        <!-- ===================== PLAN DE VOL (ADR-004) =====================
+             La septième vue, et la seule qui soit une CONCLUSION : on y arrive une fois tout
+             paramétré, pour regarder le résultat. On n'y change rien — d'où les filtres masqués,
+             les réglages repris en texte, et un récapitulatif sans un seul bouton d'action.
+             Le bandeau du haut (#shipJourneyRow) est masqué ICI et seulement ici : il reste dans
+             les six vues de recherche, c'est la décision 3. -->
+        <section id="plan" class="plan-view" hidden>
+          <div class="plan-head" id="planHead"></div>
+
+          <!-- Carte 2D du parcours (ADR-001), qui ne vit plus QUE là (ADR-004, décision 4) : si
+               elle restait partout, la conclusion ne montrerait rien qu'on n'ait déjà sous les yeux.
+               ÉLÉMENT PERSISTANT, frère de #planHead et #planBody et jamais leur enfant :
+               ses écouteurs sont posés en direct et une seule fois (cf. app.js), et la loger dans un
+               conteneur réécrit par innerHTML reproduirait #24 — un geste qui cesse de répondre
+               après un rendu. Purement décorative : son échec de chargement ne casse rien d'autre. -->
+          <aside id="journeyMap" class="journey-map" hidden></aside>
+
+          <div class="plan-body" id="planBody"></div>
+        </section>
 
         <section id="enrouteControls" class="enroute-controls" hidden>
           <div class="field">

--- a/style.css
+++ b/style.css
@@ -109,6 +109,17 @@ a:hover { color: #ffcf6b; text-decoration: underline; }
 .brand-text { line-height: 1.05; }
 .brand-name { font-family: var(--display); font-weight: 800; font-size: 14px; letter-spacing: 2px; color: #fff; }
 .brand-sub { font-size: 8.5px; letter-spacing: 2.5px; color: var(--muted); text-transform: uppercase; }
+/* La marque est un BOUTON depuis l'ADR-004 (§5 : elle ramène aux Trajets). Style natif remis à
+   zéro, et .brand-name / .brand-sub repassent en bloc : le contenu d'un <button> doit être du
+   phrasé, donc des <span>, qui sans ça se colleraient sur une seule ligne. */
+.brand-home {
+  display: flex; align-items: center; gap: 12px; width: 100%;
+  background: none; border: 0; margin: 0; padding: 0;
+  font: inherit; color: inherit; text-align: left; cursor: pointer;
+}
+.brand-name, .brand-sub { display: block; }
+.brand-home:hover .brand-name { color: var(--acc); }
+.rail-collapsed .brand-home { justify-content: center; }
 
 .rail-toggle {
   align-self: flex-end; width: 28px; height: 28px; margin: -6px 0 8px;
@@ -1170,7 +1181,78 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 .comm-points .num { font-family: var(--mono); }
 .comm-detail .muted { color: var(--muted); }
 
+/* ---------- Plan de vol : la vue de conclusion (ADR-004) ---------- */
+/* Deux niveaux : la carte du parcours EN GRAND (c'est ce qui justifie la vue), puis le
+   récapitulatif en deux colonnes sous elle. Rien n'est actionnable ici, sauf la copie. */
+.plan-view { display: flex; flex-direction: column; gap: 14px; }
+.plan-head {
+  padding: 12px 16px; background: var(--panel);
+  border: 1px solid var(--line); border-left: 2px solid var(--acc);
+}
+.plan-title { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.plan-kicker { font-size: 10px; letter-spacing: 2px; text-transform: uppercase; color: var(--acc); font-weight: 700; }
+.plan-copy {
+  background: transparent; border: 1px solid var(--line2); color: var(--muted);
+  font-family: var(--font); font-size: 11px; padding: 4px 10px; cursor: pointer;
+}
+.plan-copy:hover { color: var(--acc); border-color: var(--acc); }
+.plan-copy.copied { color: var(--good); border-color: var(--good); }
+/* La ligne d'hypothèses : une conclusion ÉNONCE ce sur quoi elle repose au lieu de l'offrir à la
+   modification. C'est du texte, pas des contrôles — les changer se fait dans une vue de recherche. */
+.plan-hyp {
+  margin-top: 8px; font-family: var(--mono); font-size: 12px; color: var(--text);
+  letter-spacing: 0.3px;
+}
+/* La carte reprend TOUTE la largeur, contrairement à sa colonne de 460 px d'avant : c'est l'objet
+   qu'on vient voir en grand. Le dessin garde un plafond (un disque étiré ne gagne rien) mais bien
+   plus haut que les 760 px du bandeau. */
+#plan .journey-map { flex: none; width: 100%; min-width: 0; }
+#plan .jm-svg { max-width: 1200px; }
+.plan-grid { display: grid; grid-template-columns: minmax(280px, 1fr) minmax(0, 2fr); gap: 14px; align-items: start; }
+.plan-card { padding: 12px 16px; background: var(--panel); border: 1px solid var(--line); border-left: 2px solid var(--acc-2); }
+.plan-card-head { font-size: 10px; letter-spacing: 2px; text-transform: uppercase; color: var(--acc-2); font-weight: 700; margin-bottom: 10px; }
+.plan-card-meta { margin-top: 10px; padding-top: 9px; border-top: 1px solid var(--line); font-size: 11.5px; color: var(--muted); }
+.plan-card-meta b { font-family: var(--mono); color: var(--text); }
+.plan-muted { margin: 0; font-size: 12px; color: var(--muted); line-height: 1.5; }
+/* Soute : une barre par commodité, rapportée à la capacité. C'est le « vrai visuel » que l'encart
+   latéral du bandeau, large de 240 px, ne pouvait pas porter. */
+.plan-hold-lines { display: flex; flex-direction: column; gap: 7px; }
+/* La JAUGE prend la place disponible, pas le nom : c'est elle qu'on vient lire d'un coup d'œil. */
+.plan-hold-line { display: grid; grid-template-columns: minmax(0, 1fr) minmax(60px, 1.4fr) auto auto; align-items: center; gap: 10px; font-size: 12px; }
+.plan-hold-name { display: flex; align-items: center; gap: 6px; min-width: 0; }
+/* .cicon est en `display: grid`, donc de niveau bloc : sans conteneur flex il passe à la ligne et
+   sépare l'icône de son nom. Même réduction que sur les jambes du bandeau (.jcargo-item). */
+.plan-hold-name .cicon, .plan-cargo-item .cicon { width: 18px; height: 18px; font-size: 10px; }
+.plan-hold-name > span:not(.cicon) { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.plan-hold-bar { display: block; height: 6px; background: rgba(130, 150, 210, 0.14); }
+.plan-hold-bar i { display: block; height: 100%; background: var(--acc); box-shadow: 0 0 8px rgba(255, 176, 32, 0.35); }
+.plan-hold-scu { font-family: var(--mono); font-size: 11px; color: var(--muted); }
+.plan-hold-scu b { color: var(--text); font-size: 12px; }
+.plan-hold-paid { font-family: var(--mono); font-size: 11px; color: var(--muted); }
+/* Le parcours : les mêmes étapes que le bandeau, mais INERTES — aucun bouton, aucun ✕. */
+.plan-path { display: flex; flex-wrap: wrap; align-items: center; gap: 6px 4px; margin-bottom: 12px; }
+.plan-step { padding: 3px 5px; border: 1px solid var(--line); background: rgba(255, 255, 255, 0.03); font-size: 12px; }
+.plan-step.here { border-color: var(--acc); box-shadow: 0 0 0 1px var(--acc), 0 0 10px rgba(255, 176, 32, 0.25); }
+.plan-sep { color: var(--muted); }
+.plan-legs { display: flex; flex-direction: column; gap: 8px; }
+.plan-leg { padding: 8px 10px; border: 1px solid var(--line); border-left: 2px solid var(--line); }
+.plan-leg.current { border-left-color: var(--acc); background: rgba(255, 176, 32, 0.04); }
+.plan-leg.done { opacity: 0.62; }
+.plan-leg-head { display: flex; align-items: center; gap: 9px; font-size: 12px; }
+.plan-leg-n { font-family: var(--mono); font-size: 10px; color: var(--muted); }
+.plan-leg-route { font-weight: 600; }
+.plan-leg-state { font-size: 9.5px; letter-spacing: 1px; text-transform: uppercase; color: var(--muted); }
+.plan-leg-profit { margin-left: auto; font-family: var(--mono); font-size: 12px; }
+.plan-leg-cargo { display: flex; flex-wrap: wrap; gap: 4px 12px; margin-top: 5px; font-size: 11px; color: var(--muted); }
+.plan-cargo-item { display: flex; align-items: center; gap: 6px; }
+.plan-cargo-item b { font-family: var(--mono); color: var(--text); }
+
 /* ---------- Responsive ---------- */
+/* Le récapitulatif passe en une colonne bien avant les tableaux : ses deux cartes ont chacune
+   besoin de largeur (des noms de commodités d'un côté, des noms de terminaux de l'autre). */
+@media (max-width: 1100px) {
+  .plan-grid { grid-template-columns: 1fr; }
+}
 @media (max-width: 820px) {
   .comm-cols { grid-template-columns: 1fr; }
   .rail { position: static; height: auto; width: 100%; flex-direction: row; flex-wrap: wrap; align-items: center; overflow: visible; }


### PR DESCRIPTION
## Ce que ça change

Une **septième vue, « Plan de vol »** (raccourci `7`, en fin de rail) : la **conclusion** du
travail de planification. On y arrive une fois tout paramétré, pour regarder ce qui est engagé — la
**carte du parcours en grand**, la soute commodité par commodité avec sa jauge, la place libre et le
capital engagé, le parcours étape par étape, la jambe en cours et son manifeste, ce qu'il reste à
faire. **On n'y change rien** : pas un bouton d'action, et un `⧉ Copier le récapitulatif` qui en
sort le texte à coller dans un salon.

La **carte du parcours quitte les six autres vues** — c'est ce qui justifie l'existence de la vue —
et la **marque HAULR** devient un bouton qui ramène à Trajets.

## Pourquoi

[ADR-004](docs/superpowers/specs/2026-08-14-plan-de-vol-adr.md), déjà fusionné, tranche les huit
décisions ; cette PR est le second livrable de #61. Les six vues existantes servent toutes à
**chercher** ; il manquait l'endroit où **regarder le résultat**. Ce récapitulatif n'avait pas de
chez-soi : il vivait dans une rangée posée au-dessus du contenu de toutes les vues
(`.ship-journey-row`, hors des sections de vue), jamais assez large pour se déployer, toujours assez
présente pour repousser le tableau vers le bas — et la carte y était comprimée dans une colonne de
460 px (`style.css`, `#journeyMap { flex: 1 1 460px }`).

Quatre décisions d'implémentation méritent d'être dites :

- **Les filtres sont masqués, les réglages repris en texte.** `<section class="controls">` était la
  seule section de contrôles que `switchView` ne basculait pas — permanente par construction. Elle
  reçoit un `id` et rejoint les autres. Mais **masquer les quatre réglages sans rien mettre à la
  place rendrait la conclusion silencieusement ambiguë** : on lirait un profit sans savoir s'il est
  net. D'où la ligne d'hypothèses en clair — « Gatac Railen · soute 640 SCU · budget 1 000 000 aUEC ·
  profits bruts ». Masquer n'est pas désactiver : les valeurs survivent au passage et au retour.
- **Le bandeau est masqué dans cette vue, et là seulement.** Ses cartes sont éditables (le ✕ du
  parcours, la vente en soute) et c'est tout ce que cette vue n'est pas. Il reste **intact dans les
  six vues de recherche** — c'est la décision 3 de l'ADR, et une non-régression testée.
- **La carte reste un frère persistant**, jamais l'enfant d'un conteneur réécrit : ses écouteurs sont
  posés en direct et une seule fois, et la loger dans du HTML réécrit par `innerHTML` reproduirait
  #24. Le geste « changer d'étape » ne se perd pas pour autant — les `.jstep` du bandeau le portent
  toujours, la carte n'en était qu'une **seconde** entrée.
- **La liste blanche de `applyState`** est le piège documenté par l'ADR : sans ajout, la vue s'ouvre
  au clic mais ne revient ni d'un permalien ni du localStorage. Elle a son test.

### Le correctif embarqué (#91)

Le critère « le bouton de capture échoue proprement, jamais en silence » a mis au jour un bug du
point de sortie **partagé** par les quatre boutons de copie (`copierTexte`, `app.js:1195` avant
correctif) : hors contexte sécurisé `navigator.clipboard` est absent, le `?.` rendait `undefined` et
le `.then` qui suivait levait une **TypeError** ; et un refus de permission tombait dans un
`.catch(() => {})` **vide**. Dans les deux cas l'utilisateur repartait en croyant avoir son texte.
Corrigé à la source plutôt qu'en dotant le seul bouton neuf d'un chemin d'erreur à lui.

## Vérification

```
node --test        ℹ tests 455 · ℹ pass 455 · ℹ fail 0
npx playwright test  162 passed · 2 skipped (1.1 min)
```

**17 tests e2e neufs** (`e2e/plan.pw.mjs`), un par critère d'acceptation. Les 15 premiers étaient
**rouges avant** l'implémentation (13 échecs au premier jet, les 2 verts étant les non-régressions
« le bandeau reste dans les six autres vues » et « Trajets reste la vue par défaut », qui devaient
l'être). Les deux tests de #91 ont été **rejoués en rouge** sur le commit précédent
(`git stash push app.js` → `2 failed`), puis verts avec le correctif.

**Quatre tests existants adaptés** (`Carte : …` dans `smoke.pw.mjs`) : ils regardaient la carte depuis
Trajets ou En route, où elle ne vit plus. Ils y passent maintenant par le Plan de vol et **en
reviennent** pour agir sur le parcours — sans rien perdre de ce qu'ils vérifiaient. Un détail les
concernant vaut d'être noté : `innerText` rend une chaîne vide sur un élément non rendu, donc le fil
d'étapes du bandeau se lit **avant** de passer dans la conclusion.

La vue a aussi été **regardée**, pas seulement testée : capture à 1600 px, carte à 1 200 px de large
(contre 760 px de plafond et 460 px de colonne auparavant).

## Ce qui n'est pas couvert

- **La hiérarchie du rail** : le Plan de vol se place **en dernier**, décision volontairement
  révisable par #45 — cette PR ajoute une entrée, elle ne réorganise pas le menu.
- **La capture en image** : l'ADR retient le texte (voie 1). La carte peinte au Canvas 2D (voie 2)
  reste réalisable le jour venu, au prix d'un second moteur de rendu à tenir en phase avec le SVG.
- **#43** (« le vaisseau, le voyage et sa carte éclatés sur trois colonnes ») est **absorbé** par
  cette PR et reste à fermer ; **#42** (ordre des systèmes sur la carte) et **#53** (bouton
  « ✓ chargé ») portent sur des éléments qui viennent de déménager — à traiter ensuite.
- **La disposition sous 1 280 px** suit les mêmes règles que les tableaux (le récapitulatif passe en
  une colonne sous 1 100 px), mais #81 et #86 restent ouverts sur ce terrain.
- **Aucun calcul n'a bougé** : c'est un déménagement d'interface, les chiffres sont les mêmes.

Closes #61
Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)