### PR TITLE
feat(menu): le rail se lit du général au particulier, et le numéro dit la touche

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,22 @@ reconstruites/redéployées **quand UEX a réellement changé** — et le site e
 
 ## Fonctionnalités
 
-Huit vues, un même moteur de calcul (soute SCU + budget aUEC → unités, coût, profit/voyage, profit/heure) :
+Huit vues, un même moteur de calcul (soute SCU + budget aUEC → unités, coût, profit/voyage,
+profit/heure). Le menu les range **du général au particulier, les réglages en dernier** — recherche
+de fret, marché, soute, conclusion, réglage — et **« En route » est une sous-entrée de « Trajets »** :
+c'est la même question, posée depuis un point de départ donné. Le numéro affiché est la touche qui
+ouvre la vue.
 
 | Vue | Ce qu'elle fait |
 |-----|-----------------|
 | **Trajets simples** | Meilleures routes A→B, triables, triées par **profit net** par défaut. Une colonne **Fiabilité** dit ce qu'on sait de la donnée — fraîcheur du relevé × part du volume publiée par UEX — **sans entrer dans le tri** ([ADR-005](docs/superpowers/specs/2026-08-14-refonte-du-score-adr.md)). Coche **Multi commodité** : liste plutôt les **chargements combinés** (plusieurs commodités d'un même A vers un même B), dépliables (📦) pour voir le détail par commodité |
