### PR TITLE
chore(release): v1.1.0 — plan de vol

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "best-hauling",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "best-hauling",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.48.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "best-hauling",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Site statique des meilleures routes d'arbitrage de commodités Star Citizen (données UEX Corp).",
   "license": "MIT",
   "author": "0xKestrelNova",

--- a/sw.js
+++ b/sw.js
@@ -5,7 +5,7 @@
 // recevrait encore l'ANCIEN index.html — sans CSP et avec son <script> inline — pendant toute une
 // visite, tandis que rail.js, lui, serait déjà là. `activate` purge tout cache au nom différent :
 // le bump garantit que la nouvelle page et son script arrivent ENSEMBLE.
-const CACHE = "best-hauling-v1.0.1";
+const CACHE = "best-hauling-v1.1.0";
 // Coquille précachée. Les woff2 (mêmes-origine depuis fonts/) sont mis en cache au premier
 // rendu par le gestionnaire fetch ci-dessous (stale-while-revalidate) -> hors-ligne complet.
 const SHELL = ["./", "./index.html", "./app.js", "./rail.js", "./logic.mjs", "./style.css", "./fonts/fonts.css", "./icon.svg", "./manifest.webmanifest"];


### PR DESCRIPTION
## Ce que ça change

Rien pour l'utilisateur, et c'est le but : ce bump **clôture le jalon `v1.1.0 — Plan de vol`**,
16 issues fermées. Il fait aussi en sorte que les visiteurs déjà installés reçoivent réellement ce
qui a été livré.

## Pourquoi

**Incrément MINEUR au sens semver** — des capacités nouvelles, rien de cassé. Aucun permalien déjà
partagé ne casse : les huit clés de vue sont textuelles et n'ont pas bougé, même quand #45 a
réordonné le rail.

Ce que le jalon a apporté : le **Plan de vol** (7ᵉ vue, seule à porter la carte), la **Tournée
d'écoulement** (8ᵉ vue), la **chaîne multi-commodités**, la **soute déclarable**, les **deux exports
datés**, la **refonte du score** (tri par profit net, colonne Fiabilité qui ne classe plus), la
**hiérarchie du rail**, et la **carte du parcours** qui se lit enfin toujours dans le même sens.

**Le nom du cache n'est pas décoratif.** La coquille est servie en *stale-while-revalidate* : sans
changement de nom, un visiteur déjà installé continuerait de recevoir l'**ancien** `index.html`
pendant toute une visite — c'est-à-dire sans la vue Tournée et sans le rail réordonné. C'est
précisément le cas que `scripts/version.test.mjs` a été écrit pour rendre impossible à oublier.

## Vérification

```
node --test           ℹ tests 475 · ℹ pass 475 · ℹ fail 0
```

Dont les deux qui tiennent la chaîne de version :

```
✔ le nom du cache de sw.js suit la version — le bump manuel n'est plus oubliable
✔ le build estampille meta.json avec la version et le commit
```

Playwright n'est pas rejoué ici : ce commit ne touche que `package.json`, `package-lock.json` et la
constante de cache de `sw.js`. La CI le lance de toute façon.

## Ce qui n'est pas couvert

- **`data/meta.json` n'est pas dans ce commit** : il est estampillé **au build**, avec le commit
  court du runner. C'est le déploiement qui le produit, pas cette PR.
- **Le tag et la release viennent APRÈS la fusion**, sur `main` : le tag doit désigner le commit
  réellement déployé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
