### PR TITLE
feat(soute): la tournée d'écoulement — vider la soute en un minimum d'arrêts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ reconstruites/redéployées **quand UEX a réellement changé** — et le site e
 
 ## Fonctionnalités
 
-Sept vues, un même moteur de calcul (soute SCU + budget aUEC → unités, coût, profit/voyage, profit/heure) :
+Huit vues, un même moteur de calcul (soute SCU + budget aUEC → unités, coût, profit/voyage, profit/heure) :
 
 | Vue | Ce qu'elle fait |
 |-----|-----------------|
@@ -34,6 +34,7 @@ Sept vues, un même moteur de calcul (soute SCU + budget aUEC → unités, coût
 | **Corrections ✎** | Ses corrections locales **rangées par station** (bande de vignettes), et de quoi en créer via un sélecteur groupé `système › zone › station` (voir plus bas) |
 | **Commodités 📊** | *Big board* type « salle des marchés », en deux modes. **◈ Marché** : toutes les commodités échangeables avec leur **code officiel UEX** (AGRI, QUAN…), triables (marge / code / catégorie), et au clic **tous leurs points d'achat et de vente** — pratique pour trouver **où écouler** une commodité quand une station n'a plus de demande. **💰 Butin** : le board bascule sur le **prix de revente au SCU** et fait entrer les commodités qu'on **ne peut pas acheter** (minerais raffinés, salvage, drogues de wreck) — la réponse à « j'ai trouvé ça, ça vaut combien et où je l'écoule ? » |
 | **Plan de vol 🗺️** | La **conclusion** : une fois tout paramétré, le récapitulatif de ce qui est engagé — la **carte du parcours en grand** (elle ne vit plus que là), la soute commodité par commodité avec la place libre et le capital engagé, le parcours étape par étape, la jambe en cours et son manifeste, ce qu'il reste à faire. **On n'y change rien** : la barre de filtres y est masquée, et les quatre réglages qui donnent leur sens aux chiffres (vaisseau, soute, budget, frais d'autoload) y sont **repris en texte, en lecture seule** — une conclusion énonce ses hypothèses au lieu de les offrir à la modification. Un bouton **⧉ Copier le récapitulatif** en sort le texte, à coller dans un salon ([ADR-004](docs/superpowers/specs/2026-08-14-plan-de-vol-adr.md)) |
+| **Tournée 📦** | **Vider la soute en un minimum d'arrêts**, l'argent n'arbitrant qu'à nombre d'arrêts égal — un comptoir qui reprend trois commodités à prix moyen bat un comptoir qui n'en reprend qu'une au meilleur prix. C'est l'**inverse** de « où écouler », qui classe par ce que ça rapporte : les deux questions sont différentes, et celle-ci répond à « je ne veux plus porter ça » (le cas d'une sortie butin). La tournée est un **plancher** — un point de vente sur six seulement publie sa capacité — et se recalcule après chaque arrêt réel. La meilleure tournée **à un arrêt de plus** s'affiche à côté, avec son écart chiffré : l'app ne sait pas si tu as le temps ([ADR-007](docs/superpowers/specs/2026-08-15-tournee-ecoulement-adr.md)) |
 
 Autres éléments :
 
@@ -57,7 +58,7 @@ signe et **en rouge**, jamais dans le vert des gains.
 - **Fiabilité des données** : pastille d'âge par relevé, filtre de fraîcheur (< 24 h / 3 j / 7 j), point de statut d'inventaire, tag « à vérifier », bandeau global « données d'il y a X h ».
 - **Filtres** : commodité, système, même système uniquement, exclure les avant-postes, commodités légales uniquement, limiter au stock & à la demande UEX. Ils ne s'appliquent pas tous à toutes les vues — voir la **[matrice ci-dessous](#portée-des-filtres-par-vue)**.
 - **Permaliens & persistance** : l'état (filtres, tri, vue, vaisseau) est mémorisé (localStorage) et encodé dans l'URL → bouton **Partager**.
-- **Copier le manifeste**, **raccourcis clavier** (`/` recherche, `1`–`7` vues) ; tout ce qui s'active
+- **Copier le manifeste**, **raccourcis clavier** (`/` recherche, `1`–`8` vues) ; tout ce qui s'active
   au clic s'active aussi à **Entrée/Espace** (en-têtes de tri, escales de la carte, valeurs
   corrigeables, en-tête d'une jambe), et les raccourcis se taisent tant que le focus est sur l'un d'eux.
 - Systèmes couverts : **Stanton**, **Pyro**, **Nyx**.
@@ -69,6 +70,11 @@ Tous les filtres ne s'appliquent pas à toutes les vues — comportement **garan
 Le **Plan de vol** n'a pas de colonne : il n'affiche aucun filtre (ADR-004). Les chiffres qu'il
 récapitule restent ceux calculés sous les réglages en cours — c'est précisément pourquoi il les
 énonce en tête, en toutes lettres.
+
+La **Tournée** n'en a pas non plus, mais pour une autre raison : elle ne part d'aucun budget ni
+d'aucune soute à remplir — le fret est déjà à bord. Elle honore en revanche exactement les mêmes
+filtres qu'« où écouler » (avant-postes, commodités légales, fraîcheur, système), plus **sa propre
+portée** : le système courant par défaut, ouvrable aux autres d'un menu.
 
 | Filtre | Trajets | Boucles | En route | Chaîne | Corrections | Commodités |
 |--------|:-:|:-:|:-:|:-:|:-:|:-:|
@@ -391,7 +397,7 @@ Deux gestes, deux sens :
 | **`✓ chargé`** | « c'est payé et à bord » — ce ne sont plus des SCU prévus, ce sont des faits | elle **fige ses SCU** et prend `🔒`. Une correction du stock de départ **postérieure** ne la rétrécit plus |
 
 Une jambe figée continue de suivre les **prix** ; seules ses quantités sont gelées. Tout ce qui est
-calculé **ensuite** — les autres jambes, les sept vues, un arrêt ajouté plus tard — voit le stock tel
+calculé **ensuite** — les autres jambes, les huit vues, un arrêt ajouté plus tard — voit le stock tel
 que tu l'as corrigé, déduction du chargement comprise. `↺ optimal` lève le gel.
 
 Conséquence utile : charger la jambe 1 ne fige plus la jambe 3 qui rachètera la même commodité au

--- a/app.js
+++ b/app.js
@@ -14,7 +14,7 @@ import {
   legFromRoute, legsFromLoop, legsFromChain, legFromManifest, stopSuggestions, bestLegBetween,
   manifestJourneyState, manifestIntent, sameIntent, manifestIntentSurvives, legsToPin, journeyMap,
   loadHold, declarerLot, holdScu, freeCargo, holdByCommodity, sellFromHold, refuseHere, refusActif, migrerRefus, sellableAt, sellAllAt,
-  offloadPlan, storeFromHold, takeFromStore, stockApres,
+  offloadPlan, tourneesEcoulement, storeFromHold, takeFromStore, stockApres,
   startJourney, startJourneyAt, journeyStations, journeyEnd,
   journeyConnects, addToJourney, setJourneyPosition, currentLeg, journeyMargin,
   removeJourneyStop as removeStopPure,
@@ -2459,6 +2459,109 @@ function renderJourneyRecap({ n, totalProfit, totalScu, totalFees, systems }) {
      </div>`;
 }
 
+// ---------- La tournée d'écoulement : la huitième vue (ADR-007, #57) ----------
+// « Comment me débarrasser d'une soute que je ne veux plus porter ? » — l'AUTRE question, celle
+// qu'« où écouler » ne pose pas. Les deux vues coexistent parce que les deux classements sont
+// incompatibles, et l'écran doit le dire : sans ça l'app se contredit sous les yeux de
+// l'utilisateur, qui lit deux ordres opposés du même fret.
+
+// Un arrêt de la tournée. Les lignes sont plafonnées à 12 : le calcul est linéaire, c'est la
+// lisibilité qui souffre — et ce qui est écarté se dit, plutôt que de disparaître.
+function tourArretHTML(a, rang) {
+  const MAX = 12;
+  const visibles = a.lignes.slice(0, MAX);
+  const reste = a.lignes.length - visibles.length;
+  const detail = visibles
+    .map((l) => `<span class="tour-ligne${l.sousLePrixPaye ? " perte" : ""}">${esc(l.name)} <b>${fmt(l.absorbe)}</b>${l.reste > 0 ? `/${fmt(l.absorbe + l.reste)}` : ""} SCU</span>`)
+    .join("");
+  const cert = a.certitude === "connue"
+    ? `<span class="ec-sur" title="Capacité publiée par UEX">${fmt(a.garanti)} SCU garantis</span>`
+    : a.certitude === "inconnue"
+      ? '<span class="ec-flou" title="UEX ne publie pas la capacité de ce point : ni zéro, ni illimitée">capacité inconnue</span>'
+      : `<span class="ec-flou" title="Capacité publiée pour une partie seulement">${fmt(a.garanti)} SCU garantis, reste inconnu</span>`;
+  return `<div class="tour-arret">
+      <div class="tour-arret-head">
+        <span class="tour-n">${rang}</span>
+        <span class="tour-nom">${esc(a.terminal)}${sysBadge(a.system)}${a.cross ? ' <span class="cross" title="Changement de système">⚡</span>' : ""}${outpostTag(a.outpost)}</span>
+        <span class="tour-lignes-n">${a.lignes.length} ligne${a.lignes.length > 1 ? "s" : ""} · <b>${fmt(a.scu)}</b> SCU</span>
+        <span class="tour-encaisse" title="Encaissement brut. Profit, prix d'achat déduit : ${a.profit >= 0 ? "+" : ""}${fmt(Math.round(a.profit))} aUEC.">${fmt(Math.round(a.encaisse))}</span>
+      </div>
+      <div class="tour-arret-lignes">${detail}${reste > 0 ? `<span class="tour-ligne muted">+ ${reste} autre${reste > 1 ? "s" : ""}</span>` : ""}</div>
+      <div class="tour-arret-meta">${cert}${a.aPerte ? ' · <span class="ec-perte" title="Le prix ici est inférieur à ce que tu as payé">sous le prix payé</span>' : ""}</div>
+    </div>`;
+}
+
+function tourHTML(t, alt, systeme, toutSysteme) {
+  if (!t.arrets.length && !t.sansDebouche.length) {
+    return `<div class="tour-vide"><p class="muted">Aucun comptoir ne reprend ce fret ${toutSysteme ? "où que ce soit" : `dans ${esc(systeme)}`} avec ces filtres.
+      Ouvre la portée aux autres systèmes, ou <b>dépose</b> le fret à une station : il n'est alors ni vendu ni perdu.</p></div>`;
+  }
+  // Le plancher, dit AVANT les chiffres. 307 des 1 879 points de vente publient leur capacité :
+  // le nombre d'arrêts est presque toujours faux vers le bas, et un total ne s'affiche jamais sans
+  // dire s'il est garanti ou parié.
+  const parie = t.certitude !== "connue";
+  const bandeau = `<div class="tour-plancher ${parie ? "parie" : "sur"}">${parie
+    ? "Plancher : UEX ne publie la capacité que d'un point de vente sur six. Il faudra sans doute <b>plus d'arrêts</b> que ce qui est annoncé — la tournée se recalcule après chaque arrêt réel."
+    : "Toutes les capacités de cette tournée sont publiées par UEX : le nombre d'arrêts est <b>garanti</b>."}</div>`;
+
+  const orphelines = t.sansDebouche.length
+    ? `<div class="tour-orphelines"><b>${t.sansDebouche.length} ligne${t.sansDebouche.length > 1 ? "s ne s'écoulent" : " ne s'écoule"} nulle part ${toutSysteme ? "dans la portée" : `dans ${esc(systeme)}`}</b> :
+        ${t.sansDebouche.map((g) => `<span class="tour-orph">${esc(g.name)} ${fmt(g.units)} SCU</span>`).join("")}
+        <span class="muted">— ouvre la portée, dépose-les à une station, ou garde-les à bord.</span></div>`
+    : "";
+
+  const entete = `<div class="tour-head">
+      <span class="tour-titre">◈ Tournée d'écoulement</span>
+      <span class="tour-bilan"><b>${t.arrets.length}</b> arrêt${t.arrets.length > 1 ? "s" : ""}${t.sauts > 0 ? ` · <b>${t.sauts}</b> saut${t.sauts > 1 ? "s" : ""} de système` : ""} · <b>${fmt(t.scu)}</b> SCU écoulés${t.resteScu > 0 ? ` · <b class="tour-reste">${fmt(t.resteScu)}</b> SCU resteraient à bord` : " · <b>soute vidée</b>"}</span>
+      <span class="tour-total" title="Encaissement brut de la tournée. Profit, prix d'achat déduit : ${t.profit >= 0 ? "+" : ""}${fmt(Math.round(t.profit))} aUEC.">${fmt(Math.round(t.encaisse))} <span>aUEC</span></span>
+    </div>`;
+
+  // L'alternative « un arrêt de plus », chiffrée. L'ordre reste lexicographique STRICT : la plus
+  // courte est retenue. Un seuil serait un paramètre invérifiable — l'app ne sait pas si tu as le
+  // temps, si c'est sur ton chemin, ou si tu veux juste te coucher. On montre les deux.
+  const alternative = alt
+    ? `<div class="tour-alt">
+        <div class="tour-alt-head">Un arrêt de plus : <b class="profit">+${fmt(Math.round(alt.ecart))}</b> aUEC${alt.ecartPct != null ? ` <span class="muted">(+${alt.ecartPct.toFixed(1)} %)</span>` : ""}</div>
+        <div class="tour-alt-chemin">${alt.arrets.map((a) => `${esc(a.terminal)} <span class="muted">(${a.lignes.length})</span>`).join(" <span class=\"tour-fleche\">→</span> ")}</div>
+        <div class="tour-alt-note muted">À toi de trancher : l'app ne sait pas si tu as le temps, ni si c'est sur ton chemin.</div>
+      </div>`
+    : "";
+
+  return entete + bandeau + orphelines +
+    `<div class="tour-arrets">${t.arrets.map((a, i) => tourArretHTML(a, i + 1)).join("")}</div>` +
+    alternative;
+}
+
+function renderTour() {
+  const box = $("tour");
+  if (!box) return;
+  if (!SOUTE.length) {
+    box.innerHTML = `<div class="tour-vide"><p class="muted">Ta soute est vide — il n'y a rien à écouler.
+      Déclare ce que tu transportes avec <b>« + déclarer ce que j'ai à bord »</b> depuis une vue de recherche,
+      ou charge le manifeste d'une jambe avec <b>« ✓ chargé »</b>.</p></div>`;
+    return;
+  }
+  // Le graphe d'échange porte les débouchés. On passe `refresh` et non `renderTour` : c'est la règle
+  // de withMarket — le fetch dure, et l'utilisateur peut avoir changé de vue entre-temps.
+  if (!MARKET) { withMarket(refresh); box.innerHTML = '<p class="muted tour-vide">Chargement du marché…</p>'; return; }
+  // Le champ de la vue prime sur la position du voyage : on peut vouloir simuler depuis ailleurs.
+  const saisi = $("tourFrom").value.trim();
+  const ici = saisi ? resolveStationLabel(saisi) : stationCourante();
+  if (ici == null) {
+    box.innerHTML = `<div class="tour-vide"><p class="muted">Dis d'abord <b>où tu es</b> : une tournée part d'un terminal.
+      Le champ <b>Je suis à</b>, juste au-dessus, l'attend.</p></div>`;
+    return;
+  }
+  const f = readFilters();
+  const systeme = MARKET.terminals[ici].system;
+  const toutSysteme = $("tourScope").value === "all";
+  // Portée par défaut = le système où l'on se trouve (27 terminaux en Pyro, 80 en Stanton, 7 en Nyx
+  // sur 114). L'ouvrir est un geste explicite, et le saut apparaît alors comme une ligne de coût.
+  const ft = { ...f, sysFilter: toutSysteme ? f.sysFilter : systeme };
+  const { tournee, alternative } = tourneesEcoulement(MARKET, SOUTE, ici, ft, effVals, feeResolver(f));
+  box.innerHTML = tourHTML(tournee, alternative, systeme, toutSysteme);
+}
+
 // ---------- Plan de vol : la vue de conclusion (ADR-004) ----------
 // Une CONCLUSION, pas un tableau de bord : on y arrive une fois tout paramétré, pour REGARDER le
 // résultat. Rien n'y est actionnable — pas un bouton de vente, pas un ✕, pas un champ. Les gestes
@@ -2640,6 +2743,7 @@ function refresh() {
   else if (view === "corrections") renderCorrections();
   else if (view === "commodities") renderCommodities();
   else if (view === "plan") renderPlan();
+  else if (view === "tour") renderTour();
   else render();
   // La carte Voyage est affichée À CÔTÉ des tableaux, dans toutes les vues : la laisser hors du
   // cycle de rendu la figeait sur l'état d'avant. Corriger un prix ne mettait donc pas à jour les
@@ -2668,6 +2772,7 @@ function switchView(v) {
   $("viewCorrections").classList.toggle("active", v === "corrections");
   $("viewCommodities").classList.toggle("active", v === "commodities");
   $("viewPlan").classList.toggle("active", v === "plan");
+  $("viewTour").classList.toggle("active", v === "tour");
   $("routes").hidden = v !== "routes";
   $("loops").hidden = v !== "loops";
   $("enroute").hidden = v !== "enroute";
@@ -2679,6 +2784,8 @@ function switchView(v) {
   $("commoditiesControls").hidden = v !== "commodities";
   $("commodities").hidden = v !== "commodities";
   $("plan").hidden = v !== "plan";
+  $("tourControls").hidden = v !== "tour";
+  $("tour").hidden = v !== "tour";
   // Les deux blocs jusqu'ici PERMANENTS, que seule la vue de conclusion masque (ADR-004 §4 et §6).
   // La barre de filtres : on ne change rien au voyage depuis le Plan de vol, l'y laisser ferait
   // croire le contraire. Le bandeau : ses cartes sont éditables (✕ du parcours, vente en soute) et
@@ -2687,7 +2794,7 @@ function switchView(v) {
   $("controls").hidden = v === "plan";
   $("shipJourneyRow").hidden = v === "plan";
   if (v !== "enroute") $("manifest").hidden = true;
-  if (v === "chain" || v === "corrections" || v === "commodities" || v === "plan") $("empty").hidden = true;
+  if (v === "chain" || v === "corrections" || v === "commodities" || v === "plan" || v === "tour") $("empty").hidden = true;
   refresh();
 }
 
@@ -2879,7 +2986,7 @@ async function loadShips() {
 // hash de l'URL, pour reprendre là où on s'est arrêté et partager une vue précise.
 // `alk` = coefficient d'autoload global : partageable, comme tous les réglages. Les relevés PAR
 // STATION, eux, restent locaux — c'est la même frontière que pour les corrections de prix.
-const STATE_FIELDS = ["cargo", "budget", "search", "system", "freshness", "ship", "origin", "destSystem", "destTerminal", "chainOrigin", "hops", "station", "alk", "multiMode"];
+const STATE_FIELDS = ["cargo", "budget", "search", "system", "freshness", "ship", "origin", "destSystem", "destTerminal", "chainOrigin", "hops", "station", "alk", "multiMode", "tourFrom", "tourScope"];
 const STATE_CHECKS = ["useCargo", "useBudget", "sameSystem", "noOutpost", "legalOnly", "capStock", "multiCommodity", "autoload"];
 // Champs qui gardent leur défaut HTML quand la clé est absente de l'état. #system, #freshness et
 // #destSystem ont chacun une option VIDE (« Tous », « Toutes », « N'importe où ») : leur poser ""
@@ -2994,7 +3101,7 @@ function applyState(s) {
   // Liste blanche des vues restaurables. Y OUBLIER une vue neuve est le piège documenté par
   // l'ADR-004 : elle s'ouvre au clic, mais ne revient ni d'un permalien ni du localStorage — et
   // l'oubli ne se voit qu'au rechargement suivant.
-  if (["routes", "loops", "enroute", "chain", "corrections", "commodities", "plan"].includes(s.v)) view = s.v;
+  if (["routes", "loops", "enroute", "chain", "corrections", "commodities", "plan", "tour"].includes(s.v)) view = s.v;
   if (s.cb === "loot") commBoard = "loot";
   if (s.j) JOURNEY = decodeJourney(s.j); // compagnon de voyage restauré (les champs sont déjà repris ci-dessus)
   applySortIndicators();
@@ -3528,6 +3635,11 @@ async function init() {
   $("viewCorrections").addEventListener("click", () => switchView("corrections"));
   $("viewCommodities").addEventListener("click", () => switchView("commodities"));
   $("viewPlan").addEventListener("click", () => switchView("plan"));
+  $("viewTour").addEventListener("click", () => switchView("tour"));
+  // Terminal à SAISIE LIBRE (datalist, mais rien n'oblige à choisir dedans) : même debounce que
+  // #origin et #chainOrigin, faute de quoi chaque frappe re-rendrait ET réécrirait le hash.
+  $("tourFrom").addEventListener("input", refreshDebounced);
+  $("tourScope").addEventListener("input", refresh); // <select> : un seul événement, immédiat
   // La marque ramène à TRAJETS, la vue principale — pas au Plan de vol (ADR-004 §5). Un <button>
   // natif : Entrée et Espace y viennent sans rien ajouter.
   $("brandHome").addEventListener("click", () => switchView("routes"));
@@ -3807,13 +3919,13 @@ async function init() {
       startEdit(e.target);
     }
   });
-  // Raccourcis clavier : / (recherche), 1 à 7 (vues). Ignorés pendant la saisie.
+  // Raccourcis clavier : / (recherche), 1 à 8 (vues). Ignorés pendant la saisie.
   document.addEventListener("keydown", (e) => {
     if (e.ctrlKey || e.metaKey || e.altKey) return;
     const el = document.activeElement;
     // `role="button"` couvre d'un coup tout ce que l'app rend activable sans être un <button> :
     // l'en-tête d'une jambe, une escale de la carte, une valeur corrigeable. Sans lui, tabuler
-    // jusqu'à l'un d'eux puis taper « 1 »…« 7 » changeait de vue — l'utilisateur clavier perdait son
+    // jusqu'à l'un d'eux puis taper « 1 »…« 8 » changeait de vue — l'utilisateur clavier perdait son
     // contexte au moment précis où il essayait d'agir dessus.
     if (el && (el.tagName === "INPUT" || el.tagName === "SELECT" || el.tagName === "TEXTAREA" ||
                el.getAttribute("role") === "button" || el.classList.contains("editv"))) return;
@@ -3825,6 +3937,7 @@ async function init() {
     else if (e.key === "5") switchView("corrections");
     else if (e.key === "6") switchView("commodities");
     else if (e.key === "7") switchView("plan");
+    else if (e.key === "8") switchView("tour");
   });
   loadOverrides();
   loadAutoloadK();

--- a/e2e/tournee.pw.mjs
+++ b/e2e/tournee.pw.mjs
@@ -1,0 +1,145 @@
+import { test, expect } from "@playwright/test";
+
+// La tournée d'écoulement : la huitième vue (#57, ADR-007).
+// Elle répond à l'AUTRE question que « où écouler » — non pas « combien puis-je en tirer » mais
+// « comment me débarrasser d'une soute que je ne veux plus porter ». L'écran doit le dire, sinon
+// l'app se contredit sous les yeux de l'utilisateur, qui lit deux classements opposés du même fret.
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/index.html");
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+});
+
+// Déclare du fret à bord : la tournée n'a de sens que sur une soute pleine, et c'est #55 qui a
+// livré cette porte d'entrée — l'issue #57 la réclamait encore, sa prémisse était périmée.
+async function declarer(page, nom, scu) {
+  await page.locator("#holdAddOpen").click();
+  await expect(page.locator("#holdAddName")).toBeVisible();
+  await expect.poll(() => page.locator("#commodityList option").count()).toBeGreaterThan(0);
+  await page.fill("#holdAddName", nom);
+  await page.fill("#holdAddScu", String(scu));
+  await page.locator("#holdAddOk").click();
+  await expect(page.locator("#holdCard")).toBeVisible();
+}
+
+// Une tournée calculée, depuis un terminal de Pyro qui existe dans le jeu de données.
+async function tourneeDepuis(page, terminal = "Megumi") {
+  await page.click("#viewTour");
+  await expect(page.locator("#tour")).toBeVisible();
+  await page.fill("#tourFrom", terminal);
+  await expect(page.locator("#tour .tour-arret").first()).toBeVisible({ timeout: 10_000 });
+}
+
+test("Tournée : une huitième entrée au rail, au clic comme au raccourci « 8 » (#57)", async ({ page }) => {
+  await expect(page.locator("#viewTour")).toBeVisible();
+  await page.click("#viewTour");
+  await expect(page.locator("#tour")).toBeVisible();
+  await expect(page.locator("#tourControls")).toBeVisible();
+  await expect(page.locator("#viewTour")).toHaveClass(/active/);
+  await expect(page.locator("#routes")).toBeHidden();
+
+  await page.click("#viewRoutes");
+  await expect(page.locator("#tour")).toBeHidden();
+  await expect(page.locator("#tourControls")).toBeHidden(); // les contrôles ne fuient pas hors de leur vue
+  await page.keyboard.press("8");
+  await expect(page.locator("#tour")).toBeVisible();
+});
+
+test("Tournée : la vue revient d'un rechargement ET d'un permalien, terminal compris (#57)", async ({ page }) => {
+  // Le piège documenté par l'ADR-004 : sans ajout dans la liste blanche d'applyState, la vue
+  // s'ouvre au clic mais ne revient d'aucun état sauvé.
+  await page.click("#viewTour");
+  await page.fill("#tourFrom", "Megumi");
+  await page.selectOption("#tourScope", "all");
+  await expect.poll(() => page.url()).toContain("v=tour");
+
+  await page.reload();
+  await expect(page.locator("#tour")).toBeVisible();
+  await expect(page.locator("#viewTour")).toHaveClass(/active/);
+  await expect(page.locator("#tourFrom")).toHaveValue("Megumi");
+  await expect(page.locator("#tourScope")).toHaveValue("all"); // la portée voyage aussi
+});
+
+test("Tournée : soute vide, la vue dit quoi faire plutôt que de rester blanche (#57)", async ({ page }) => {
+  await page.click("#viewTour");
+  await expect(page.locator("#tour .tour-vide")).toContainText(/déclarer ce que j'ai à bord/i);
+  await expect(page.locator("#tour .tour-arret")).toHaveCount(0);
+});
+
+test("Tournée : sans point de départ, elle le réclame — une tournée part d'un terminal (#57)", async ({ page }) => {
+  // stationCourante() rend null sans voyage ni terminal « En route » : la vue a son propre champ.
+  await declarer(page, "Titanium", 100);
+  await page.click("#viewTour");
+  await expect(page.locator("#tour .tour-vide")).toContainText(/où tu es/i);
+});
+
+test("Tournée : elle propose des arrêts, et annonce ce qui reste à bord (#57)", async ({ page }) => {
+  await declarer(page, "Titanium", 100);
+  await tourneeDepuis(page);
+
+  await expect(page.locator("#tour .tour-head")).toContainText(/arrêt/);
+  await expect(page.locator("#tour .tour-bilan")).toContainText(/SCU/);
+  // Chaque arrêt nomme son comptoir, ses lignes et ce qu'il encaisse.
+  const premier = page.locator("#tour .tour-arret").first();
+  await expect(premier.locator(".tour-nom")).not.toBeEmpty();
+  await expect(premier.locator(".tour-arret-lignes")).toContainText("Titanium");
+  await expect(premier.locator(".tour-encaisse")).not.toBeEmpty();
+});
+
+test("Tournée : le PLANCHER est dit avant les chiffres, jamais après (#57)", async ({ page }) => {
+  // 307 des 1 879 points de vente publient leur capacité : le nombre d'arrêts est presque toujours
+  // faux vers le bas. Un total ne doit jamais s'afficher sans dire s'il est garanti ou parié.
+  await declarer(page, "Titanium", 100);
+  await tourneeDepuis(page);
+  const bandeau = page.locator("#tour .tour-plancher");
+  await expect(bandeau).toBeVisible();
+  await expect(bandeau).toContainText(/garanti|plancher/i);
+  // …et il se lit AVANT le premier arrêt.
+  const yBandeau = (await bandeau.boundingBox()).y;
+  const yArret = (await page.locator("#tour .tour-arret").first().boundingBox()).y;
+  expect(yBandeau).toBeLessThan(yArret);
+});
+
+test("Tournée : l'écran dit en quoi elle diffère d'« où écouler » (ADR-007)", async ({ page }) => {
+  // Les deux vues classent le MÊME fret dans deux ordres opposés. Sans cette phrase, l'app se
+  // contredit sous les yeux de l'utilisateur — c'est une exigence de l'ADR, pas du confort.
+  await page.click("#viewTour");
+  const aide = page.locator("#tourControls .enroute-hint");
+  await expect(aide).toContainText(/minimum d'arrêts/i);
+  await expect(aide).toContainText(/où écouler/i);
+});
+
+test("Tournée : la portée s'ouvre aux autres systèmes, et ça change le calcul (#57)", async ({ page }) => {
+  await declarer(page, "Titanium", 100);
+  await tourneeDepuis(page);
+  await expect(page.locator("#tourScope")).toHaveValue(""); // système courant par défaut
+
+  const avant = await page.locator("#tour .tour-arret .tour-nom").allInnerTexts();
+  await page.selectOption("#tourScope", "all");
+  await expect(page.locator("#tour .tour-arret").first()).toBeVisible();
+  const apres = await page.locator("#tour .tour-arret .tour-nom").allInnerTexts();
+  // Ouvrir la portée ne peut pas RÉTRÉCIR l'ensemble des débouchés : au pire c'est identique.
+  expect(apres.length).toBeGreaterThan(0);
+  expect(avant.length).toBeGreaterThan(0);
+});
+
+test("Tournée : ne repasse jamais deux fois au même comptoir (ADR-007)", async ({ page }) => {
+  // La capacité repousse par ticks en jeu, mais l'app n'a aucune donnée sur le débit de recharge :
+  // un aller-retour pour attendre un tick n'est pas « tout écouler au plus vite ».
+  await declarer(page, "Titanium", 5000); // volontairement énorme : force le résidu
+  await tourneeDepuis(page);
+  const noms = await page.locator("#tour .tour-arret .tour-nom").allInnerTexts();
+  expect(new Set(noms.map((n) => n.trim())).size).toBe(noms.length);
+  expect(noms.length).toBeLessThanOrEqual(5); // et bornée à 5 arrêts
+});
+
+test("Tournée : le bandeau et les filtres restent, seule la vue change (#57)", async ({ page }) => {
+  // Non-régression : la tournée n'est pas une conclusion, contrairement au Plan de vol — le
+  // bandeau et la barre de filtres continuent d'y vivre.
+  await declarer(page, "Titanium", 100);
+  await page.click("#viewTour");
+  await expect(page.locator("#controls")).toBeVisible();
+  await expect(page.locator("#shipJourneyRow")).toBeVisible();
+  await expect(page.locator("#holdCard")).toBeVisible();
+  await expect(page.locator("#journeyMap")).toBeHidden(); // la carte ne vit que dans le Plan de vol
+});

--- a/index.html
+++ b/index.html
@@ -77,6 +77,10 @@
              produit, et la placer en tête renuméroterait des raccourcis déjà appris pour un gain
              nul. Révisable par #45, qui refond la hiérarchie du rail dans le même jalon. -->
         <button id="viewPlan" class="vbtn" data-view="plan" aria-label="Plan de vol" title="Plan de vol : le récapitulatif du voyage engagé (raccourci : 7)"><span class="rn">07</span><span class="rl">Plan&nbsp;de&nbsp;vol</span></button>
+        <!-- L'aria-label OUVRE le libellé visible plutôt que de le remplacer (même patron que
+             #share) : « Tournée » y est repris mot pour mot, SC 2.5.3 tient, et le nom accessible
+             dit en plus de quoi il s'agit une fois le rail rétracté. -->
+        <button id="viewTour" class="vbtn" data-view="tour" aria-label="Tournée d'écoulement" title="Tournée d'écoulement : vider la soute en un minimum d'arrêts (raccourci : 8)"><span class="rn">08</span><span class="rl">Tournée</span></button>
       </div>
 
       <!-- Le libellé visible « Partager » OUVRE l'aria-label : sinon le nom accessible ne le
@@ -289,6 +293,27 @@
           <div id="correctionsStation"></div>
           <div id="correctionsFees"></div>
         </div>
+
+        <!-- ===================== TOURNÉE D'ÉCOULEMENT (ADR-007) =====================
+             L'autre question que celle d'« où écouler » : non pas « combien puis-je en tirer »,
+             mais « comment me débarrasser d'une soute que je ne veux plus porter ». La vue a son
+             PROPRE point de départ : stationCourante() rend null sans voyage ni terminal « En
+             route », et une tournée sans origine n'a pas de premier arrêt. -->
+        <section id="tourControls" class="enroute-controls" hidden>
+          <div class="field">
+            <label for="tourFrom">Je suis à</label>
+            <input id="tourFrom" list="stationList" type="text" placeholder="Tape un terminal (ex : Checkmate)" autocomplete="off" />
+          </div>
+          <div class="field">
+            <label for="tourScope">Portée</label>
+            <select id="tourScope" title="Par défaut la tournée reste dans le système où tu te trouves. L'ouvrir aux autres systèmes fait apparaître le saut comme une ligne de coût visible — c'est le seul palier de distance que les données permettent de tenir.">
+              <option value="">Système courant</option>
+              <option value="all">Tous les systèmes</option>
+            </select>
+          </div>
+          <p class="enroute-hint">Vide ta soute en un <b>minimum d'arrêts</b> — un comptoir qui reprend trois commodités à prix moyen bat un comptoir qui n'en reprend qu'une au meilleur prix. C'est l'inverse de <b>« où écouler »</b>, qui classe par ce que ça rapporte : <b>les deux questions sont différentes</b>, et cette vue-ci répond à « je ne veux plus porter ça ».</p>
+        </section>
+        <div id="tour" class="tour-wrap" hidden></div>
 
         <section id="commoditiesControls" class="enroute-controls" hidden>
           <div class="field">

--- a/logic.mjs
+++ b/logic.mjs
@@ -1961,8 +1961,16 @@ export function sellAllAt(hold, market, terminalIdx, resolve, nowSec = Date.now(
 // la demande d'une station est par commodité, les résidus ne se disputent donc rien. La « reine »
 // est celle qui RAPPORTE le plus — units × meilleur prix atteignable — et non celle qui a coûté le
 // plus cher : `holdByCommodity` trie par capital engagé, ce qui est un autre critère.
-export function offloadPlan(market, hold, originIdx, f = {}, resolve = null, autoloadFor = null, limit = 6) {
+// `opts` (ADR-007) : la tournée d'écoulement PARAMÈTRE cette fonction au lieu de la dupliquer —
+// deux fonctions entretiendraient deux classements divergents, exactement le défaut que le dépôt
+// corrige ailleurs. Deux réglages, et les deux défauts sont ceux d'« où écouler » :
+//   `inclureOrigine` — le terminal de départ est écarté ici (« où écouler AILLEURS »), ce qui est
+//     faux pour une tournée : la station où l'on se trouve peut être le meilleur premier arrêt, à
+//     coût de déplacement nul — on vient justement d'y ramasser le butin ;
+//   `comparer` — le tri par profit reste le défaut ; la tournée injecte son tri par couverture.
+export function offloadPlan(market, hold, originIdx, f = {}, resolve = null, autoloadFor = null, limit = 6, opts = {}) {
   if (!hold || !hold.length) return [];
+  const inclureOrigine = !!opts.inclureOrigine;
   const origine = market.terminals[originIdx];
   const parNom = holdByCommodity(hold);
   // La reine : celle qui rapporte le plus, au meilleur prix qu'on puisse en tirer quelque part.
@@ -1973,7 +1981,7 @@ export function offloadPlan(market, hold, originIdx, f = {}, resolve = null, aut
     let meilleur = 0;
     for (const sv of c.sells) {
       const t = market.terminals[sv[0]];
-      if (!t || sv[0] === originIdx) continue;
+      if (!t || (sv[0] === originIdx && !inclureOrigine)) continue;
       const e = resolve ? resolve(g.name, t.name, "sell", sv[1], sv[2], sv[3]) : { price: sv[1] };
       if (e.price > meilleur) meilleur = e.price;
     }
@@ -1983,7 +1991,7 @@ export function offloadPlan(market, hold, originIdx, f = {}, resolve = null, aut
   const out = [];
 
   market.terminals.forEach((t, idx) => {
-    if (idx === originIdx) return;                                   // on y est déjà
+    if (idx === originIdx && !inclureOrigine) return;                // on y est déjà
     if (f.noOutpost && t.outpost) return;
     if (f.sameOnly && origine && t.system !== origine.system) return;
     if (f.sysFilter && t.system !== f.sysFilter) return;
@@ -2039,8 +2047,113 @@ export function offloadPlan(market, hold, originIdx, f = {}, resolve = null, aut
   // Profit d'abord ; à égalité, celle qui écoule le plus de la reine — un booléen « solde-t-elle la
   // reine ? » abandonnerait la priorité dans tous les cas où AUCUNE destination ne la solde.
   return out
-    .sort((a, b) => b.profit - a.profit || b.scuReine - a.scuReine || b.garanti - a.garanti)
+    .sort(opts.comparer || ((a, b) => b.profit - a.profit || b.scuReine - a.scuReine || b.garanti - a.garanti))
     .slice(0, limit);
+}
+
+// ---------- La tournée d'écoulement (ADR-007, #57) ----------
+// « Comment me débarrasser d'une soute que je ne veux plus porter ? » — l'autre question, celle
+// qu'`offloadPlan` ne pose PAS. Lui demande « combien puis-je en tirer » et classe par profit ;
+// ici le fret est déjà à bord, le coût est coulé, et ce qui compte est le NOMBRE D'ARRÊTS.
+// Un comptoir qui reprend trois commodités à prix moyen bat donc un comptoir qui n'en reprend
+// qu'une au meilleur prix. Les deux vues coexistent parce que les deux questions sont
+// incompatibles — un seul classement ne peut pas servir les deux.
+
+// Le choix d'un arrêt : couverture d'abord (c'est elle qui réduit les arrêts À VENIR), puis on
+// préfère rester dans le système, puis le volume, puis l'argent. L'argent ne départage qu'en
+// dernier, et c'est l'ENCAISSEMENT, pas le profit : le prix payé est coulé et identique quelle que
+// soit la destination — sur une soute mixte, le profit comparerait des bases de coût hétérogènes
+// et pénaliserait la ligne réellement achetée, donc la destination qui l'écoule.
+const parCouverture = (a, b) =>
+  b.lignes.length - a.lignes.length ||
+  (a.cross === b.cross ? 0 : a.cross ? 1 : -1) ||
+  b.scu - a.scu ||
+  b.encaisse - a.encaisse;
+
+// Agrège une suite d'arrêts. `certitude` vaut « connue » seulement si TOUS les arrêts le sont :
+// 16,3 % des points de vente publient leur capacité, donc un total est presque toujours un pari.
+function bilanTournee(arrets, reste, sansDebouche) {
+  const somme = (cle) => arrets.reduce((s, a) => s + a[cle], 0);
+  const connus = arrets.filter((a) => a.certitude === "connue").length;
+  return {
+    arrets, reste, sansDebouche,
+    resteScu: holdScu(reste),
+    scu: somme("scu"), garanti: somme("garanti"),
+    encaisse: somme("encaisse"), profit: somme("profit"),
+    sauts: arrets.filter((a) => a.cross).length,
+    certitude: !arrets.length || connus === arrets.length ? (arrets.length ? "connue" : "inconnue")
+      : connus === 0 ? "inconnue" : "partielle",
+  };
+}
+
+// Glouton par couverture maximale, rejoué après chaque arrêt. C'est SET COVER (Karp, 1972),
+// inapproximable en deçà de (1−o(1))·ln n sauf si P = NP (Feige, 1998) — et le glouton par
+// couverture maximale atteint EXACTEMENT cette borne. Ce n'est pas un pis-aller : c'est l'optimum
+// de ce qu'on peut espérer en temps polynomial. À 7 lignes, ln(7) ≈ 1,95.
+// L'autre moitié du problème — ordonner les arrêts choisis — est dégénérée ici : sans matrice de
+// distances (aucune coordonnée dans market.json, 161 routes sur 316 portant une distance), il n'y
+// a rien à ordonner. Tout le NP-difficile est dans le CHOIX des comptoirs.
+export function tourneeEcoulement(market, hold, originIdx, f = {}, resolve = null, autoloadFor = null, opts = {}) {
+  const maxArrets = opts.maxArrets || 5;
+  const tous = market.terminals.length; // jamais de `limit` ici : on filtre nous-mêmes, après
+  // Les lignes qui ne s'écoulent NULLE PART dans la portée, sorties du calcul avant la boucle et
+  // nommées : sinon on annonce une soute vidée qui ne l'est pas. On les déduit d'un `offloadPlan`
+  // complet plutôt que d'une seconde règle d'éligibilité — deux règles finiraient par diverger.
+  const portee = offloadPlan(market, hold, originIdx, f, resolve, autoloadFor, tous, { inclureOrigine: true });
+  const ecoulables = new Set(portee.flatMap((d) => d.lignes.map((l) => l.name)));
+  const sansDebouche = holdByCommodity(hold)
+    .filter((g) => !ecoulables.has(g.name))
+    .map((g) => ({ name: g.name, units: g.units }));
+
+  const arrets = [], vus = new Set();
+  let h = hold, ici = originIdx;
+  while (holdScu(h) > 0 && arrets.length < maxArrets) {
+    const cands = offloadPlan(market, h, ici, f, resolve, autoloadFor, tous, {
+      inclureOrigine: !arrets.length, comparer: parCouverture,
+    }).filter((d) => !vus.has(d.idx));
+    // Un premier arrêt imposé sert à dérouler les alternatives : on ne force que le tout premier.
+    const best = !arrets.length && opts.premierForce != null
+      ? cands.find((d) => d.idx === opts.premierForce)
+      : cands[0];
+    if (!best) break; // plus rien d'écoulable : on sort avec ce qui reste, et on le dit
+    // PAS `sellAllAt` : il ignore la capacité ET les filtres de vue (mesuré). Le résidu se
+    // construit ligne par ligne, sur `absorbe`, qu'offloadPlan a déjà plafonné.
+    h = best.lignes.reduce((acc, l) => sellFromHold(acc, l.name, l.absorbe, l.price).hold, h);
+    arrets.push(best);
+    vus.add(best.idx); // on ne repasse jamais deux fois : la recharge par ticks n'est pas modélisable
+    ici = best.idx;
+  }
+  return bilanTournee(arrets, h, sansDebouche);
+}
+
+// La tournée retenue, et la meilleure « à un arrêt de plus » — affichée avec son écart chiffré.
+// L'ordre lexicographique est STRICT (la plus courte gagne toujours) : un seuil serait un paramètre
+// invérifiable, l'app ne sachant ni si tu as le temps, ni si c'est sur ton chemin. Montrer les deux
+// rend l'arbitrage à qui a le contexte.
+// L'alternative se cherche en FORÇANT un autre premier arrêt, puis en déroulant le même glouton :
+// borné à `k` essais, c'est le faisceau étroit de l'ADR, appliqué au seul endroit qui en a besoin.
+export function tourneesEcoulement(market, hold, originIdx, f = {}, resolve = null, autoloadFor = null, opts = {}) {
+  const tournee = tourneeEcoulement(market, hold, originIdx, f, resolve, autoloadFor, opts);
+  const k = opts.k || 3;
+  const premiers = offloadPlan(market, hold, originIdx, f, resolve, autoloadFor, market.terminals.length,
+    { inclureOrigine: true }) // par PROFIT : c'est là que se cachent les tournées plus payantes
+    .filter((d) => d.idx !== (tournee.arrets[0] || {}).idx)
+    .slice(0, k);
+
+  let alternative = null;
+  for (const d of premiers) {
+    const t = tourneeEcoulement(market, hold, originIdx, f, resolve, autoloadFor, { ...opts, premierForce: d.idx });
+    // « Un arrêt de plus », et pas deux : au-delà, ce n'est plus la même question.
+    if (t.arrets.length !== tournee.arrets.length + 1) continue;
+    if (t.resteScu > tournee.resteScu) continue;          // elle doit au moins vider autant
+    if (t.encaisse <= tournee.encaisse) continue;          // et rapporter plus, sinon elle n'a aucun sens
+    if (!alternative || t.encaisse > alternative.encaisse) alternative = t;
+  }
+  if (alternative) {
+    alternative.ecart = alternative.encaisse - tournee.encaisse;
+    alternative.ecartPct = tournee.encaisse > 0 ? (alternative.ecart / tournee.encaisse) * 100 : null;
+  }
+  return { tournee, alternative };
 }
 
 // Dépose des SCU à une station : ils quittent la soute SANS être vendus. Troisième sortie du fret,

--- a/logic.test.mjs
+++ b/logic.test.mjs
@@ -19,7 +19,7 @@ import {
   journeyMap, nameAngle, CARTE, nomPasserelle,
   loadHold, declarerLot, holdScu, freeCargo, holdByCommodity, sellFromHold, storeFromHold, takeFromStore,
   refusActif, migrerRefus, DUREE_VOL,
-  refuseHere, sellableAt, sellAllAt, offloadPlan, stockApres,
+  refuseHere, sellableAt, sellAllAt, offloadPlan, tourneeEcoulement, tourneesEcoulement, stockApres,
   startJourney, startJourneyAt, journeyStations, journeyEnd,
   journeyConnects, addToJourney, setJourneyPosition, currentLeg, journeyMargin,
   encodeJourney, decodeJourney, removeJourneyStop, freeManifestLine, hydrateManifestLine,
@@ -2361,6 +2361,161 @@ test("takeFromStore : reprendre rend le lot à la soute avec son prix payé, et 
   // Rien à reprendre : ni station inconnue, ni commodité absente ne fabriquent quoi que ce soit.
   assert.deepEqual(takeFromStore([], depose.entrepots, "Gold", 10, "Nulle part").hold, []);
   assert.deepEqual(takeFromStore([], depose.entrepots, "Inconnue", 10, "Ruin Station — Pyro").hold, []);
+});
+
+// ---------- La tournée d'écoulement : vider la soute en un minimum d'arrêts (ADR-007, #57) ----------
+// Marché-jouet construit pour que COUVERTURE et PROFIT désignent des destinations différentes —
+// c'est tout l'objet de l'ADR-007. « Large » reprend les trois lignes à prix moyen ; « Riche » n'en
+// reprend qu'une, mais dix fois plus cher. Le contre-exemple à 886 SCU de l'issue, en miniature.
+const MARCHE_TOURNEE = {
+  terminals: [
+    { name: "Ici", system: "S" },       // 0 — on y est, et il ne reprend rien
+    { name: "Large", system: "S" },     // 1 — les trois lignes, à 100
+    { name: "Riche", system: "S" },     // 2 — X seule, à 1 000
+    { name: "Ailleurs", system: "T" },  // 3 — Y seule, et dans un autre système
+  ],
+  commodities: [
+    { name: "X", kind: "metal", illegal: false, buys: [], sells: [[1, 100, null, 9e9, 3], [2, 1000, null, 9e9, 3]] },
+    { name: "Y", kind: "metal", illegal: false, buys: [], sells: [[1, 100, null, 9e9, 3], [3, 900, null, 9e9, 3]] },
+    { name: "Z", kind: "metal", illegal: false, buys: [], sells: [[1, 100, null, 9e9, 3]] },
+  ],
+};
+const souteXYZ = () => ["X", "Y", "Z"].map((name) => ({ name, units: 10, paid: 0, from: "", at: 1 }));
+
+test("tournée : la plus COURTE gagne, même quand elle rapporte moins (ADR-007)", () => {
+  const t = tourneeEcoulement(MARCHE_TOURNEE, souteXYZ(), 0, fEcouler(), null);
+  assert.deepEqual(t.arrets.map((a) => a.terminal), ["Large"]);
+  assert.equal(t.resteScu, 0);
+  assert.equal(t.encaisse, 30 * 100);
+  // Le tri par profit, lui, partirait chez « Riche » — et coûterait un arrêt de plus pour finir.
+  assert.equal(offloadPlan(MARCHE_TOURNEE, souteXYZ(), 0, fEcouler(), null)[0].terminal, "Riche");
+});
+
+test("tournée : la meilleure « à un arrêt de plus » est proposée, avec son écart (ADR-007)", () => {
+  // L'arbitrage ne se tranche pas par un seuil : l'app ne sait pas si tu as le temps. Elle montre
+  // les deux et rend la décision à qui a le contexte.
+  const { tournee, alternative } = tourneesEcoulement(MARCHE_TOURNEE, souteXYZ(), 0, fEcouler(), null);
+  assert.equal(tournee.arrets.length, 1);
+  assert.deepEqual(alternative.arrets.map((a) => a.terminal), ["Riche", "Large"]);
+  assert.equal(alternative.encaisse, 10 * 1000 + 20 * 100);
+  assert.equal(alternative.ecart, alternative.encaisse - tournee.encaisse);
+  assert.ok(alternative.ecartPct > 0);
+});
+
+test("tournée : la station où l'on se trouve est un arrêt candidat, à coût de déplacement nul", () => {
+  // On vient justement d'y ramasser le butin. `offloadPlan` seul l'exclut toujours — c'est juste
+  // pour « où écouler AILLEURS », et faux pour une tournée.
+  const t = tourneeEcoulement(MARCHE_TOURNEE, souteXYZ(), 1, fEcouler(), null); // on EST à « Large »
+  assert.deepEqual(t.arrets.map((a) => a.terminal), ["Large"]);
+  assert.equal(t.resteScu, 0);
+  assert.equal(offloadPlan(MARCHE_TOURNEE, souteXYZ(), 1, fEcouler(), null).every((d) => d.terminal !== "Large"), true);
+});
+
+test("tournée : on ne repasse jamais deux fois au même comptoir (ADR-007)", () => {
+  // La capacité repousse par ticks en jeu, mais l'app n'a aucune donnée sur le débit de recharge.
+  // Attendre un tick n'est pas « tout écouler au plus vite » : le résidu ressort en « reste à bord »,
+  // pas en second passage fantôme.
+  const marche = {
+    terminals: [{ name: "Ici", system: "S" }, { name: "Petit", system: "S" }],
+    commodities: [{ name: "X", kind: "metal", illegal: false, buys: [], sells: [[1, 100, 40, 9e9, 3]] }],
+  };
+  const h = [{ name: "X", units: 100, paid: 0, from: "", at: 1 }];
+  const t = tourneeEcoulement(marche, h, 0, fEcouler(), null);
+  assert.equal(t.arrets.length, 1);
+  assert.equal(t.resteScu, 60); // 100 − 40, et on n'y retourne pas
+});
+
+test("tournée : les lignes qui ne s'écoulent nulle part sont NOMMÉES, pas oubliées", () => {
+  // 15 commodités sur 113 n'ont aucun débouché dans Pyro : c'est massif, pas marginal. Les taire
+  // ferait annoncer une soute vidée qui ne l'est pas.
+  const h = souteXYZ().concat([{ name: "Orphelin", units: 7, paid: 0, from: "", at: 1 }]);
+  const t = tourneeEcoulement(MARCHE_TOURNEE, h, 0, fEcouler(), null);
+  assert.deepEqual(t.sansDebouche, [{ name: "Orphelin", units: 7 }]);
+  assert.equal(t.resteScu, 7);
+});
+
+test("tournée : le résidu suit la CAPACITÉ et les FILTRES — jamais un sellAllAt brut", () => {
+  const marche = {
+    terminals: [{ name: "Ici", system: "S" }, { name: "A", system: "S" }],
+    commodities: [{ name: "Poudre", kind: "vice", illegal: true, buys: [], sells: [[1, 900, 40, 9e9, 3]] }],
+  };
+  const h = [{ name: "Poudre", units: 100, paid: 0, from: "", at: 1 }];
+  assert.equal(tourneeEcoulement(marche, h, 0, fEcouler(), null).resteScu, 60); // capacité 40 sur 100
+  assert.equal(sellAllAt(h, marche, 1, null).hold.length, 0); // la brique qu'il ne FAUT PAS employer
+  // …et les filtres de vue s'appliquent, comme partout ailleurs.
+  const t = tourneeEcoulement(marche, h, 0, fEcouler({ legalOnly: true }), null);
+  assert.equal(t.arrets.length, 0);
+  assert.equal(t.resteScu, 100);
+});
+
+test("tournée : bornée à 5 arrêts — au-delà, ce n'est plus « tout écouler au plus vite »", () => {
+  const n = 7;
+  const terminals = [{ name: "Ici", system: "S" }].concat(
+    Array.from({ length: n }, (_, i) => ({ name: `T${i}`, system: "S" })));
+  const commodities = Array.from({ length: n }, (_, i) => ({
+    name: `C${i}`, kind: "metal", illegal: false, buys: [], sells: [[i + 1, 100, null, 9e9, 3]],
+  }));
+  const h = commodities.map((c) => ({ name: c.name, units: 10, paid: 0, from: "", at: 1 }));
+  const t = tourneeEcoulement({ terminals, commodities }, h, 0, fEcouler(), null);
+  assert.equal(t.arrets.length, 5);
+  assert.equal(t.resteScu, 20); // deux lignes n'ont pas pu être servies, et ça se voit
+});
+
+test("tournée : un total bâti sur des capacités inconnues se dit PARIÉ, jamais garanti", () => {
+  // 307 des 1 879 points de vente publient leur capacité (16,3 %) : le nombre d'arrêts est un
+  // PLANCHER, presque toujours faux vers le bas. Il ne doit jamais s'afficher sans le dire.
+  const t = tourneeEcoulement(MARCHE_TOURNEE, souteXYZ(), 0, fEcouler(), null);
+  assert.equal(t.certitude, "inconnue");
+  assert.equal(t.garanti, 0);
+});
+
+test("tournée : sur les VRAIES données, la couverture l'emporte et l'alternative coûte UN arrêt", () => {
+  // La soute du contre-exemple de l'ADR-007 : une sortie butin en Pyro, 886 SCU sur 7 lignes.
+  // AUCUN montant n'est figé ici — les données se régénèrent, et un test adossé à un chiffre du
+  // jour se casse au premier `npm run build`. Ce qui est vérifié, c'est la FORME de l'arbitrage.
+  // Les avant-postes doivent rester ACTIVÉS : les destinations divergentes en sont toutes, et les
+  // exclure effondrerait les quatre tournées sur une seule — le cas intéressant disparaîtrait.
+  const noms = ["Janalite", "Hadanite", "Aphorite", "Dolivine", "Quantainium",
+    "Recycled Material Composite", "Titanium"];
+  const soute = noms
+    .filter((n) => REAL.commodities.some((c) => c.name === n))
+    .map((name, i) => ({ name, units: 10 * (i + 1), paid: 0, from: "", at: 1 }));
+  assert.ok(soute.length >= 4, `moins de 4 commodités du contre-exemple existent encore : ${soute.length}`);
+
+  const origine = REAL.terminals.findIndex((t) => t.system === "Pyro");
+  const f = fEcouler({ sysFilter: "Pyro" });
+  const { tournee, alternative } = tourneesEcoulement(REAL, soute, origine, f, null);
+
+  assert.ok(tournee.arrets.length >= 1, "aucun débouché trouvé pour une soute de butin en Pyro");
+  // Jamais deux fois le même comptoir : la capacité repousse par ticks, l'app n'en sait rien.
+  assert.equal(new Set(tournee.arrets.map((a) => a.idx)).size, tournee.arrets.length);
+  // COUVERTURE d'abord : aucun candidat ne reprend plus de lignes que le premier arrêt retenu.
+  const cands = offloadPlan(REAL, soute, origine, f, null, null, REAL.terminals.length, { inclureOrigine: true });
+  const maxLignes = Math.max(...cands.map((d) => d.lignes.length));
+  assert.equal(tournee.arrets[0].lignes.length, maxLignes);
+
+  if (alternative) {
+    assert.equal(alternative.arrets.length, tournee.arrets.length + 1); // UN arrêt de plus, pas deux
+    assert.ok(alternative.encaisse > tournee.encaisse);                 // et il doit se payer
+    assert.equal(alternative.ecart, alternative.encaisse - tournee.encaisse);
+    assert.ok(alternative.resteScu <= tournee.resteScu);                // sans vider moins
+  }
+});
+
+test("offloadPlan : l'origine reste exclue par défaut, incluse à la demande", () => {
+  assert.equal(offloadPlan(MARCHE_TOURNEE, souteXYZ(), 1, fEcouler(), null).every((d) => d.terminal !== "Large"), true);
+  const avec = offloadPlan(MARCHE_TOURNEE, souteXYZ(), 1, fEcouler(), null, null, 6, { inclureOrigine: true });
+  assert.ok(avec.some((d) => d.terminal === "Large"));
+  assert.equal(avec.find((d) => d.terminal === "Large").cross, false); // on y est : aucun saut
+});
+
+test("offloadPlan : le comparateur est injectable, et le tri par PROFIT reste le défaut", () => {
+  // Paramétrer plutôt que dupliquer : deux fonctions entretiendraient deux classements divergents,
+  // exactement le défaut que le dépôt corrige ailleurs.
+  assert.equal(offloadPlan(MARCHE_TOURNEE, souteXYZ(), 0, fEcouler(), null)[0].terminal, "Riche");
+  const parCouverture = offloadPlan(MARCHE_TOURNEE, souteXYZ(), 0, fEcouler(), null, null, 6,
+    { comparer: (a, b) => b.lignes.length - a.lignes.length });
+  assert.equal(parCouverture[0].terminal, "Large");
 });
 
 // ---------- Carte 2D du parcours (ADR-001) ----------

--- a/style.css
+++ b/style.css
@@ -1181,6 +1181,56 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 .comm-points .num { font-family: var(--mono); }
 .comm-detail .muted { color: var(--muted); }
 
+/* ---------- Tournée d'écoulement : la huitième vue (ADR-007) ---------- */
+.tour-wrap { display: flex; flex-direction: column; gap: 12px; margin-top: 16px; }
+.tour-head {
+  display: flex; flex-wrap: wrap; align-items: baseline; gap: 10px 16px; padding: 12px 16px;
+  background: var(--panel); border: 1px solid var(--line); border-left: 2px solid var(--good);
+}
+.tour-titre { font-size: 10px; letter-spacing: 2px; text-transform: uppercase; color: var(--good); font-weight: 700; }
+.tour-bilan { font-size: 12px; color: var(--muted); }
+.tour-bilan b { font-family: var(--mono); color: var(--text); }
+.tour-reste { color: var(--warn) !important; }
+.tour-total { margin-left: auto; font-family: var(--mono); font-size: 18px; font-weight: 700; color: var(--good); }
+.tour-total span { font-size: 10px; color: var(--muted); font-weight: 400; letter-spacing: 1px; }
+/* Le PLANCHER, dit avant les chiffres : un point de vente sur six publie sa capacité, donc le
+   nombre d'arrêts est presque toujours faux vers le bas. Un total ne s'affiche jamais sans dire
+   s'il est garanti ou parié (ADR-007 §8). */
+.tour-plancher { padding: 8px 14px; font-size: 11.5px; line-height: 1.5; border-left: 2px solid; }
+.tour-plancher.parie { color: var(--warn); border-color: var(--warn); background: rgba(245, 167, 66, 0.06); }
+.tour-plancher.sur { color: var(--good); border-color: var(--good); background: rgba(70, 229, 160, 0.05); }
+.tour-plancher b { color: inherit; }
+.tour-orphelines {
+  padding: 8px 14px; font-size: 11.5px; line-height: 1.6; color: var(--text);
+  border-left: 2px solid var(--bad); background: rgba(255, 93, 93, 0.05);
+}
+.tour-orph { display: inline-block; margin: 0 8px 0 0; font-family: var(--mono); font-size: 11px; color: var(--bad); }
+.tour-arrets { display: flex; flex-direction: column; gap: 8px; }
+.tour-arret { padding: 10px 14px; background: var(--panel); border: 1px solid var(--line); border-left: 2px solid var(--acc); }
+.tour-arret-head { display: flex; flex-wrap: wrap; align-items: baseline; gap: 10px; }
+.tour-n {
+  font-family: var(--mono); font-size: 11px; width: 20px; height: 20px; flex-shrink: 0;
+  display: grid; place-items: center; color: var(--acc); border: 1px solid var(--line2);
+}
+.tour-nom { font-weight: 600; font-size: 13px; }
+.tour-lignes-n { font-size: 11px; color: var(--muted); }
+.tour-lignes-n b { font-family: var(--mono); color: var(--text); }
+.tour-encaisse { margin-left: auto; font-family: var(--mono); font-size: 13px; color: var(--good); }
+.tour-arret-lignes { display: flex; flex-wrap: wrap; gap: 4px 14px; margin-top: 6px; font-size: 11px; color: var(--muted); }
+.tour-ligne b { font-family: var(--mono); color: var(--text); }
+.tour-ligne.perte b { color: var(--bad); }
+.tour-arret-meta { margin-top: 6px; font-size: 10.5px; color: var(--muted); }
+/* L'alternative « un arrêt de plus » : l'ordre reste lexicographique strict, c'est l'utilisateur
+   qui arbitre — l'app ne sait pas s'il a le temps. */
+.tour-alt { padding: 10px 14px; border: 1px dashed var(--line2); background: rgba(255, 176, 32, 0.04); }
+.tour-alt-head { font-size: 12px; color: var(--text); }
+.tour-alt-head b { font-family: var(--mono); }
+.tour-alt-chemin { margin-top: 5px; font-size: 12px; }
+.tour-fleche { color: var(--muted); }
+.tour-alt-note { margin-top: 4px; font-size: 10.5px; }
+.tour-vide { padding: 14px 16px; background: var(--panel); border: 1px solid var(--line); }
+.tour-vide p { margin: 0; font-size: 12px; line-height: 1.6; }
+
 /* ---------- Plan de vol : la vue de conclusion (ADR-004) ---------- */
 /* Deux niveaux : la carte du parcours EN GRAND (c'est ce qui justifie la vue), puis le
    récapitulatif en deux colonnes sous elle. Rien n'est actionnable ici, sauf la copie. */


### PR DESCRIPTION
## Ce que ça change

Une **huitième vue, « Tournée »** (raccourci `8`) : tu rentres d'une sortie butin, la soute porte
sept commodités que tu n'as pas payées, et ce que tu veux n'est pas le meilleur prix de chacune mais
**la suite d'arrêts qui vide tout**. Un comptoir qui reprend trois commodités à prix moyen bat donc
un comptoir qui n'en reprend qu'une au meilleur prix.

C'est le **second livrable de #57**, après l'ADR-007 (#94).

## Pourquoi

« Où écouler » répond à « **combien puis-je en tirer** » et classe par profit. La tournée répond à
« **comment me débarrasser de ça** ». Les deux questions sont incompatibles, un seul classement ne
peut pas servir les deux — et le dépôt a **déjà tranché deux fois en sens opposés** sur cet axe
(`68fc1f7`, `d41d9cd`). L'ADR-007 écrit pourquoi les deux vues coexistent ; **l'aide de la vue le
dit à l'écran**, ce qui est une exigence de l'ADR et pas du confort : sans cette phrase, l'app se
contredit sous les yeux de l'utilisateur.

### Les décisions qui se voient dans le code

- **Ordre lexicographique strict** — la tournée la plus courte gagne toujours — et la meilleure
  **« à un arrêt de plus »** affichée à côté avec son écart chiffré. Un seuil serait un paramètre
  invérifiable : l'app ne sait pas si tu as le temps.
- **`offloadPlan` est PARAMÉTRÉ, pas dupliqué** : un drapeau pour inclure l'origine (la station où
  l'on est peut être le meilleur premier arrêt, à coût nul — on vient d'y ramasser le butin) et un
  comparateur injectable. Les deux défauts restent ceux d'« où écouler ».
- **Le résidu se construit sur `absorbe`, jamais avec `sellAllAt`** : celui-ci ignore la capacité
  **et** les filtres de vue. Une tournée bâtie dessus annoncerait des arrêts plus courts que la
  réalité et vendrait ce que les filtres viennent d'écarter. C'est le piège le plus facile à rater.
- **On ne repasse jamais deux fois au même comptoir** : la capacité repousse par ticks en jeu, mais
  l'app n'a aucune donnée sur le débit de recharge. Le résidu ressort en « reste à bord ».
- **Le plancher est dit AVANT les chiffres** : 307 des 1 879 points de vente publient leur capacité.
  Le nombre d'arrêts est presque toujours faux vers le bas, et la tournée se recalcule après chaque
  arrêt réel.
- **Les lignes qui ne s'écoulent nulle part sont nommées** — 15 commodités sur 113 n'ont aucun
  débouché dans Pyro. Les taire ferait annoncer une soute vidée qui ne l'est pas.

Le glouton par couverture maximale n'est pas un pis-aller : c'est SET COVER, et le glouton atteint
**exactement** la borne de Feige (1998). La moitié « ordonnancement » est dégénérée faute de matrice
de distances — `market.json` n'a aucune coordonnée, 161 routes sur 316 portent une distance.

## Vérification

```
node --test           ℹ tests 470 · ℹ pass 470 · ℹ fail 0   (459 avant : 11 tests neufs)
npx playwright test   174 passed · 2 skipped (1,2 min)      (164 avant : 10 tests neufs)
```

**Le noyau a été écrit en rouge d'abord** : les 10 tests unitaires de `tourneeEcoulement` /
`tourneesEcoulement` ont fait tomber tout le module (import inexistant) avant l'implémentation.

**Et il a été confronté aux vraies données** — le contre-exemple de l'ADR retombe au chiffre près :

```
TOURNEE     : Ruin Station (7 lignes)   1 arrêt · reste 0 SCU · 62,64 M
ALTERNATIVE : Jackson's Swap (1) → Ruin Station (6)   2 arrêts · 66,24 M · +3,60 M (+5,7 %)
```

Le test « sur les VRAIES données » **ne fige aucun montant** — les données se régénèrent, et un test
adossé au chiffre du jour se casse au premier `npm run build`. Il vérifie la **forme** de
l'arbitrage : couverture maximale au premier arrêt, aucun comptoir visité deux fois, et une
alternative qui coûte exactement un arrêt pour un encaissement strictement supérieur.

**La vue a aussi été regardée**, pas seulement testée : sur une soute de minage (534 SCU, 4 lignes,
depuis Checkmate), elle rend **1 arrêt — Ruin Station, soute vidée** avec l'alternative
**Canard View → Ruin Station à +2 560 000 (+23,4 %)**. C'est exactement le second scénario que
l'ADR annonçait.

## Ce qui n'est pas couvert

- **La hiérarchie du rail** : la Tournée est une huitième entrée **en fin de liste**, révisable par
  #45 — la dernière issue de `v1.1.0`.
- **Le faisceau large** : l'alternative déroule au plus 3 premiers arrêts forcés. Élargir n'est utile
  que si le glouton myope déçoit sur des cas réels — pas d'optimisation préventive.
- **La `Map` nom → commodité** qui supprimerait le `find` niché : bonne idée, explicitement pas un
  prérequis (glouton complet mesuré à 0,13 ms en portée Pyro).
- **Déposer depuis la vue** : `storeFromHold` existe et l'ADR prévoit de ne le proposer qu'au
  **dernier** arrêt. Non câblé ici — la vue nomme les lignes orphelines et renvoie vers le dépôt du
  bandeau.
- **#22** et **#21** : la tournée lit la soute, elle n'en corrige pas la tenue.

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)