+| **↳ En route 🧭** | *Sous-entrée de Trajets.* Depuis un terminal de départ : le fret rentable + un **manifeste optimal** qui remplit la soute avec **plusieurs commodités** vers une même destination (avec suggestions pour combler l'espace libre) |
 | **Boucles ⇄** | Meilleures boucles A⇄B (une commodité à l'aller, une autre au retour) pour ne jamais repartir à vide |
-| **En route 🧭** | Depuis un terminal de départ : le fret rentable + un **manifeste optimal** qui remplit la soute avec **plusieurs commodités** vers une même destination (avec suggestions pour combler l'espace libre) |
 | **Chaîne ⛓️** | Trajets **multi-sauts A→B→C…** (2 à 4 sauts) : achète, vends, rachète sur place, revends plus loin — recherche par faisceau du circuit le plus rentable. Chaque saut transporte un **manifeste multi-commodités** détaillé sur la carte : quand le stock au départ ou la demande à l'arrivée ne suffit pas à remplir la soute, le reste se comble avec d'autres commodités, exactement comme « En route » |
-| **Corrections ✎** | Ses corrections locales **rangées par station** (bande de vignettes), et de quoi en créer via un sélecteur groupé `système › zone › station` (voir plus bas) |
 | **Commodités 📊** | *Big board* type « salle des marchés », en deux modes. **◈ Marché** : toutes les commodités échangeables avec leur **code officiel UEX** (AGRI, QUAN…), triables (marge / code / catégorie), et au clic **tous leurs points d'achat et de vente** — pratique pour trouver **où écouler** une commodité quand une station n'a plus de demande. **💰 Butin** : le board bascule sur le **prix de revente au SCU** et fait entrer les commodités qu'on **ne peut pas acheter** (minerais raffinés, salvage, drogues de wreck) — la réponse à « j'ai trouvé ça, ça vaut combien et où je l'écoule ? » |
-| **Plan de vol 🗺️** | La **conclusion** : une fois tout paramétré, le récapitulatif de ce qui est engagé — la **carte du parcours en grand** (elle ne vit plus que là), la soute commodité par commodité avec la place libre et le capital engagé, le parcours étape par étape, la jambe en cours et son manifeste, ce qu'il reste à faire. **On n'y change rien** : la barre de filtres y est masquée, et les quatre réglages qui donnent leur sens aux chiffres (vaisseau, soute, budget, frais d'autoload) y sont **repris en texte, en lecture seule** — une conclusion énonce ses hypothèses au lieu de les offrir à la modification. Un bouton **⧉ Copier le récapitulatif** en sort le texte, à coller dans un salon ([ADR-004](docs/superpowers/specs/2026-08-14-plan-de-vol-adr.md)) |
 | **Tournée 📦** | **Vider la soute en un minimum d'arrêts**, l'argent n'arbitrant qu'à nombre d'arrêts égal — un comptoir qui reprend trois commodités à prix moyen bat un comptoir qui n'en reprend qu'une au meilleur prix. C'est l'**inverse** de « où écouler », qui classe par ce que ça rapporte : les deux questions sont différentes, et celle-ci répond à « je ne veux plus porter ça » (le cas d'une sortie butin). La tournée est un **plancher** — un point de vente sur six seulement publie sa capacité — et se recalcule après chaque arrêt réel. La meilleure tournée **à un arrêt de plus** s'affiche à côté, avec son écart chiffré : l'app ne sait pas si tu as le temps ([ADR-007](docs/superpowers/specs/2026-08-15-tournee-ecoulement-adr.md)) |
+| **Plan de vol 🗺️** | La **conclusion** : une fois tout paramétré, le récapitulatif de ce qui est engagé — la **carte du parcours en grand** (elle ne vit plus que là), la soute commodité par commodité avec la place libre et le capital engagé, le parcours étape par étape, la jambe en cours et son manifeste, ce qu'il reste à faire. **On n'y change rien** : la barre de filtres y est masquée, et les quatre réglages qui donnent leur sens aux chiffres (vaisseau, soute, budget, frais d'autoload) y sont **repris en texte, en lecture seule** — une conclusion énonce ses hypothèses au lieu de les offrir à la modification. Un bouton **⧉ Copier le récapitulatif** en sort le texte, à coller dans un salon ([ADR-004](docs/superpowers/specs/2026-08-14-plan-de-vol-adr.md)) |
+| **Corrections ✎** | *Un réglage, pas une vue d'analyse — d'où la dernière place.* Ses corrections locales **rangées par station** (bande de vignettes), et de quoi en créer via un sélecteur groupé `système › zone › station` (voir plus bas) |
 
 Autres éléments :
 
@@ -76,18 +80,18 @@ d'aucune soute à remplir — le fret est déjà à bord. Elle honore en revanch
 filtres qu'« où écouler » (avant-postes, commodités légales, fraîcheur, système), plus **sa propre
 portée** : le système courant par défaut, ouvrable aux autres d'un menu.
 
-| Filtre | Trajets | Boucles | En route | Chaîne | Corrections | Commodités |
+| Filtre | Trajets | ↳ En route | Boucles | Chaîne | Commodités | Corrections |
 |--------|:-:|:-:|:-:|:-:|:-:|:-:|
 | Soute (SCU) | ✅ | ✅ | ✅ | ✅ | — | — |
 | Budget | ✅ | ✅ | ✅ | —¹ | — | — |
-| Commodité (recherche) | ✅ | ✅ | ✅ | —² | station | ✅ (tableau) |
-| Système d'achat | ✅ | ✅ | —³ | —³ | — | — |
+| Commodité (recherche) | ✅ | ✅ | ✅ | —² | ✅ (tableau) | station |
+| Système d'achat | ✅ | —³ | ✅ | —³ | — | — |
 | Fraîcheur | ✅ | ✅ | ✅ | ✅ | — | — |
 | Même système | ✅ | ✅ | ✅ | ✅ | — | — |
-| Exclure avant-postes | ✅ | ✅ | ✅ | ✅ | — | ✅ |
-| Légales uniquement | ✅ | ✅ | ✅ | ✅ | — | ✅ |
+| Exclure avant-postes | ✅ | ✅ | ✅ | ✅ | ✅ | — |
+| Légales uniquement | ✅ | ✅ | ✅ | ✅ | ✅ | — |
 | Stock & demande | ✅ | ✅ | ✅ | ✅⁴ | — | — |
-| Frais d'autoload | ✅ | ✅ | ✅ | ✅ | — | —⁵ |
+| Frais d'autoload | ✅ | ✅ | ✅ | ✅ | —⁵ | — |
 
 ¹ Le budget se reconstitue à chaque vente → non pertinent pour une chaîne. Le **remplissage** de
 chaque saut l'ignore donc lui aussi : reprise dans le Voyage, qui le consomme, une jambe peut

--- a/app.js
+++ b/app.js
@@ -3175,15 +3175,25 @@ function startEdit(span) {
 // Met à jour le libellé du bouton de vue « Corrections » (compteur).
 function updateOvBadge() {
   const n = ovCount();
-  const libelle = n ? `✎ Corrections (${n})` : "✎ Corrections";
+  const bouton = $("viewCorrections");
+  const rl = bouton.querySelector(".rl");
   // On écrit DANS le .rl, au lieu d'écraser le bouton entier en textContent : cette écriture-là
   // détruisait le <span class="rn">, et le numéro de Corrections n'a donc jamais existé à l'écran
   // (#45). Le rail annonce une touche par numéro — il ne peut pas en manquer un sur huit.
-  $("viewCorrections").querySelector(".rl").textContent = libelle;
+  rl.textContent = "Corrections";
+  // Le compteur en plus petit, sans interlettrage : mesuré, il rend 20 px au libellé. Sans lui
+  // « Corrections (123) » repart à la ligne, et le bouton fait deux fois la hauteur des sept
+  // autres — un rail qui cède quand la place manque, c'est le symptôme de #86.
+  if (n) {
+    const compteur = document.createElement("span");
+    compteur.className = "ov-n";
+    compteur.textContent = `(${n})`;
+    rl.append(" ", compteur);
+  }
   // Le libellé étant maintenant dans un .rl, il disparaît au rail rétracté : l'aria-label est le
   // seul à porter le compteur à ce moment-là, et il doit donc suivre. Même geste que
   // copyShareLink() sur #share.
-  $("viewCorrections").setAttribute("aria-label", libelle);
+  bouton.setAttribute("aria-label", n ? `Corrections (${n})` : "Corrections");
 }
 
 function resetAllOverrides() {
@@ -3394,7 +3404,7 @@ function copierCorrections() {
 
 // Liste des relevés d'autoload, à côté des corrections locales et sur le même modèle : ils sont de
 // la même nature (mesures faites en jeu, purement locales), mais ils ne comptent PAS dans le badge
-// « ✎ Corrections (n) » et « Tout réinitialiser » ne les touche pas — ils ont leur propre store.
+// « Corrections (n) » du rail et « Tout réinitialiser » ne les touche pas — ils ont leur propre store.
 function autoloadListHTML() {
   const keys = Object.keys(AUTOLOAD_K);
   if (!keys.length) return "";

--- a/app.js
+++ b/app.js
@@ -3175,7 +3175,15 @@ function startEdit(span) {
 // Met à jour le libellé du bouton de vue « Corrections » (compteur).
 function updateOvBadge() {
   const n = ovCount();
-  $("viewCorrections").textContent = n ? `✎ Corrections (${n})` : "✎ Corrections";
+  const libelle = n ? `✎ Corrections (${n})` : "✎ Corrections";
+  // On écrit DANS le .rl, au lieu d'écraser le bouton entier en textContent : cette écriture-là
+  // détruisait le <span class="rn">, et le numéro de Corrections n'a donc jamais existé à l'écran
+  // (#45). Le rail annonce une touche par numéro — il ne peut pas en manquer un sur huit.
+  $("viewCorrections").querySelector(".rl").textContent = libelle;
+  // Le libellé étant maintenant dans un .rl, il disparaît au rail rétracté : l'aria-label est le
+  // seul à porter le compteur à ce moment-là, et il doit donc suivre. Même geste que
+  // copyShareLink() sur #share.
+  $("viewCorrections").setAttribute("aria-label", libelle);
 }
 
 function resetAllOverrides() {
@@ -3930,14 +3938,17 @@ async function init() {
     if (el && (el.tagName === "INPUT" || el.tagName === "SELECT" || el.tagName === "TEXTAREA" ||
                el.getAttribute("role") === "button" || el.classList.contains("editv"))) return;
     if (e.key === "/") { e.preventDefault(); $("search").focus(); }
+    // L'ordre suit celui du rail (#45), et c'est le contrat : le numéro lu sur un bouton EST la
+    // touche qui l'ouvre. Quatre destinations changent de touche — le prix payé une fois pour que
+    // les deux se disent la même chose.
     else if (e.key === "1") switchView("routes");
-    else if (e.key === "2") switchView("loops");
-    else if (e.key === "3") switchView("enroute");
+    else if (e.key === "2") switchView("enroute");
+    else if (e.key === "3") switchView("loops");
     else if (e.key === "4") switchView("chain");
-    else if (e.key === "5") switchView("corrections");
-    else if (e.key === "6") switchView("commodities");
+    else if (e.key === "5") switchView("commodities");
+    else if (e.key === "6") switchView("tour");
     else if (e.key === "7") switchView("plan");
-    else if (e.key === "8") switchView("tour");
+    else if (e.key === "8") switchView("corrections");
   });
   loadOverrides();
   loadAutoloadK();

--- a/docs/superpowers/specs/2026-08-14-plan-de-vol-adr.md
+++ b/docs/superpowers/specs/2026-08-14-plan-de-vol-adr.md
@@ -126,6 +126,13 @@ Décision volontairement **révisable par #45**, qui refond la hiérarchie du me
 cet ADR ajoute une entrée, il ne réorganise pas le rail. Si #45 introduit des sous-entrées, le Plan
 de vol trouvera sa place dans cette hiérarchie plutôt qu'au bout d'une liste plate.
 
+> **Révisé par #45 (2026-08-15).** C'est arrivé : le Plan de vol est **septième sur huit**, devant
+> « ✎ Corrections ». Le principe tient — une conclusion se lit après ce qui la produit — mais il
+> s'arrête à ce qui produit quelque chose : un **réglage** se lit après une conclusion. La crainte
+> de renuméroter des raccourcis appris ne l'a pas emporté, pour une raison que cet ADR ne pouvait
+> pas voir depuis une seule entrée : le rail affiche un numéro par vue, et un numéro qui ne désigne
+> pas la touche qui l'active ne vaut rien. Le Plan de vol garde d'ailleurs sa touche `7`.
+
 ### 8. Le bouton de capture produit du **texte**, pas une image
 
 Le besoin : envoyer son voyage à un collègue.

--- a/e2e/autoload.pw.mjs
+++ b/e2e/autoload.pw.mjs
@@ -346,7 +346,8 @@ test("relevé de station : k déduit d'un montant observé, persistant, hors du 
   // Un relevé n'est PAS une correction de prix. Le compteur du bouton « ✎ Corrections » compte les
   // clés du store des corrections : si les relevés y atterrissaient, il afficherait « (1) » ici.
   // C'est exactement ce que garantit le choix d'un store localStorage séparé.
-  await expect(page.locator("#viewCorrections")).toHaveText("✎ Corrections");
+  // Le libellé se lit dans son .rl : le bouton porte aussi son numéro de rail depuis #45.
+  await expect(page.locator("#viewCorrections .rl")).toHaveText("✎ Corrections");
   // Ni dans le lien (il est local, comme les corrections).
   expect(await page.evaluate(() => location.hash)).not.toContain("1159");
 

--- a/e2e/autoload.pw.mjs
+++ b/e2e/autoload.pw.mjs
@@ -343,11 +343,11 @@ test("relevé de station : k déduit d'un montant observé, persistant, hors du 
   await page.click("#alSave");
   await expect(page.locator(".corr-item.autoload")).toContainText("1,41");
 
-  // Un relevé n'est PAS une correction de prix. Le compteur du bouton « ✎ Corrections » compte les
+  // Un relevé n'est PAS une correction de prix. Le compteur du bouton « Corrections » compte les
   // clés du store des corrections : si les relevés y atterrissaient, il afficherait « (1) » ici.
   // C'est exactement ce que garantit le choix d'un store localStorage séparé.
   // Le libellé se lit dans son .rl : le bouton porte aussi son numéro de rail depuis #45.
-  await expect(page.locator("#viewCorrections .rl")).toHaveText("✎ Corrections");
+  await expect(page.locator("#viewCorrections .rl")).toHaveText("Corrections");
   // Ni dans le lien (il est local, comme les corrections).
   expect(await page.evaluate(() => location.hash)).not.toContain("1159");
 

--- a/e2e/rail.pw.mjs
+++ b/e2e/rail.pw.mjs
@@ -1,0 +1,118 @@
+import { test, expect } from "@playwright/test";
+
+// La hiérarchie du rail (#45). Huit vues se sont accumulées une par une, chacune ajoutée en fin de
+// liste : l'ordre raconte l'historique du dépôt, pas la parenté des vues. « En route » est une
+// lecture des trajets depuis un point de départ, pas une famille à part ; « Corrections » est un
+// réglage, et passait avant les vues d'analyse.
+//
+// Le rail se lit maintenant du général au particulier, et les réglages ferment la marche :
+//   recherche de fret │ marché │ soute │ conclusion │ réglage
+//
+// Ces tests tiennent l'INVARIANT que le réordonnancement doit préserver : un numéro affiché
+// désigne la touche qui l'active. Sans lui, autant retirer les numéros.
+
+const ORDRE = ["routes", "enroute", "loops", "chain", "commodities", "tour", "plan", "corrections"];
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/index.html");
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+});
+
+test("Rail : les huit vues se suivent du général au particulier, réglages en dernier (#45)", async ({ page }) => {
+  const vus = await page.locator(".rail-nav .vbtn").evaluateAll((els) => els.map((e) => e.dataset.view));
+  expect(vus).toEqual(ORDRE);
+});
+
+test("Rail : « En route » se donne pour une sous-entrée de Trajets (#45)", async ({ page }) => {
+  await expect(page.locator("#viewEnroute")).toHaveClass(/vbtn-sub/);
+  // Une seule sous-entrée : le rail a deux niveaux, pas trois, et rien d'autre ne s'indente.
+  await expect(page.locator(".rail-nav .vbtn-sub")).toHaveCount(1);
+
+  // Le filet passe par un ::before et NON par border-left : celui-ci est déjà l'accent de
+  // .vbtn.active (style.css), et le marqueur de sous-niveau se serait évanoui pile quand la vue
+  // est active — c'est-à-dire quand on la regarde.
+  const filet = () =>
+    page.evaluate(() => {
+      const cs = getComputedStyle(document.getElementById("viewEnroute"), "::before");
+      return { largeur: parseFloat(cs.width), contenu: cs.content };
+    });
+
+  const auRepos = await filet();
+  expect(auRepos.contenu).not.toBe("none");
+  expect(auRepos.largeur).toBeGreaterThan(0);
+
+  await page.click("#viewEnroute");
+  await expect(page.locator("#viewEnroute")).toHaveClass(/active/);
+  const actif = await filet();
+  expect(actif.largeur).toBeGreaterThan(0); // survit à l'état actif
+});
+
+test("Rail : chaque numéro affiché désigne la touche qui l'ouvre, des huit côtés (#45)", async ({ page }) => {
+  for (let n = 1; n <= 8; n++) {
+    await page.keyboard.press(String(n));
+    const actif = page.locator(".rail-nav .vbtn.active");
+    await expect(actif, `la touche ${n} n'active pas exactement une vue`).toHaveCount(1);
+    await expect(actif.locator(".rn"), `le numéro affiché ne suit pas la touche ${n}`)
+      .toHaveText(String(n).padStart(2, "0"));
+    // Le title l'annonce aussi : les trois doivent dire la même chose.
+    await expect(actif).toHaveAttribute("title", new RegExp(`raccourci\\s*:\\s*${n}\\b`));
+    await expect(actif).toHaveAttribute("data-view", ORDRE[n - 1]);
+  }
+});
+
+test("Rail : Corrections porte enfin son numéro, compteur compris (#45)", async ({ page }) => {
+  // Le balisage mort de l'ancien rail : updateOvBadge() écrasait tout le contenu du bouton en
+  // textContent, détruisant le <span class="rn"> posé dans index.html. Le numéro de Corrections
+  // n'a jamais existé à l'écran — le réordonnancement ne vaut rien s'il le laisse muet.
+  await expect(page.locator("#viewCorrections .rn")).toHaveText("08");
+  await expect(page.locator("#viewCorrections .rl")).toHaveText("✎ Corrections");
+
+  const cell = page.locator("#rows .editv").first();
+  await cell.click();
+  await cell.locator("input").fill("12345");
+  await page.keyboard.press("Enter");
+
+  // Après réécriture du bouton par updateOvBadge : le numéro tient, le compteur arrive.
+  await expect(page.locator("#viewCorrections .rn")).toHaveText("08");
+  await expect(page.locator("#viewCorrections .rl")).toHaveText("✎ Corrections (1)");
+  // Et le compteur reste dans le NOM ACCESSIBLE. Le libellé passant en .rl (masqué au repli),
+  // le bouton gagne un aria-label tenu à jour — même patron que #share.
+  await expect(page.locator("#viewCorrections")).toHaveAccessibleName(/Corrections \(1\)/);
+});
+
+test("Rail rétracté : les huit entrées restent distinctes, et le repli survit au rechargement (#45)", async ({ page }) => {
+  await page.click("#railToggle");
+  await expect(page.locator("#app")).toHaveClass(/rail-collapsed/);
+
+  // Le cas le plus contraint : 68 px, tous les .rl masqués. Les huit doivent rester cliquables.
+  for (const v of ORDRE) {
+    const btn = page.locator(`.rail-nav .vbtn[data-view="${v}"]`);
+    await expect(btn, `${v} a disparu du rail rétracté`).toBeVisible();
+    const boite = await btn.boundingBox();
+    expect(boite.width, `${v} déborde des 68 px du rail rétracté`).toBeLessThanOrEqual(68);
+  }
+
+  // La parenté ne doit pas être le seul retrait typographique : replié, il n'en reste rien.
+  const largeurFilet = await page.evaluate(() =>
+    parseFloat(getComputedStyle(document.getElementById("viewEnroute"), "::before").width));
+  expect(largeurFilet).toBeGreaterThan(0);
+
+  await page.reload();
+  await expect(page.locator("#app")).toHaveClass(/rail-collapsed/);
+  await expect(page.locator("#viewEnroute")).toHaveClass(/vbtn-sub/);
+});
+
+test("Rail horizontal : la sous-entrée garde un marqueur quand le rail passe en ligne (#45)", async ({ page }) => {
+  // Sous 820 px, .rail-nav bascule en flex-direction: row — une indentation verticale n'y veut
+  // plus rien dire. Le filet, lui, borde le côté qui touche Trajets.
+  await page.setViewportSize({ width: 760, height: 900 });
+  await expect(page.locator(".rail-nav")).toHaveCSS("flex-direction", "row");
+
+  const largeurFilet = await page.evaluate(() =>
+    parseFloat(getComputedStyle(document.getElementById("viewEnroute"), "::before").width));
+  expect(largeurFilet).toBeGreaterThan(0);
+
+  // Et l'ordre tient : en ligne, la sous-entrée suit immédiatement son parent.
+  const vus = await page.locator(".rail-nav .vbtn").evaluateAll((els) => els.map((e) => e.dataset.view));
+  expect(vus.slice(0, 2)).toEqual(["routes", "enroute"]);
+});

--- a/e2e/rail.pw.mjs
+++ b/e2e/rail.pw.mjs
@@ -65,7 +65,7 @@ test("Rail : Corrections porte enfin son numéro, compteur compris (#45)", async
   // textContent, détruisant le <span class="rn"> posé dans index.html. Le numéro de Corrections
   // n'a jamais existé à l'écran — le réordonnancement ne vaut rien s'il le laisse muet.
   await expect(page.locator("#viewCorrections .rn")).toHaveText("08");
-  await expect(page.locator("#viewCorrections .rl")).toHaveText("✎ Corrections");
+  await expect(page.locator("#viewCorrections .rl")).toHaveText("Corrections");
 
   const cell = page.locator("#rows .editv").first();
   await cell.click();
@@ -74,10 +74,27 @@ test("Rail : Corrections porte enfin son numéro, compteur compris (#45)", async
 
   // Après réécriture du bouton par updateOvBadge : le numéro tient, le compteur arrive.
   await expect(page.locator("#viewCorrections .rn")).toHaveText("08");
-  await expect(page.locator("#viewCorrections .rl")).toHaveText("✎ Corrections (1)");
+  await expect(page.locator("#viewCorrections .rl")).toHaveText("Corrections (1)");
   // Et le compteur reste dans le NOM ACCESSIBLE. Le libellé passant en .rl (masqué au repli),
   // le bouton gagne un aria-label tenu à jour — même patron que #share.
   await expect(page.locator("#viewCorrections")).toHaveAccessibleName(/Corrections \(1\)/);
+});
+
+test("Rail : Corrections tient sur UNE ligne, compteur compris (#45)", async ({ page }) => {
+  // Le numéro a pris 26 px des 144 px du bouton, et l'ancien « ✎ Corrections (1) » (125 px pour
+  // 118 px de place) repartait à la ligne : le bouton faisait 57 px contre 40 pour ses voisins.
+  // Défaut invisible aux assertions de contenu — il ne se voit qu'à l'écran, d'où ce test sur la
+  // GÉOMÉTRIE. Le « ✎ » a été retiré (20 px) et le compteur réduit : « Corrections (123) » tient.
+  const hauteur = async (id) => (await page.locator(`#${id}`).boundingBox()).height;
+  const reference = await hauteur("viewRoutes");
+
+  const cell = page.locator("#rows .editv").first();
+  await cell.click();
+  await cell.locator("input").fill("12345");
+  await page.keyboard.press("Enter");
+  await expect(page.locator("#viewCorrections .rl")).toHaveText("Corrections (1)");
+
+  expect(await hauteur("viewCorrections"), "le bouton Corrections passe à la ligne").toBe(reference);
 });
 
 test("Rail rétracté : les huit entrées restent distinctes, et le repli survit au rechargement (#45)", async ({ page }) => {

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -1156,14 +1156,14 @@ test("Soute : « où écouler » répond à une soute DÉCLARÉE, sans le moindr
 test("Soute : déclarer un lot ne corrige AUCUN stock de station (#55)", async ({ page }) => {
   // `✓ chargé` vide le rayon parce qu'on vient d'y acheter. Un lot déclaré n'a été pris nulle part
   // que l'app connaisse : y déduire quoi que ce soit serait inventer un achat.
-  await expect(page.locator("#viewCorrections")).toHaveText("✎ Corrections");
+  await expect(page.locator("#viewCorrections .rl")).toHaveText("✎ Corrections");
   await ouvrirDeclaration(page);
   const nom = (await commodites(page))[0];
   await page.fill("#holdAddName", nom);
   await page.fill("#holdAddScu", "9999");
   await page.locator("#holdAddOk").click();
 
-  await expect(page.locator("#viewCorrections")).toHaveText("✎ Corrections"); // compteur inchangé
+  await expect(page.locator("#viewCorrections .rl")).toHaveText("✎ Corrections"); // compteur inchangé
   const ov = await page.evaluate(() => localStorage.getItem("best-hauling-overrides"));
   expect(JSON.parse(ov || "{}")).toEqual({});
 });
@@ -2038,7 +2038,7 @@ test("service worker : les données atterrissent vraiment dans le cache", async 
 // ---------- Corrections locales & réactivité des filtres (#39, #49) ----------
 
 test("consulter un chiffre ne crée aucune correction locale", async ({ page }) => {
-  await expect(page.locator("#viewCorrections")).toHaveText("✎ Corrections"); // aucune au départ
+  await expect(page.locator("#viewCorrections .rl")).toHaveText("✎ Corrections"); // aucune au départ
   const cell = page.locator("#rows .editv").first();
   const avant = await cell.innerText();
 
@@ -2046,7 +2046,7 @@ test("consulter un chiffre ne crée aucune correction locale", async ({ page }) 
   await expect(cell.locator("input")).toBeVisible();
   await page.locator("h1").click(); // blur SANS rien modifier
 
-  await expect(page.locator("#viewCorrections")).toHaveText("✎ Corrections"); // toujours aucune
+  await expect(page.locator("#viewCorrections .rl")).toHaveText("✎ Corrections"); // toujours aucune
   await expect(page.locator("#rows .editv.ov")).toHaveCount(0);
   await expect(cell).toHaveText(avant); // l'affichage d'origine est restauré, ✎ compris
 

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -1156,14 +1156,14 @@ test("Soute : « où écouler » répond à une soute DÉCLARÉE, sans le moindr
 test("Soute : déclarer un lot ne corrige AUCUN stock de station (#55)", async ({ page }) => {
   // `✓ chargé` vide le rayon parce qu'on vient d'y acheter. Un lot déclaré n'a été pris nulle part
   // que l'app connaisse : y déduire quoi que ce soit serait inventer un achat.
-  await expect(page.locator("#viewCorrections .rl")).toHaveText("✎ Corrections");
+  await expect(page.locator("#viewCorrections .rl")).toHaveText("Corrections");
   await ouvrirDeclaration(page);
   const nom = (await commodites(page))[0];
   await page.fill("#holdAddName", nom);
   await page.fill("#holdAddScu", "9999");
   await page.locator("#holdAddOk").click();
 
-  await expect(page.locator("#viewCorrections .rl")).toHaveText("✎ Corrections"); // compteur inchangé
+  await expect(page.locator("#viewCorrections .rl")).toHaveText("Corrections"); // compteur inchangé
   const ov = await page.evaluate(() => localStorage.getItem("best-hauling-overrides"));
   expect(JSON.parse(ov || "{}")).toEqual({});
 });
@@ -2038,7 +2038,7 @@ test("service worker : les données atterrissent vraiment dans le cache", async 
 // ---------- Corrections locales & réactivité des filtres (#39, #49) ----------
 
 test("consulter un chiffre ne crée aucune correction locale", async ({ page }) => {
-  await expect(page.locator("#viewCorrections .rl")).toHaveText("✎ Corrections"); // aucune au départ
+  await expect(page.locator("#viewCorrections .rl")).toHaveText("Corrections"); // aucune au départ
   const cell = page.locator("#rows .editv").first();
   const avant = await cell.innerText();
 
@@ -2046,7 +2046,7 @@ test("consulter un chiffre ne crée aucune correction locale", async ({ page }) 
   await expect(cell.locator("input")).toBeVisible();
   await page.locator("h1").click(); // blur SANS rien modifier
 
-  await expect(page.locator("#viewCorrections .rl")).toHaveText("✎ Corrections"); // toujours aucune
+  await expect(page.locator("#viewCorrections .rl")).toHaveText("Corrections"); // toujours aucune
   await expect(page.locator("#rows .editv.ov")).toHaveCount(0);
   await expect(cell).toHaveText(avant); // l'affichage d'origine est restauré, ✎ compris
 

--- a/e2e/tournee.pw.mjs
+++ b/e2e/tournee.pw.mjs
@@ -30,7 +30,9 @@ async function tourneeDepuis(page, terminal = "Megumi") {
   await expect(page.locator("#tour .tour-arret").first()).toBeVisible({ timeout: 10_000 });
 }
 
-test("Tournée : une huitième entrée au rail, au clic comme au raccourci « 8 » (#57)", async ({ page }) => {
+// La Tournée est passée en SIXIÈME position au rail (#45) : elle lit la soute, elle appartient
+// donc à la famille « soute », entre le marché et la conclusion. Son raccourci a suivi son numéro.
+test("Tournée : une entrée au rail, au clic comme au raccourci « 6 » (#57, #45)", async ({ page }) => {
   await expect(page.locator("#viewTour")).toBeVisible();
   await page.click("#viewTour");
   await expect(page.locator("#tour")).toBeVisible();
@@ -41,7 +43,7 @@ test("Tournée : une huitième entrée au rail, au clic comme au raccourci « 8 
   await page.click("#viewRoutes");
   await expect(page.locator("#tour")).toBeHidden();
   await expect(page.locator("#tourControls")).toBeHidden(); // les contrôles ne fuient pas hors de leur vue
-  await page.keyboard.press("8");
+  await page.keyboard.press("6");
   await expect(page.locator("#tour")).toBeVisible();
 });
 

--- a/index.html
+++ b/index.html
@@ -91,10 +91,17 @@
              updateOvBadge() écrasait tout le bouton en textContent, ce texte survivait au repli et
              portait seul le nom accessible ; un aria-label statique y aurait figé le compteur. Il
              est maintenant masqué au repli comme les autres, donc l'aria-label est le seul à porter
-             « ✎ Corrections (3) » à ce moment-là — et updateOvBadge() le tient à jour AVEC le
+             « Corrections (3) » à ce moment-là — et updateOvBadge() le tient à jour AVEC le
              compteur, exactement comme copyShareLink() le fait pour #share. Le numéro, lui, cesse
-             d'être du balisage mort : il était détruit à chaque appel depuis toujours. -->
-        <button id="viewCorrections" class="vbtn" data-view="corrections" aria-label="✎ Corrections" title="Corrections locales (raccourci : 8)"><span class="rn">08</span><span class="rl">✎ Corrections</span></button>
+             d'être du balisage mort : il était détruit à chaque appel depuis toujours.
+
+             Le « ✎ » a disparu du libellé, et ce n'est pas de la coquetterie : MESURÉ, il coûte
+             20 px sur les 118 px que laisse le numéro, et « ✎ Corrections (12) » repartait à la
+             ligne — le bouton faisait deux fois la hauteur des sept autres. C'était d'ailleurs le
+             seul picto du rail, hérité de ce que ce libellé s'écrivait en JS au lieu d'être posé
+             ici comme les autres. Élargir le rail était l'autre voie : elle aggrave #86. -->
+
+        <button id="viewCorrections" class="vbtn" data-view="corrections" aria-label="Corrections" title="Corrections locales (raccourci : 8)"><span class="rn">08</span><span class="rl">Corrections</span></button>
       </div>
 
       <!-- Le libellé visible « Partager » OUVRE l'aria-label : sinon le nom accessible ne le

--- a/index.html
+++ b/index.html
@@ -60,27 +60,41 @@
       <button class="rail-toggle" id="railToggle" title="Rétracter / déplier le menu" aria-label="Rétracter le menu" aria-expanded="true">«</button>
 
       <div class="rail-nav">
-        <!-- aria-label explicite sur chaque bouton : rail rétracté, le libellé .rl passe en display:none
-             et le nom accessible tomberait sinon au simple numéro (« 01 »…). Chaque libellé visible y
-             est REPRIS mot pour mot (SC 2.5.3 « Label in Name » : le pilotage vocal vise le texte lu
-             à l'écran). #viewCorrections fait exception et n'en porte PAS : updateOvBadge() réécrit
-             son textContent, compteur compris (« ✎ Corrections (3) »), et un aria-label figerait le
-             nom accessible en masquant ce compteur. Son texte n'a alors plus de .rl : il survit au
-             repli, c'est justement pourquoi il se passe d'aria-label. -->
+        <!-- L'ORDRE EST UNE DÉCISION (#45), pas l'historique des ajouts. Le rail se lit du général
+             au particulier, et les réglages ferment la marche :
+                 recherche de fret │ marché │ soute │ conclusion │ réglage
+             « En route » n'est pas une famille : c'est une lecture des trajets depuis un point de
+             départ donné, d'où la sous-entrée. Et « Plan de vol » quitte la dernière place que lui
+             donnait l'ADR-004 §7 — une conclusion se lit toujours après ce qui la produit, mais un
+             RÉGLAGE se lit après une conclusion.
+
+             Le numéro affiché désigne TOUJOURS la touche qui l'active, sous-entrée comprise : sinon
+             autant retirer les numéros. Les data-view et les id ne bougent pas — ce sont des clés
+             textuelles, les permaliens déjà partagés ouvrent la même vue qu'avant.
+
+             aria-label explicite sur chaque bouton : rail rétracté, le libellé .rl passe en
+             display:none et le nom accessible tomberait sinon au simple numéro (« 01 »…). Chaque
+             libellé visible y est REPRIS mot pour mot (SC 2.5.3 « Label in Name » : le pilotage
+             vocal vise le texte lu à l'écran). -->
         <button id="viewRoutes" class="vbtn active" data-view="routes" aria-label="Trajets simples" title="Trajets simples (raccourci : 1)"><span class="rn">01</span><span class="rl">Trajets</span></button>
-        <button id="viewLoops" class="vbtn" data-view="loops" aria-label="Boucles aller-retour" title="Boucles aller-retour (raccourci : 2)"><span class="rn">02</span><span class="rl">Boucles</span></button>
-        <button id="viewEnroute" class="vbtn" data-view="enroute" aria-label="En route" title="En route (raccourci : 3)"><span class="rn">03</span><span class="rl">En&nbsp;route</span></button>
+        <button id="viewEnroute" class="vbtn vbtn-sub" data-view="enroute" aria-label="En route" title="En route (raccourci : 2)"><span class="rn">02</span><span class="rl">En&nbsp;route</span></button>
+        <button id="viewLoops" class="vbtn" data-view="loops" aria-label="Boucles aller-retour" title="Boucles aller-retour (raccourci : 3)"><span class="rn">03</span><span class="rl">Boucles</span></button>
         <button id="viewChain" class="vbtn" data-view="chain" aria-label="Chaîne multi-sauts" title="Chaîne multi-sauts (raccourci : 4)"><span class="rn">04</span><span class="rl">Chaîne</span></button>
-        <button id="viewCorrections" class="vbtn" data-view="corrections" title="Corrections locales (raccourci : 5)"><span class="rn">05</span><span class="rl">Corrections</span></button>
-        <button id="viewCommodities" class="vbtn" data-view="commodities" aria-label="Commodités : tous les points d'achat/vente" title="Commodités : tous les points d'achat/vente (raccourci : 6)"><span class="rn">06</span><span class="rl">Commodités</span></button>
-        <!-- EN DERNIER, et c'est une décision (ADR-004 §7) : une conclusion se lit après ce qui la
-             produit, et la placer en tête renuméroterait des raccourcis déjà appris pour un gain
-             nul. Révisable par #45, qui refond la hiérarchie du rail dans le même jalon. -->
-        <button id="viewPlan" class="vbtn" data-view="plan" aria-label="Plan de vol" title="Plan de vol : le récapitulatif du voyage engagé (raccourci : 7)"><span class="rn">07</span><span class="rl">Plan&nbsp;de&nbsp;vol</span></button>
+        <button id="viewCommodities" class="vbtn" data-view="commodities" aria-label="Commodités : tous les points d'achat/vente" title="Commodités : tous les points d'achat/vente (raccourci : 5)"><span class="rn">05</span><span class="rl">Commodités</span></button>
         <!-- L'aria-label OUVRE le libellé visible plutôt que de le remplacer (même patron que
              #share) : « Tournée » y est repris mot pour mot, SC 2.5.3 tient, et le nom accessible
              dit en plus de quoi il s'agit une fois le rail rétracté. -->
-        <button id="viewTour" class="vbtn" data-view="tour" aria-label="Tournée d'écoulement" title="Tournée d'écoulement : vider la soute en un minimum d'arrêts (raccourci : 8)"><span class="rn">08</span><span class="rl">Tournée</span></button>
+        <button id="viewTour" class="vbtn" data-view="tour" aria-label="Tournée d'écoulement" title="Tournée d'écoulement : vider la soute en un minimum d'arrêts (raccourci : 6)"><span class="rn">06</span><span class="rl">Tournée</span></button>
+        <button id="viewPlan" class="vbtn" data-view="plan" aria-label="Plan de vol" title="Plan de vol : le récapitulatif du voyage engagé (raccourci : 7)"><span class="rn">07</span><span class="rl">Plan&nbsp;de&nbsp;vol</span></button>
+        <!-- Le libellé passe en .rl comme ses sept voisins, et le bouton gagne donc un aria-label —
+             ce qu'il n'avait volontairement PAS avant #45. La raison a changé de camp : tant que
+             updateOvBadge() écrasait tout le bouton en textContent, ce texte survivait au repli et
+             portait seul le nom accessible ; un aria-label statique y aurait figé le compteur. Il
+             est maintenant masqué au repli comme les autres, donc l'aria-label est le seul à porter
+             « ✎ Corrections (3) » à ce moment-là — et updateOvBadge() le tient à jour AVEC le
+             compteur, exactement comme copyShareLink() le fait pour #share. Le numéro, lui, cesse
+             d'être du balisage mort : il était détruit à chaque appel depuis toujours. -->
+        <button id="viewCorrections" class="vbtn" data-view="corrections" aria-label="✎ Corrections" title="Corrections locales (raccourci : 8)"><span class="rn">08</span><span class="rl">✎ Corrections</span></button>
       </div>
 
       <!-- Le libellé visible « Partager » OUVRE l'aria-label : sinon le nom accessible ne le

--- a/style.css
+++ b/style.css
@@ -147,6 +147,21 @@ a:hover { color: #ffcf6b; text-decoration: underline; }
 }
 .vbtn .rn { font-family: var(--mono); font-size: 10px; opacity: 0.7; }
 
+/* Sous-entrée du rail (#45) : « En route » est une lecture des trajets, pas une famille à part.
+   Le filet passe par ::before et NON par border-left — celui-ci est déjà pris par l'accent de
+   .vbtn.active juste au-dessus, et le marqueur de sous-niveau se serait évanoui pile quand la vue
+   est active, c'est-à-dire quand on la regarde. Posé en absolu, il se cale sur la boîte de padding :
+   il vient donc APRÈS le border, et les deux traits coexistent sans se recouvrir.
+   Le retrait, lui, ne survit à rien : .rail-collapsed .vbtn (plus bas, et plus spécifique) remet
+   padding-left à 0 sur les 68 px du rail replié, et sous 820 px le rail passe en ligne. Dans ces
+   deux états contraints c'est le filet seul qui dit la parenté — d'où le choix de ne pas s'en
+   remettre à l'indentation. */
+.vbtn-sub { position: relative; padding-left: 26px; }
+.vbtn-sub::before {
+  content: ""; position: absolute; left: 0; top: 9px; bottom: 9px;
+  width: 2px; background: var(--line2);
+}
+
 .share-btn {
   display: flex; align-items: center; justify-content: center; gap: 8px;
   margin-top: 6px; padding: 11px 14px;

--- a/style.css
+++ b/style.css
@@ -156,6 +156,10 @@ a:hover { color: #ffcf6b; text-decoration: underline; }
    padding-left à 0 sur les 68 px du rail replié, et sous 820 px le rail passe en ligne. Dans ces
    deux états contraints c'est le filet seul qui dit la parenté — d'où le choix de ne pas s'en
    remettre à l'indentation. */
+/* Le compteur de corrections : plus petit et sans interlettrage, il rend 20 px au libellé. Le
+   numéro du rail a pris cette place, et « Corrections (123) » repartait à la ligne sans ça. */
+.vbtn .ov-n { font-size: 10px; letter-spacing: 0; opacity: 0.85; }
+
 .vbtn-sub { position: relative; padding-left: 26px; }
 .vbtn-sub::before {
   content: ""; position: absolute; left: 0; top: 9px; bottom: 9px;


### PR DESCRIPTION
## Ce que ça change

Le rail rangeait ses huit vues dans l'ordre où elles ont été écrites. Il les range maintenant **du
général au particulier, les réglages en dernier** — et « En route » devient une **sous-entrée de
Trajets**, ce qu'elle a toujours été : la même question, posée depuis un point de départ donné.

```
01 Trajets      02 └ En route     03 Boucles       04 Chaîne
05 Commodités   06 Tournée        07 Plan de vol   08 Corrections

recherche de fret │ marché │ soute │ conclusion │ réglage
```

Quatre destinations changent de touche, et c'est le prix assumé de l'invariant que cette PR
installe : **un numéro affiché DÉSIGNE la touche qui l'active**, sous-entrée comprise. Sinon autant
retirer les numéros.

## Pourquoi

L'ordre racontait l'historique du dépôt, pas la parenté des vues. « En route » côtoyait « Boucles »
et « Chaîne » comme si les trois étaient de même nature ; « Corrections », un réglage qui n'affiche
aucun profit, passait **avant** les vues d'analyse. On cherchait le grand board du marché et on
tombait d'abord sur ses corrections locales.

**L'issue #45 a été écrite quand le rail portait six vues.** Il en porte huit, et ses ancrages de
ligne sont tous périmés : `index.html:52-66` → `70-83`, `switchView` `app.js:2136` → `2766`, la
liste blanche `2459` → `3104`, les raccourcis `3221-3236` → `3933-3940`. La hiérarchie proposée a
donc été étendue aux deux vues neuves : la Tournée lit la soute (famille « soute »), le Plan de vol
conclut, et **un réglage se lit après une conclusion**.

### Trois pièges, tous vérifiés

**Le filet de sous-niveau ne pouvait pas être un `border-left`.** `style.css:138` en donne déjà un à
toute `.vbtn`, et `:144` le passe à l'accent sur `.vbtn.active` : le marqueur se serait évanoui pile
quand la vue est active, c'est-à-dire quand on la regarde. Il passe par un `::before` absolu, calé
sur la boîte de padding — il vient donc après le border, et les deux traits coexistent.

**`updateOvBadge()` détruisait le numéro de Corrections depuis toujours.** `app.js:3178` écrasait
tout le bouton en `textContent`, effaçant le `<span class="rn">05</span>` posé dans le HTML : ce
numéro n'a **jamais** existé à l'écran. Elle écrit maintenant dans le `.rl`.

**Ce libellé passant en `.rl`, il disparaît au rail rétracté.** Le bouton gagne donc l'`aria-label`
qu'il n'avait **volontairement pas** — la raison a changé de camp : tant que son texte survivait au
repli, un `aria-label` statique y aurait figé le compteur ; maintenant qu'il est masqué comme les
autres, l'`aria-label` est le seul à le porter, et `updateOvBadge()` le tient à jour **avec** le
compteur. Même geste que `copyShareLink()` sur `#share`.

### Le défaut qu'aucune assertion de contenu ne voyait

Le rail a été **regardé**, pas seulement testé — et il fallait : le numéro rendu à Corrections lui a
pris 26 des 144 px du bouton, et `✎ Corrections (1)` mesure **125 px pour 118 px de place**. Le
bouton repartait à la ligne, **57 px de haut contre 40** pour ses sept voisins. Les tests lisaient
le bon texte sur un bouton deux fois trop haut.

| libellé | largeur | place |
|---|---|---|
| `✎ Corrections (1)` | 125 px | **118 px** |
| `✎ Corrections (12)` | 133 px | 118 px |
| `✎ Corrections (12)` + compteur réduit | 124 px | 118 px |
| `Corrections (12)` + compteur réduit | **104 px** | 118 px |

Le `✎` part : **20 px mesurés**, et c'était le seul picto du rail, hérité de ce que ce libellé
s'écrivait en JS au lieu d'être posé dans `index.html` comme les sept autres. Le compteur passe en
plus petit sans interlettrage. `Corrections (123)` tient à 111 px. Élargir le rail était l'autre
voie : écartée, elle aggrave **#86**.

## Vérification

```
node --test           ℹ tests 470 · ℹ pass 470 · ℹ fail 0   (inchangé : rien ne bouge dans logic.mjs)
npx playwright test   181 passed · 2 skipped (1,2 min)      (174 avant : 7 tests neufs)
```

**Écrit en rouge d'abord.** Les six premiers tests de `e2e/rail.pw.mjs` sont tombés ensemble avant
l'implémentation — classe `vbtn-sub` absente, touche `2` ouvrant `loops`, ordre du DOM inchangé :

```
6 failed
  Rail : les huit vues se suivent du général au particulier, réglages en dernier (#45)
  Rail : « En route » se donne pour une sous-entrée de Trajets (#45)
  Rail : chaque numéro affiché désigne la touche qui l'ouvre, des huit côtés (#45)
  Rail : Corrections porte enfin son numéro, compteur compris (#45)
  Rail rétracté : les huit entrées restent distinctes, et le repli survit au rechargement (#45)
  Rail horizontal : la sous-entrée garde un marqueur quand le rail passe en ligne (#45)
```

Le septième — celui sur la **géométrie** — a été écrit après la capture d'écran qui a révélé le
débordement, et il était rouge lui aussi, chiffré : `Expected: 40 / Received: 57`.

**Quatre tests existants tombaient**, et c'était attendu, pas subi : `tournee.pw.mjs` pressait la
touche `8` pour la Tournée (passée à `6`), et trois assertions visaient le bouton Corrections entier
en égalité stricte. Elles visent maintenant `#viewCorrections .rl`, ce qui dit mieux leur intention
— *le compteur est resté à zéro* — et les rend insensibles au numéro.

**Les trois états contraints ont été regardés à l'écran**, avec 9 corrections en mémoire :
le rail déployé (huit entrées, une ligne chacune), le rail **rétracté à 68 px avec la sous-entrée
INACTIVE** — le seul cas où le filet doit se lire seul, et il se lit — et le rail horizontal
sous 820 px.

## Ce qui n'est pas couvert

- **Le compteur au-delà de 999 corrections** repartirait à la ligne. Mesuré jusqu'à `(123)`.
- **Fusionner « En route » dans « Trajets »** (un onglet interne plutôt qu'une entrée de rail) :
  hors périmètre de l'issue, ça toucherait `#enrouteControls` et le manifeste. `switchView` garde
  ses huit vues.
- **#86 et #81**, les deux bugs d'affichage du rail et des trajets en fenêtre réduite : cette PR ne
  les corrige pas, elle se contente de ne pas les aggraver.
- **#26 et #25** (bugs de bascule entre vues pendant le chargement du marché) : réordonner le rail
  ne les touche pas.
- **Aucun `data-view`, aucun `id`, aucune clé d'état ne bouge** : `app.js:3104` est inchangée et les
  permaliens déjà partagés ouvrent la même vue qu'avant. Les ~30 `page.click("#viewXxx")` de la
  suite e2e non plus.

> **Base** : cette PR est empilée sur `feat/tournee-ecoulement` (#95), car la 8ᵉ vue n'existe pas
> encore sur `main` — réorganiser un rail à sept entrées n'aurait pas eu de sens. GitHub la
> repointera sur `main` à la fusion de #95.

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)
