### PR TITLE
feat(carte): la carte se lit toujours dans le même sens, quel que soit le voyage

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,10 @@ n'as pas touché n'est **pas** persisté — la jambe reste branchée sur le mar
 
 À côté du compagnon, une **troisième colonne** pose les arrêts **dans l'espace** : un disque par
 système traversé, le vaisseau sur l'escale courante, et un corridor violet `⚡` quand le parcours
-change de système. Elle ne reste à côté que si elle y garde une largeur lisible (≈ 460 px) —
+change de système. Les systèmes se lisent **toujours de gauche à droite dans le même ordre — Nyx,
+Pyro, Stanton** — quel que soit le sens du voyage : une carte qu'on doit relire à chaque trajet ne
+se lit pas d'un coup d'œil. Seuls les systèmes **traversés** ont un disque, sans case vide pour les
+autres ; un système qu'UEX publierait en plus se range après les trois connus. Elle ne reste à côté que si elle y garde une largeur lisible (≈ 460 px) —
 en dessous, elle repasse en **bandeau pleine largeur** sur sa propre ligne, ce qui vaut mieux qu'une
 colonne où les libellés d'escale tomberaient sous 5 px.
 Un saut est **routé par les deux passerelles** — on ne change pas de système n'importe où : le

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -1282,7 +1282,36 @@ test("Carte : un saut inter-système dessine deux disques et un corridor", async
   await expect(page.locator("#journeyMap .jm-sys")).toHaveCount(2); // Pyro et Stanton côte à côte
   // `allInnerTexts` rend `undefined` sur du <text> SVG : ces nœuds n'ont pas d'innerText.
   const noms = await page.locator("#journeyMap .jm-sysnom").allTextContents();
-  expect(noms).toEqual(["PYRO", "STANTON"]); // dans l'ordre du parcours
+  expect(noms).toEqual(["PYRO", "STANTON"]); // ordre canonique, cf. #42
+});
+
+test("Carte : le sens du voyage ne retourne PAS la géographie (#42)", async ({ page }) => {
+  // Le test ci-dessus va de Pyro vers Stanton, le sens qui donnait DÉJÀ le bon ordre : il restait
+  // vert avant comme après le correctif. Celui-ci part de Stanton, et c'est lui qui tombait —
+  // la carte rendait alors ["STANTON", "PYRO"], la même géographie en miroir.
+  // On pose le départ à la main plutôt que par un manifeste : depuis New Babbage le jeu de données
+  // n'offre pas toujours de fret rentable, et le test échouerait alors AVANT d'avoir rien prouvé.
+  await page.click("#viewEnroute");
+  // #journeyStart reste inerte tant que le marché n'est pas chargé (garde `enrouteReady`) : sans
+  // cette attente le test échouerait sur un champ mort, bien avant de regarder la carte.
+  await expect(page.locator("#stationList option").first()).toBeAttached({ timeout: 15000 });
+  // Le libellé est celui de la datalist, au caractère près : « New Babbage » seul n'y existe pas,
+  // UEX y publie deux comptoirs (« MTP … » et « TDD … ») et le champ résout par égalité exacte.
+  await page.fill("#journeyStart", "TDD New Babbage — Stanton");
+  await page.click("#journeyStartBtn");
+  await expect(page.locator("#journeyAddStop")).toBeVisible();
+
+  await page.fill("#journeyAddStop", "Pyro Gateway (Stanton) — Stanton");
+  await page.click("#journeyAddBtn");
+  await page.fill("#journeyAddStop", "Stanton Gateway (Pyro) — Pyro");
+  await page.click("#journeyAddBtn");
+  await page.fill("#journeyAddStop", "Megumi — Pyro");
+  await page.click("#journeyAddBtn");
+
+  await auPlanDeVol(page);
+  await expect(page.locator("#journeyMap .jm-sys")).toHaveCount(2);
+  const noms = await page.locator("#journeyMap .jm-sysnom").allTextContents();
+  expect(noms).toEqual(["PYRO", "STANTON"]); // Pyro reste à gauche, quel que soit le sens
 });
 
 test("Carte : un saut est routé par les passerelles, et chaque jambe porte son sens", async ({ page }) => {

--- a/logic.mjs
+++ b/logic.mjs
@@ -2202,6 +2202,22 @@ export function takeFromStore(hold, entrepots, name, units, station) {
 // filtre, appliqué à la collecte, qui tient les systèmes du lore hors de la carte.
 export const CARTE = { largeur: 680, hauteur: 296, marge: 26 };
 
+// Ordre CANONIQUE des systèmes sur la carte, de gauche à droite (#42). Il ne vient pas de la
+// donnée : les clés de data/starmap.json sont dans l'ordre `Pyro, Stanton, Nyx`, et s'y fier
+// donnerait justement le mauvais. Il ne vient pas non plus du parcours — c'était le défaut : la
+// même géographie se dessinait en miroir selon le sens du voyage, et on ne reconnaissait jamais
+// la carte. Un système hors de cette liste n'est pas perdu, il se range après (voir rangCarte).
+//
+// À NE PAS CONFONDRE avec `ORDRE_SYSTEMES` (logic.mjs:1325), qui range le SÉLECTEUR de station par
+// volume de terminaux — `["Stanton", "Pyro", "Nyx"]`, soit exactement l'inverse. Les deux ordres
+// sont légitimes et ne fusionneront pas : une liste déroulante se parcourt du plus fourni au moins
+// fourni, une carte se lit dans l'ordre où les systèmes sont posés dans l'espace.
+const ORDRE_CARTE = ["Nyx", "Pyro", "Stanton"];
+const rangCarte = (nom) => {
+  const i = ORDRE_CARTE.indexOf(nom);
+  return i === -1 ? ORDRE_CARTE.length : i;
+};
+
 // Angle déterministe dérivé d'un nom : deux terminaux d'une même planète ne se superposent pas,
 // et la carte ne bouge pas d'un rendu à l'autre (aucun hasard, donc aucun scintillement).
 export function nameAngle(nom) {
@@ -2233,10 +2249,17 @@ export function journeyMap(stations, current, starmap, infoTerminal, enVol = fal
   if (!stations || !stations.length) return null;
   const { largeur, hauteur, marge } = CARTE;
 
-  // Un disque par système TRAVERSÉ, dans l'ordre où le parcours les rencontre.
+  // Un disque par système TRAVERSÉ — et seulement ceux-là : on collecte d'abord, on trie ensuite.
+  // Projeter sur les trois cases de l'ordre canonique laisserait un trou au milieu d'un parcours
+  // Nyx -> Stanton, et le corridor ⚡ traverserait un disque inutilisé.
   const ordre = [];
   for (const s of stations) if (s.system && !ordre.includes(s.system)) ordre.push(s.system);
   if (!ordre.length) return null;
+  // L'ordre de gauche à droite est CANONIQUE, jamais celui de la rencontre (#42) : sinon la même
+  // géographie se dessine en miroir selon le sens du voyage. Le tri est STABLE (garanti par la
+  // spec depuis ES2019), donc les systèmes inconnus — tous à rang égal — gardent entre eux
+  // l'ordre du parcours au lieu d'être réordonnés au gré du moteur.
+  ordre.sort((a, b) => rangCarte(a) - rangCarte(b));
   const n = ordre.length;
   const rayon = Math.min((largeur - marge * 2) / (n * 2.35), (hauteur - marge * 2) / 2);
   const systemes = ordre.map((nom, i) => ({

--- a/logic.test.mjs
+++ b/logic.test.mjs
@@ -2570,6 +2570,72 @@ test("journeyMap : un saut inter-système fait DEUX disques et une jambe marqué
   for (const a of c.arrets) assert.ok(dansLeCadre(a, c), `${a.nom} hors cadre`);
 });
 
+// ---------- L'ordre des systèmes est CANONIQUE, pas celui du parcours (#42) ----------
+// La carte plaçait les disques dans l'ordre où le parcours rencontre les systèmes : la même
+// géographie se dessinait donc en miroir selon le sens du trajet, et on ne reconnaissait jamais
+// la carte, on la relisait. Pour un panneau que l'ADR-001 dit DÉCORATIF — sa valeur est de se lire
+// d'un coup d'œil — c'était le seul repère spatial stable qui manquait.
+//
+// ATTENTION en relisant ces tests : le test ci-dessus va de Pyro vers Stanton, c'est-à-dire dans
+// le sens qui donnait DÉJÀ le bon résultat. Il restait vert avant comme après le correctif. Seul
+// le SENS INVERSE prouve quelque chose.
+
+test("journeyMap : le sens du voyage ne change PAS le côté des systèmes (#42)", () => {
+  const aller = journeyMap(st("Megumi", "New Babbage"), 0, STARMAP, infoT);
+  const retour = journeyMap(st("New Babbage", "Megumi"), 0, STARMAP, infoT);
+  // C'est l'assertion qui tombait : le retour rendait ["Stanton", "Pyro"].
+  assert.deepEqual(retour.systemes.map((s) => s.nom), ["Pyro", "Stanton"]);
+  assert.deepEqual(aller.systemes.map((s) => s.nom), retour.systemes.map((s) => s.nom));
+  // Et les abscisses sont les mêmes des deux côtés : la géographie ne bouge pas d'un pixel.
+  assert.deepEqual(aller.systemes.map((s) => s.cx), retour.systemes.map((s) => s.cx));
+});
+
+test("journeyMap : Nyx se lit à GAUCHE de Pyro et de Stanton (#42)", () => {
+  const c = journeyMap(st("New Babbage", "Levski"), 0, STARMAP, infoT);
+  assert.deepEqual(c.systemes.map((s) => s.nom), ["Nyx", "Stanton"]);
+  assert.ok(c.systemes[0].cx < c.systemes[1].cx);
+});
+
+test("journeyMap : un système non traversé ne laisse pas de case vide (#42)", () => {
+  // Nyx -> Stanton sans passer par Pyro : DEUX disques côte à côte, pas trois avec un trou au
+  // milieu. La carte trie ce qu'elle traverse, elle ne réserve pas de place.
+  //
+  // HONNÊTETÉ : celui-ci était VERT avant le correctif — dans ce sens, l'ordre du parcours donnait
+  // déjà le bon résultat. Ce n'est donc pas un test du bug de #42 mais un GARDE-FOU contre la
+  // mauvaise façon de le corriger : projeter sur les trois cases de l'ordre canonique et laisser
+  // un trou là où le parcours ne passe pas. Cette implémentation-là le ferait tomber.
+  const c = journeyMap(st("Levski", "New Babbage"), 0, STARMAP, infoT);
+  assert.equal(c.systemes.length, 2);
+  assert.deepEqual(c.systemes.map((s) => s.nom), ["Nyx", "Stanton"]);
+  // Les deux disques se partagent toute la largeur, comme n'importe quelle paire.
+  const paire = journeyMap(st("Megumi", "New Babbage"), 0, STARMAP, infoT);
+  assert.deepEqual(c.systemes.map((s) => s.cx), paire.systemes.map((s) => s.cx));
+});
+
+test("journeyMap : un système inconnu ne disparaît pas, il se range après les connus (#42)", () => {
+  // UEX peut publier un système que la liste canonique ignore. Le repli de teinte (app.js) a déjà
+  // ce contrat côté couleur ; l'ordre doit avoir le même — sinon la carte perdrait des escales.
+  const stations = [
+    { name: "Port Olisar", system: "Odin" },
+    { name: "New Babbage", system: "Stanton" },
+    { name: "Megumi", system: "Pyro" },
+  ];
+  const c = journeyMap(stations, 0, STARMAP, (n) => TERMS[n] || null);
+  assert.deepEqual(c.systemes.map((s) => s.nom), ["Pyro", "Stanton", "Odin"]);
+});
+
+test("journeyMap : entre inconnus, l'ordre du parcours est conservé (#42)", () => {
+  // Le tri est STABLE : à rang égal, deux systèmes hors liste gardent l'ordre où on les rencontre.
+  // Sans cette garantie, deux systèmes neufs se réordonneraient au gré du moteur.
+  const stations = [
+    { name: "A", system: "Odin" },
+    { name: "B", system: "Terra" },
+    { name: "C", system: "Pyro" },
+  ];
+  const c = journeyMap(stations, 0, STARMAP, () => null);
+  assert.deepEqual(c.systemes.map((s) => s.nom), ["Pyro", "Odin", "Terra"]);
+});
+
 test("journeyMap : un saut est ROUTÉ par les deux passerelles, pas tiré en ligne droite", () => {
   // On ne passe pas d'un système à l'autre n'importe où : le trajet réel emprunte la passerelle
   // d'ici puis celle de là-bas. Trois segments, dont un seul est le corridor.


### PR DESCRIPTION
## Ce que ça change

La carte du parcours se lit maintenant **toujours dans le même sens** : les systèmes sont posés de
gauche à droite dans un ordre fixe — **NYX → PYRO → STANTON** — quel que soit le sens du voyage.

Avant, les disques suivaient l'ordre où le parcours rencontrait les systèmes : `Megumi → New
Babbage` mettait Pyro à gauche, le trajet retour mettait Stanton à gauche. La même géographie se
dessinait en miroir, sans que rien ne l'annonce.

## Pourquoi

On ne *reconnaissait* jamais la carte, on la **relisait** à chaque voyage. Pour un panneau dont
l'[ADR-001](docs/superpowers/specs/2026-08-12-carte-2d-voyage-adr.md) dit explicitement qu'il est
**décoratif** — toute sa valeur est de se lire d'un coup d'œil — c'était le seul repère spatial
stable qui manquait.

**Cause racine : `logic.mjs:2238`.** `for (const s of stations) if (s.system && !ordre.includes(...))
ordre.push(s.system)` — le rang dans `ordre` devient directement l'abscisse (`logic.mjs:2242-2244`).
L'ordre horizontal **était** l'ordre de première rencontre. Un tri suffit, au même endroit.

L'ordre ne pouvait pas venir de la donnée : les clés de `data/starmap.json` sont dans l'ordre
`Pyro, Stanton, Nyx`, et s'y fier aurait donné justement le mauvais. Il est donc écrit dans le code,
à côté de `CARTE`.

### Trois points qui ne se devinent pas

**Le tri porte sur les systèmes EFFECTIVEMENT traversés**, collectés d'abord. Projeter sur les trois
cases de l'ordre canonique laisserait un trou au milieu d'un parcours Nyx → Stanton, et le corridor
`⚡` traverserait un disque inutilisé. Un test verrouille ce piège.

**`Array.sort` est stable** (garanti par la spec depuis ES2019) : les systèmes hors liste, tous à
rang égal, gardent entre eux l'ordre du parcours au lieu d'être réordonnés au gré du moteur. Un
système neuf publié par UEX ne disparaît donc pas, il se range après les trois connus — même
contrat que le repli de teinte côté couleur (`app.js`).

**`ORDRE_CARTE` n'est PAS `ORDRE_SYSTEMES`.** Il en existait déjà un, `logic.mjs:1325`, qui vaut
`["Stanton", "Pyro", "Nyx"]` et range le **sélecteur de station** par volume de terminaux. Les deux
ordres sont opposés, tous deux légitimes, et ne fusionneront pas : une liste déroulante se parcourt
du plus fourni au moins fourni, une carte se lit dans l'ordre où les systèmes sont posés dans
l'espace. Le nom déjà réservé a d'ailleurs fait échouer la première tentative à l'import —
`SyntaxError: Identifier 'ORDRE_SYSTEMES' has already been declared`.

**Rien à toucher côté rendu** : `journeyMapHTML` boucle sur `c.systemes` dans l'ordre reçu, et le
reste de `journeyMap` passe par la `Map parSysteme` et les `cx` calculés — segments, passerelles et
position du vaisseau suivent d'eux-mêmes.

## Vérification

```
node --test           ℹ tests 475 · ℹ pass 475 · ℹ fail 0   (470 avant : 5 tests neufs)
npx playwright test   182 passed · 2 skipped (1,3 min)      (181 avant : 1 test neuf)
```

**Le piège que l'issue signalait est réel, et il a été traité.** Les deux assertions qui
verrouillaient le comportement (`logic.test.mjs`, `e2e/smoke.pw.mjs`) ne testent que le sens
Pyro→Stanton : elles seraient restées **vertes** après le correctif. Les tests neufs sont donc en
**sens inverse**, et quatre des cinq unitaires étaient rouges avant l'implémentation :

```
✖ journeyMap : le sens du voyage ne change PAS le côté des systèmes (#42)
✖ journeyMap : Nyx se lit à GAUCHE de Pyro et de Stanton (#42)
✖ journeyMap : un système inconnu ne disparaît pas, il se range après les connus (#42)
✖ journeyMap : entre inconnus, l'ordre du parcours est conservé (#42)
ℹ tests 475 · ℹ pass 471 · ℹ fail 4
```

**Le cinquième était vert avant, et le commentaire du test le dit.** « un système non traversé ne
laisse pas de case vide » n'est pas un test du bug : c'est un garde-fou contre la mauvaise façon de
le corriger. Le laisser passer pour un test de régression aurait été malhonnête.

**Le test e2e a été écrit après l'implémentation, donc son rouge a été prouvé à part** : le tri a
été neutralisé le temps de le lancer. Il a d'abord échoué pour de **mauvaises** raisons — libellé
`New Babbage — Stanton` inexistant (UEX publie `MTP` et `TDD New Babbage`), puis `#journeyStart`
inerte tant que le marché n'est pas chargé. Corrigé deux fois jusqu'à ce qu'il tombe sur la bonne
assertion, l'ordre des noms, avant d'être remis au vert par le correctif.

## Ce qui n'est pas couvert

- **L'ordre canonique est en dur** dans `logic.mjs`. Aucun champ d'ordre n'existe dans
  `data/starmap.json` ; le jour où UEX en publierait un, c'est là qu'il faudrait le lire.
- **La position verticale et la géométrie interne des disques** : inchangées. Seul l'axe horizontal
  est trié.
- **Aucun ADR à réviser** : l'ADR-001 ne prend pas de décision sur l'ordre horizontal — il ne
  mentionne que « deux systèmes côte à côte ». Ce correctif sert son intention, il ne la contredit
  pas.
- **Le sélecteur de station** garde son propre ordre, et c'est voulu (voir plus haut).

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)
