### PR TITLE
fix(voyage): corriger un stock ne fige plus une jambe qu'on n'a pas chargée

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,15 +381,23 @@ comptoir saturé dont UEX tait la capacité est donc écarté, au lieu de passer
 Une jambe non ajustée suit le marché : corriger un **prix** mesure donc aussitôt ses effets sur les
 bénéfices du parcours, jambe par jambe.
 
-Corriger un **volume** (stock ou demande) est autre chose. Dire « il ne reste que 3 SCU ici », c'est
-le plus souvent constater qu'on vient soi-même de vider la station — le trajet, lui, est déjà
-décidé. Les jambes qui **touchent ce point** (le terminal corrigé est leur départ pour un stock,
-leur arrivée pour une demande, et leur chargement porte cette commodité) **figent donc leurs SCU**
-et prennent le marqueur `🔒`. Elles continuent de suivre les prix ; seules leurs quantités sont
-gelées. Tout ce qui est calculé **ensuite** — les autres jambes, les sept vues, un arrêt ajouté plus
-tard — voit le stock tel que tu l'as corrigé. `↺ optimal` lève le gel.
+Corriger un **volume** (stock ou demande) est autre chose — et **c'est le chargement, pas la
+correction, qui fige** ([addendum à l'ADR-002](docs/superpowers/specs/2026-08-12-soute-et-residus-adr.md#addendum-du-2026-08-15--le-verrou-vient-du-chargement-48)).
+Deux gestes, deux sens :
 
-`🔒` et `✎` se distinguent : le premier vient d'une correction, le second de ta main. Toucher au
+| Le geste | Ce qu'il veut dire | Ce qui arrive à la jambe |
+|---|---|---|
+| Corriger un stock, **rien de chargé** | « le relevé est faux, recalcule » — tu es sur place et tu vois le rayon | elle **recalcule** sur la valeur corrigée : moins de SCU, éventuellement une autre commodité qui prend la place libérée. Aucun `🔒` |
+| **`✓ chargé`** | « c'est payé et à bord » — ce ne sont plus des SCU prévus, ce sont des faits | elle **fige ses SCU** et prend `🔒`. Une correction du stock de départ **postérieure** ne la rétrécit plus |
+
+Une jambe figée continue de suivre les **prix** ; seules ses quantités sont gelées. Tout ce qui est
+calculé **ensuite** — les autres jambes, les sept vues, un arrêt ajouté plus tard — voit le stock tel
+que tu l'as corrigé, déduction du chargement comprise. `↺ optimal` lève le gel.
+
+Conséquence utile : charger la jambe 1 ne fige plus la jambe 3 qui rachètera la même commodité au
+même point sans avoir rien payé — elle voit le **stock déduit**, ce qui est son bon chiffre.
+
+`🔒` et `✎` se distinguent : le premier vient du chargement, le second de ta main. Toucher au
 chargement d'une jambe figée la fait passer de l'un à l'autre.
 
 ## Corrections locales

--- a/app.js
+++ b/app.js
@@ -1458,8 +1458,7 @@ function chargerJambe(i) {
     const lignes = legEffectiveLines(leg, i, readFilters());
     if (!lignes.length) return;
     const lots = loadHold([], lignes, leg.from, nowSec()).map((l) => ({ ...l, leg: k }));
-    // Charger, c'est vider le rayon d'autant. On fige d'abord les jambes qui achetaient ce point
-    // (même règle qu'une correction de volume saisie à la main), puis on écrit la déduction.
+    // Charger, c'est vider le rayon d'autant.
     const prises = [];
     for (const l of lots) {
       const p = pointAchat(l.name, l.from);
@@ -1468,9 +1467,19 @@ function chargerJambe(i) {
       // effectif ici, ce serait relire notre propre déduction et la compter une seconde fois.
       const s = soldeDuPoint(CHARGEMENTS, l.name, l.from);
       prises.push({ name: l.name, terminal: l.from, ref: s.ref != null ? s.ref : p.stock, units: l.units });
-      pinLegsForVolume(l.name, l.from, "buy");
     }
+    // LE REGISTRE D'ABORD, le gel ensuite (#48). C'est le registre qui porte « chargée », et c'est
+    // lui que consulte désormais pinLegsForVolume : figer avant de l'écrire laissait hors du verrou
+    // la jambe qu'on vient précisément de charger — celle dont les SCU sont pourtant les plus sûrs.
     CHARGEMENTS = poserChargement(CHARGEMENTS, k, prises);
+    // Cette jambe fige ses SCU : le fret est payé et à bord, c'est un FAIT et plus un plan. On la
+    // fige EXPLICITEMENT, et pas seulement par ricochet d'une déduction : un chargement dont aucune
+    // commodité n'a de stock publié n'entre dans aucune `prise`, et n'était donc jamais figé.
+    if (figerJambe(i, lignes)) { saveJourneyEdits(); saveJourneyPins(); }
+    // Les AUTRES jambes déjà chargées qui achètent le même fret au même rayon : la déduction qu'on
+    // vient d'écrire ne doit pas les rétrécir non plus. Celles qui ne sont PAS chargées, si — c'est
+    // le stock déduit qui est leur bon chiffre.
+    for (const pr of prises) pinLegsForVolume(pr.name, pr.terminal, "buy");
     const vides = [];
     for (const pr of prises) {
       const s = ecrireStockDuPoint(pr);
@@ -2075,17 +2084,29 @@ function legIntent(leg, i, f) {
 // Fige les jambes qu'une correction de volume rebattrait, AVANT qu'elle soit appliquée : on capture
 // donc les quantités telles qu'elles sont encore. La sélection est pure (legsToPin) ; ici on ne
 // fournit que ce que logic.mjs ne peut pas connaître — les chargements effectifs du moment.
+// Fige les SCU d'une jambe : son chargement devient une INTENTION persistée, et le 🔒 dit que ce
+// n'est pas la main de l'utilisateur qui l'a voulu. Rend `true` si quelque chose a bougé.
+// Une jambe déjà ajustée (✎) ou déjà figée n'est pas retouchée : ses quantités ne bougeaient plus,
+// et l'écraser effacerait un ajustement fait à la main.
+function figerJambe(i, lignes) {
+  const k = legKey(JOURNEY.legs[i], i);
+  if (JOURNEY_EDITS[k]) return false;
+  JOURNEY_EDITS[k] = manifestIntent(lignes || []);
+  JOURNEY_PINS[k] = true;
+  return true;
+}
+
+// Le gel consulte désormais l'état « chargée » de chaque jambe (#48) : une jambe qu'on n'a pas
+// payée n'est plus figée par une correction de volume, elle RECALCULE. Voir legsToPin (logic.mjs)
+// pour le pourquoi du renversement.
 function pinLegsForVolume(commodity, terminal, side) {
   if (!JOURNEY || !JOURNEY.legs.length || !MARKET) return;
   const f = readFilters();
   const lignes = JOURNEY.legs.map((leg, i) => legEffectiveLines(leg, i, f));
+  const chargees = JOURNEY.legs.map((leg, i) => jambeChargee(leg, i));
   let change = false;
-  for (const i of legsToPin(JOURNEY.legs, lignes, commodity, terminal, side)) {
-    const k = legKey(JOURNEY.legs[i], i);
-    if (JOURNEY_EDITS[k]) continue; // déjà ajustée ou figée : ses quantités ne bougeaient déjà plus
-    JOURNEY_EDITS[k] = manifestIntent(lignes[i]);
-    JOURNEY_PINS[k] = true;
-    change = true;
+  for (const i of legsToPin(JOURNEY.legs, lignes, commodity, terminal, side, chargees)) {
+    if (figerJambe(i, lignes[i])) change = true;
   }
   if (change) { saveJourneyEdits(); saveJourneyPins(); }
 }

--- a/docs/superpowers/specs/2026-08-12-soute-et-residus-adr.md
+++ b/docs/superpowers/specs/2026-08-12-soute-et-residus-adr.md
@@ -439,3 +439,71 @@ Aucune ne bloque l'étape 1.
    dort du fret oublié serait cohérent avec ADR-001, mais c'est un second chantier.
 2. **Le profit d'un voyage doit-il compter le fret déposé ?** Il n'est ni vendu ni perdu : le
    compter en profit serait faux, l'ignorer masquerait un capital immobilisé.
+
+---
+
+## Addendum du 2026-08-15 — le verrou vient du CHARGEMENT (#48)
+
+**Statut :** Accepté · **Issue :** #48 · **Jalon :** v1.1.0
+
+Cet addendum **renverse** une règle posée plus haut. Elle était assumée et documentée
+(`README.md`, « Ce qu'une correction fait au voyage ») ; elle est devenue fausse.
+
+### Ce que disait la règle
+
+> Corriger un volume, c'est le plus souvent constater qu'on vient soi-même de vider la station.
+
+Toute correction de stock ou de demande figeait donc les SCU des jambes touchant ce point, avec le
+marqueur `🔒`.
+
+### Pourquoi elle ne tient plus
+
+Ce raccourci datait d'avant `✓ chargé`. **C'est le chargement qui déduit le stock maintenant** — la
+correction à la main ne le fait plus. Les deux gestes ont donc cessé de vouloir dire la même chose :
+
+| Le geste | Ce qu'il dit | Ce qu'il doit faire |
+|---|---|---|
+| Corriger un volume sans avoir chargé | « le relevé est faux, recalcule » | **recalculer** |
+| `✓ chargé` | « c'est payé et à bord » | **figer** |
+
+Le symptôme, lui, était franc : on arrive à A, le rayon n'a pas ce qu'UEX annonce, on corrige le
+chiffre sur place — et la jambe **gèle ses SCU sur la valeur qu'on vient soi-même de démentir**.
+Elle continuait d'annoncer « Copper 59 SCU » devant un rayon qui en avait 12. Le voyage faisait
+planifier sur un chiffre faux, et le gel était **persisté** : il survivait au rechargement. Pour en
+sortir, il fallait déplier la jambe et cliquer `↺ optimal`, qui efface *tout*, y compris un
+ajustement fait à la main plus tôt.
+
+### La décision
+
+**Le gel est conditionné à l'état « chargée » de la jambe.** `legsToPin` (`logic.mjs`) reçoit un
+argument de plus, `chargees`, et ne rend plus l'index d'une jambe non chargée.
+
+Trois conséquences qui ne se devinent pas :
+
+1. **Le registre avant le gel.** `chargerJambe` inscrivait le chargement **après** avoir figé.
+   Le garde tout juste posé aurait donc laissé non figée la jambe qu'on vient précisément de
+   charger — la seule dont les SCU sont pourtant certains. L'ordre est inversé : `poserChargement`
+   d'abord, gel ensuite.
+2. **Le gel de la jambe chargée est explicite.** Il ne passait que par ricochet d'une déduction de
+   stock : une jambe dont aucune commodité n'a de stock publié par UEX n'entrait dans aucune prise,
+   et n'était donc jamais figée. `figerJambe(i, lignes)` est désormais appelé directement.
+3. **Défaut sûr.** `chargees` vaut `[]` par défaut : un appelant qui l'oublierait ne fige **rien**
+   plutôt que de retomber en silence sur l'ancienne règle. Ne pas figer se rattrape au rendu
+   suivant ; figer à tort ne se défait qu'à la main, en emportant les ajustements légitimes.
+
+Le garde vit à **un seul endroit** (`pinLegsForVolume`), donc les quatre portes vers le gel —
+saisie d'une valeur, retour à la valeur UEX (`.scomm-undo`), effacement par station (`#stnClear`),
+suppression d'une correction (`.corr-del`) — le franchissent toutes.
+
+### Ce que ça ne change pas
+
+- Un **prix** corrigé n'a jamais rien figé, et ne fige toujours rien.
+- Un ajustement à la main (`✎`) reste intouchable, et `↺ optimal` lève toujours les deux formes.
+- Une jambe **déjà chargée** reste figée quand on corrige ensuite le stock de son départ.
+
+### Ce que ça ne traite pas
+
+- **#22** (annuler un chargement écrase la déduction d'une autre jambe au même point) : même
+  voisinage, autre défaut — l'instantané absolu `l.avant` réécrit par `setOverride`.
+- **#21** (soute vidée autrement que par « annuler ») : ce correctif rend `jambeChargee` **porteur**
+  de la règle de gel. Si l'état « chargée » peut se désynchroniser, le verrou se désynchronise avec.

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -1516,30 +1516,81 @@ test("Corrections : un PRIX corrigé met à jour les bénéfices du voyage en co
   await expect(page.locator("#journeyCard .jleg-pinned")).toHaveCount(0); // et ne fige rien
 });
 
-test("Corrections : un STOCK corrigé fige la jambe engagée, mais pas les trajets suivants", async ({ page }) => {
+// SCU annoncés pour une commodité dans le chargement de la première jambe, ou null si absente.
+async function scuDeLaJambe(page, nom) {
+  const item = page.locator("#journeyCard .jcargo-item", { hasText: nom }).first();
+  if (!(await item.count())) return null;
+  const txt = (await item.innerText()).replace(/[  \s]/g, "");
+  const m = txt.match(/(\d+)SCU/);
+  return m ? Number(m[1]) : null;
+}
+
+// Ce test portait EXACTEMENT la règle inverse jusqu'à #48 (« un STOCK corrigé fige la jambe
+// engagée »). Il est réécrit, pas supprimé : le renversement est une décision de conception, et
+// c'est ici qu'elle se vérifie. Voir l'addendum à l'ADR-002.
+test("Corrections : un STOCK corrigé sur une jambe NON chargée la fait RECALCULER (#48)", async ({ page }) => {
   await manifesteDepuis(page, "Megumi — Pyro");
   await page.click("#manifestToJourney");
   await expect(page.locator("#journeyCard .jleg")).toHaveCount(1);
-  const cargo = (await page.locator("#journeyCard .jleg-cargo").first().innerText()).trim();
-  const nom = await page.locator("#manifest .mline-del").first().getAttribute("data-name");
+  const nom = await page.locator("#manifest .editv[data-f='vol'][data-s='buy']").first().getAttribute("data-c");
+  // Sans ça le test ne mordrait pas : on doit corriger le stock d'une commodité que la jambe porte.
+  const avant = await scuDeLaJambe(page, nom);
+  expect(avant, `la jambe ne charge pas ${nom} — le test ne prouverait rien`).not.toBeNull();
+  expect(avant).toBeGreaterThan(3);
 
-  await corrige(page, "vol", "buy", 3); // « j'ai vidé la station en chargeant »
-  // Le trajet est décidé : ses SCU ne rétrécissent pas sous les pieds du joueur.
-  await expect(page.locator("#journeyCard .jleg-pinned")).toHaveCount(1);
-  expect((await page.locator("#journeyCard .jleg-cargo").first().innerText()).trim()).toBe(cargo);
-  expect(await page.evaluate(() => localStorage.getItem("best-hauling-journey-pins"))).toContain("true");
+  await corrige(page, "vol", "buy", 3); // « le relevé est faux : il n'en reste que 3 »
 
-  // ...mais un chargement calculé APRÈS coup, lui, ne voit plus que ce qui reste.
-  await page.fill("#origin", "Megumi — Pyro");
-  await expect(page.locator("#manifest .mqty-input").first()).toBeVisible();
-  const ligne = page.locator("#manifest .mline", { hasText: nom }).first();
-  if (await ligne.count()) await expect(ligne.locator(".mqty-input")).toHaveValue(/^[0-3]$/);
-
-  // « ↺ optimal » lève le gel : la jambe redevient branchée sur le marché.
-  await page.locator("#journeyCard .jleg-head").first().click();
-  await page.locator("#journeyCard .jman-reset").click();
+  // Le renversement : rien n'est figé, et la jambe se rebat sur la valeur corrigée. Avant #48 elle
+  // prenait 🔒 et continuait d'annoncer l'ancienne quantité — un chiffre qu'on venait de démentir.
   await expect(page.locator("#journeyCard .jleg-pinned")).toHaveCount(0);
-  expect((await page.locator("#journeyCard .jleg-cargo").first().innerText()).trim()).not.toBe(cargo);
+  expect(await page.evaluate(() => localStorage.getItem("best-hauling-journey-pins") || "{}")).not.toContain("true");
+  const apres = await scuDeLaJambe(page, nom);
+  expect(apres == null || apres <= 3, `la jambe annonce encore ${apres} SCU de ${nom}`).toBe(true);
+});
+
+test("Voyage : « ✓ chargé » fige la jambe TOUT DE SUITE, et la protège des corrections suivantes (#48)", async ({ page }) => {
+  await jambeChargeable(page);
+  await expect(page.locator("#journeyCard .jleg-pinned")).toHaveCount(0); // rien n'est payé, rien n'est figé
+  // Le nom se lit AVANT le chargement : charger vide le rayon, et le manifeste « En route » n'a
+  // alors plus rien à proposer depuis ce terminal — c'est justement l'effet qu'on va vérifier.
+  const nom = await page.locator("#manifest .editv[data-f='vol'][data-s='buy']").first().getAttribute("data-c");
+
+  await page.locator("#journeyCard .jleg-load").first().click();
+  // Le piège d'ordre : le registre des chargements doit être écrit AVANT le gel. Écrit après, la
+  // jambe qu'on vient de charger n'était pas vue comme chargée, et restait la seule à ne pas se figer.
+  await expect(page.locator("#journeyCard .jleg-pinned")).toHaveCount(1);
+  const avant = await scuDeLaJambe(page, nom);
+  expect(avant, `la jambe ne charge pas ${nom} — le test ne prouverait rien`).not.toBeNull();
+
+  // Le fret est payé et à bord : une correction POSTÉRIEURE du stock de départ ne le rétrécit plus.
+  await ouvreStation(page, "Megumi");
+  const cible = page.locator(`#correctionsStation .editv[data-s="buy"][data-f="vol"][data-c="${nom}"]`).first();
+  await expect(cible).toBeVisible({ timeout: 8000 });
+  await cible.click();
+  const champ = page.locator("#correctionsStation input.editv-input").first();
+  await champ.fill("1");
+  await champ.press("Enter");
+
+  await page.click("#viewEnroute");
+  expect(await scuDeLaJambe(page, nom)).toBe(avant);
+});
+
+test("Corrections : le retour à la valeur UEX ne fige pas davantage une jambe non chargée (#48)", async ({ page }) => {
+  // La troisième des quatre portes vers le gel (`.scomm-undo`) : le garde vit dans un seul endroit,
+  // ce test le vérifie de l'autre bout.
+  await manifesteDepuis(page, "Megumi — Pyro");
+  await page.click("#manifestToJourney");
+  await expect(page.locator("#journeyCard .jleg")).toHaveCount(1);
+  await corrige(page, "vol", "buy", 3);
+  await expect(page.locator("#journeyCard .jleg-pinned")).toHaveCount(0);
+
+  await ouvreStation(page, "Megumi");
+  const undo = page.locator("#correctionsStation .scomm-undo").first();
+  await expect(undo).toBeVisible({ timeout: 8000 });
+  await undo.click();
+
+  await page.click("#viewEnroute");
+  await expect(page.locator("#journeyCard .jleg-pinned")).toHaveCount(0);
 });
 
 test("Compagnon de voyage : retirer l'arrivée d'un parcours à DEUX arrêts garde le départ", async ({ page }) => {

--- a/logic.mjs
+++ b/logic.mjs
@@ -1498,19 +1498,31 @@ export function manifestJourneyState(journey, origin, dest) {
   return { etat: "conflit", fin: fin ? fin.name : null };
 }
 
-// Jambes qu'une correction de VOLUME (stock ou demande) rebattrait, et qu'il faut donc figer avant
-// de l'appliquer. Corriger un stock, c'est dire « j'ai vidé ce terminal » — le plus souvent parce
-// qu'on vient d'y charger. Le trajet, lui, est décidé : ses SCU ne doivent pas rétrécir sous les
-// pieds du joueur. Les jambes SUIVANTES, elles, doivent bien voir ce qu'il reste.
-// Une jambe n'est concernée que si elle touche vraiment ce point : le terminal corrigé est son
-// départ (correction d'un stock d'ACHAT) ou son arrivée (correction d'une demande de VENTE), et
-// son chargement porte cette commodité. Les autres n'en dépendent pas — les figer les marquerait
-// pour rien. Un prix, lui, ne rebat aucune quantité : il ne fige rien.
-// `lignesPar[i]` = chargement effectif de la jambe i (l'appelant le connaît, pas nous).
-export function legsToPin(legs, lignesPar, commodity, terminal, side) {
+// Jambes dont les SCU doivent être FIGÉS quand un volume (stock ou demande) change à un terminal.
+//
+// Le verrou vient du CHARGEMENT, pas de la correction (#48, ADR-002 addendum). Deux gestes, deux
+// sens, qu'il ne faut pas confondre :
+//   - « ✓ chargé » dit « c'est payé et à bord » : les SCU de cette jambe sont un FAIT, plus un plan.
+//     Rien ne doit plus les rétrécir, et surtout pas la déduction de stock que ce chargement vient
+//     lui-même de provoquer.
+//   - corriger un stock à la main dit « le relevé est faux, recalcule » : la jambe reste branchée
+//     sur le marché et se rebat sur la valeur corrigée. C'est le geste de qui est SUR PLACE et voit
+//     le rayon. Le figer sur un chiffre qu'on vient soi-même de démentir n'aurait aucun sens.
+// L'ancienne règle assimilait les deux — « corriger un volume, c'est constater qu'on vient de vider
+// la station ». Ce raccourci ne tient plus depuis que `✓ chargé` existe : c'est LUI qui déduit.
+//
+// Une jambe n'est de toute façon concernée que si elle touche vraiment ce point : le terminal est
+// son départ (stock d'ACHAT) ou son arrivée (demande de VENTE), et son chargement porte cette
+// commodité. Un prix, lui, ne rebat aucune quantité : il ne fige rien.
+// `lignesPar[i]` = chargement effectif de la jambe i ; `chargees[i]` = son état « payée et à bord ».
+// Les deux sont connus de l'appelant, pas d'ici.
+// `chargees` par défaut vide : un appelant qui l'oublierait ne fige RIEN plutôt que de retomber en
+// silence sur l'ancienne règle. Ne pas figer se rattrape tout seul au rendu suivant ; figer à tort
+// ne se défait qu'à la main, par un « ↺ optimal » qui emporte aussi les ajustements légitimes.
+export function legsToPin(legs, lignesPar, commodity, terminal, side, chargees = []) {
   const bouts = legs.map((l) => (side === "buy" ? l.from : l.to));
   return legs.map((_, i) => i).filter((i) =>
-    bouts[i] === terminal && (lignesPar[i] || []).some((l) => l.name === commodity)
+    chargees[i] && bouts[i] === terminal && (lignesPar[i] || []).some((l) => l.name === commodity)
   );
 }
 

--- a/logic.test.mjs
+++ b/logic.test.mjs
@@ -2666,31 +2666,66 @@ const CHARGEMENTS = [
 // `jambe` est défini plus bas dans le fichier : on ne l'appelle donc pas à l'évaluation du module.
 const jambeDe = (from, to) => ({ from, fromSystem: "S", to, toSystem: "S", commodity: "X", buyPrice: 1, sellPrice: 2, margin: 1 });
 const PARCOURS = [jambeDe("Megumi", "Rat's Nest"), jambeDe("Rat's Nest", "Checkmate")];
+// L'état « chargée » de chaque jambe. C'est LUI qui décide du gel depuis #48 : le verrou vient du
+// chargement (« c'est payé et à bord »), plus de la correction (« le relevé est faux, recalcule »).
+const TOUTES_CHARGEES = [true, true];
 
 test("legsToPin : seule la jambe qui ACHÈTE ce point est figée", () => {
   // Stock du Copper corrigé à Megumi : la jambe 0 en charge, elle garde ses SCU. La jambe 1 part
   // d'ailleurs et n'en dépend pas — la figer la marquerait pour rien.
-  assert.deepEqual(legsToPin(PARCOURS, CHARGEMENTS, "Copper", "Megumi", "buy"), [0]);
-  assert.deepEqual(legsToPin(PARCOURS, CHARGEMENTS, "Titanium", "Rat's Nest", "buy"), [1]);
+  assert.deepEqual(legsToPin(PARCOURS, CHARGEMENTS, "Copper", "Megumi", "buy", TOUTES_CHARGEES), [0]);
+  assert.deepEqual(legsToPin(PARCOURS, CHARGEMENTS, "Titanium", "Rat's Nest", "buy", TOUTES_CHARGEES), [1]);
 });
 
 test("legsToPin : une demande corrigée regarde l'ARRIVÉE, pas le départ", () => {
-  assert.deepEqual(legsToPin(PARCOURS, CHARGEMENTS, "Copper", "Rat's Nest", "sell"), [0]);
-  assert.deepEqual(legsToPin(PARCOURS, CHARGEMENTS, "Copper", "Megumi", "sell"), []); // Megumi n'est l'arrivée de personne
+  assert.deepEqual(legsToPin(PARCOURS, CHARGEMENTS, "Copper", "Rat's Nest", "sell", TOUTES_CHARGEES), [0]);
+  assert.deepEqual(legsToPin(PARCOURS, CHARGEMENTS, "Copper", "Megumi", "sell", TOUTES_CHARGEES), []); // Megumi n'est l'arrivée de personne
 });
 
 test("legsToPin : ni le mauvais terminal ni la mauvaise commodité ne figent quoi que ce soit", () => {
-  assert.deepEqual(legsToPin(PARCOURS, CHARGEMENTS, "Copper", "Checkmate", "buy"), []);  // bon fret, mauvais bout
-  assert.deepEqual(legsToPin(PARCOURS, CHARGEMENTS, "Gold", "Megumi", "buy"), []);        // bon bout, fret absent
-  assert.deepEqual(legsToPin(PARCOURS, [[], []], "Copper", "Megumi", "buy"), []);         // chargements vides
-  assert.deepEqual(legsToPin([], [], "Copper", "Megumi", "buy"), []);                     // aucun voyage
+  assert.deepEqual(legsToPin(PARCOURS, CHARGEMENTS, "Copper", "Checkmate", "buy", TOUTES_CHARGEES), []);  // bon fret, mauvais bout
+  assert.deepEqual(legsToPin(PARCOURS, CHARGEMENTS, "Gold", "Megumi", "buy", TOUTES_CHARGEES), []);        // bon bout, fret absent
+  assert.deepEqual(legsToPin(PARCOURS, [[], []], "Copper", "Megumi", "buy", TOUTES_CHARGEES), []);         // chargements vides
+  assert.deepEqual(legsToPin([], [], "Copper", "Megumi", "buy", []), []);                                  // aucun voyage
 });
 
-test("legsToPin : un même terminal réutilisé plus loin fige TOUTES les jambes concernées", () => {
-  // Le joueur repasse par Megumi : les deux jambes qui y chargent du Copper sont déjà décidées.
+test("legsToPin : un même terminal réutilisé plus loin fige toutes les jambes CHARGÉES", () => {
+  // Le joueur repasse par Megumi : les deux jambes qui y chargent du Copper sont déjà payées.
   const boucle = [jambeDe("Megumi", "Rat's Nest"), jambeDe("Rat's Nest", "Megumi"), jambeDe("Megumi", "Checkmate")];
   const charges = [[{ name: "Copper", units: 59 }], [{ name: "Titanium", units: 96 }], [{ name: "Copper", units: 12 }]];
-  assert.deepEqual(legsToPin(boucle, charges, "Copper", "Megumi", "buy"), [0, 2]);
+  assert.deepEqual(legsToPin(boucle, charges, "Copper", "Megumi", "buy", [true, true, true]), [0, 2]);
+});
+
+// ---------- #48 : le verrou vient du CHARGEMENT, plus de la correction ----------
+
+test("legsToPin : une jambe NON chargée n'est plus figée — elle doit recalculer", () => {
+  // LE renversement. Corriger un stock sans avoir rien chargé, c'est dire « le relevé est faux »,
+  // pas « je viens de vider le rayon » : la jambe reste branchée sur le marché et se recalcule.
+  // Avant #48, elle prenait 🔒 et continuait d'annoncer 59 SCU pendant que le rayon en avait 12.
+  assert.deepEqual(legsToPin(PARCOURS, CHARGEMENTS, "Copper", "Megumi", "buy", [false, false]), []);
+  assert.deepEqual(legsToPin(PARCOURS, CHARGEMENTS, "Copper", "Rat's Nest", "sell", [false, false]), []);
+});
+
+test("legsToPin : une jambe CHARGÉE reste figée, à l'achat comme à la demande", () => {
+  // Le cas 2, celui qui ne doit pas régresser : le fret est payé et à bord, une correction de
+  // stock postérieure ne doit plus le rétrécir.
+  assert.deepEqual(legsToPin(PARCOURS, CHARGEMENTS, "Copper", "Megumi", "buy", [true, false]), [0]);
+  assert.deepEqual(legsToPin(PARCOURS, CHARGEMENTS, "Copper", "Rat's Nest", "sell", [true, false]), [0]);
+  assert.deepEqual(legsToPin(PARCOURS, CHARGEMENTS, "Titanium", "Rat's Nest", "buy", [false, true]), [1]);
+});
+
+test("legsToPin : un terminal réutilisé ne fige QUE la jambe chargée, pas sa jumelle", () => {
+  // Charger la jambe 0 à Megumi ne doit plus figer la jambe 2, qui y rachètera du Copper sans
+  // avoir rien payé : elle doit voir le stock DÉDUIT, ce qui est le bon chiffre.
+  const boucle = [jambeDe("Megumi", "Rat's Nest"), jambeDe("Rat's Nest", "Megumi"), jambeDe("Megumi", "Checkmate")];
+  const charges = [[{ name: "Copper", units: 59 }], [{ name: "Titanium", units: 96 }], [{ name: "Copper", units: 12 }]];
+  assert.deepEqual(legsToPin(boucle, charges, "Copper", "Megumi", "buy", [true, false, false]), [0]);
+});
+
+test("legsToPin : sans état de chargement, rien n'est figé — le défaut va dans le sens sûr", () => {
+  // Un appelant qui oublierait l'argument ne doit pas retomber dans l'ancienne règle en silence.
+  // Ne rien figer est récupérable (le manifeste se recalcule) ; figer à tort ne l'est qu'à la main.
+  assert.deepEqual(legsToPin(PARCOURS, CHARGEMENTS, "Copper", "Megumi", "buy"), []);
 });
 
 test("manifestIntent : ne persiste QUE le nom et les SCU, dans l'ordre", () => {


### PR DESCRIPTION
## Ce que ça change

Tu arrives à une station, le rayon n'a pas ce qu'UEX annonce, tu corriges le chiffre sur place :
la jambe **recalcule** maintenant son chargement sur la valeur corrigée, au lieu de geler ses SCU
sur celle que tu viens de démentir.

Le verrou vient désormais du **chargement**. Deux gestes, deux sens :

| Le geste | Ce qu'il dit | Ce qui arrive à la jambe |
|---|---|---|
| Corriger un stock, rien de chargé | « le relevé est faux, recalcule » | elle **recalcule**, aucun `🔒` |
| `✓ chargé` | « c'est payé et à bord » | elle **fige**, et une correction postérieure ne la rétrécit plus |

## Pourquoi

Le symptôme était franc : la jambe continuait d'annoncer « Copper 59 SCU » devant un rayon qui en
avait 12, et le gel était **persisté** — il survivait au rechargement. Pour en sortir il fallait
déplier la jambe et cliquer `↺ optimal`, qui efface *tout*, y compris un ajustement fait à la main
plus tôt.

**Cause racine : `logic.mjs`, `legsToPin`** — la sélection pure ne recevait pas l'état « chargée »
des jambes, le paramètre n'existait pas. Elle figeait donc sur le seul critère « cette jambe touche
ce terminal et porte cette commodité ».

La règle qu'elle appliquait était assumée et documentée (« corriger un volume, c'est le plus souvent
constater qu'on vient soi-même de vider la station »). Elle datait d'**avant `✓ chargé`** : c'est
lui qui déduit le stock aujourd'hui, plus la correction à la main. Les deux gestes ont cessé de
vouloir dire la même chose.

### Deux pièges du même endroit, traités avec

1. **L'ordre dans `chargerJambe`** : le chargement était inscrit au registre **après** le gel. Le
   garde tout juste posé aurait donc laissé non figée la jambe qu'on vient précisément de charger —
   la seule dont les SCU sont pourtant certains. Vérifié en isolant l'effet : avec le garde et
   l'ancien ordre, `.jleg-pinned` tombe à 0 au lieu de 1.
2. **Le trou du stock inconnu** : le gel de la jambe chargée ne passait que par ricochet d'une
   déduction. Une jambe dont aucune commodité n'a de stock publié par UEX n'entrait dans aucune
   prise, et n'était donc jamais figée. `figerJambe` est maintenant appelé directement.

Le garde vit à **un seul endroit** (`pinLegsForVolume`), donc les quatre portes vers le gel — saisie,
`.scomm-undo`, `#stnClear`, `.corr-del` — le franchissent toutes. Une des trois portes annexes est
couverte en e2e.

`chargees` vaut `[]` par défaut : un appelant qui l'oublierait ne fige **rien** plutôt que de
retomber en silence sur l'ancienne règle. Ne pas figer se rattrape au rendu suivant ; figer à tort
ne se défait qu'à la main.

## Vérification

```
node --test           ℹ tests 459 · ℹ pass 459 · ℹ fail 0   (455 avant : 4 tests neufs)
npx playwright test   164 passed · 2 skipped (1,1 min)
```

**Le rouge a été rejoué avant chaque correctif :**

- unitaires — 3 échecs sur les tests neufs de `legsToPin` avant le changement de signature ;
- e2e — `git stash push app.js logic.mjs` puis relance : **2 des 3 tests `#48` tombent**. Le
  troisième (« `✓ chargé` fige la jambe TOUT DE SUITE ») passait déjà, et c'est normal : sous
  l'ancienne règle, charger figeait la jambe **par ricochet**. Il garde le piège d'ordre — remis
  seul, il fait tomber ce test.

Le test `Corrections : un STOCK corrigé fige la jambe engagée…` affirmait **exactement la règle
retirée**. Il est **réécrit, pas supprimé** : le renversement est une décision de conception, et
c'est là qu'elle se vérifie.

## Ce qui n'est pas couvert

- **#22** (annuler un chargement écrase la déduction d'une autre jambe au même point) : même
  voisinage (`chargerJambe`, `pinLegsForVolume`), autre défaut — l'instantané absolu `l.avant`
  réécrit par `setOverride`.
- **#21** (soute vidée autrement que par « annuler ») : ce correctif rend `jambeChargee` **porteur**
  de la règle de gel. Si l'état « chargée » peut se désynchroniser, le verrou se désynchronise avec.
- Les corrections de **prix**, qui n'ont jamais rien figé et ne figent toujours rien.
- Les lots **détachés** (fret à bord sans étiquette de jambe) : ils ne rattachent aucune jambe.

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)