### PR TITLE
docs(doc): ADR-009 et ADR-010 — lire le journal du jeu, puis lire le comptoir

### DIFF
--- a/docs/superpowers/specs/2026-08-15-lecture-de-comptoir-adr.md
+++ b/docs/superpowers/specs/2026-08-15-lecture-de-comptoir-adr.md
@@ -1,0 +1,173 @@
+# ADR-010 : La lecture de comptoir — prospecter un kiosque sans y commercer
+
+**Statut :** Accepté
+**Date :** 2026-08-15
+**Décideur :** 0xKestrelNova (propriétaire du dépôt)
+**Issue :** #101 · **Jalon :** v2.2.0 — Lecture de comptoir · **Dépend de :** ADR-009
+
+## Contexte
+
+L'ADR-009 lit `Game.log` et en tire, exactement et gratuitement, tout ce que le joueur **fait** :
+prix payé, quantité, caisses, autoload, refus, lieu. Cet acquis est si large qu'il a fallu se
+demander si la lecture d'écran gardait une raison d'être.
+
+Elle en garde une, et une seule : **le journal n'enregistre que ce qu'on fait.** Monter voir un
+kiosque sans y acheter n'y laisse que des noms de commodités et des tailles de caisse. Il manque
+donc trois choses, et ce sont précisément celles dont l'app se sert pour décider :
+
+1. **Le prix des commodités qu'on n'échange pas** — c'est-à-dire tout le tableau, alors qu'on
+   n'achète qu'une ligne.
+2. **Le stock (`scu_buy`)**, qui plafonne ce qu'on peut charger.
+3. **La demande restante (`scu_sell − scu_sell_stock`)**, sur laquelle reposent la vue « où
+   écouler » et la Tournée. UEX ne renseigne `scu_sell` que sur **~11 %** des points de vente.
+
+Et c'est là qu'est l'avantage : UEX republie un point tous les **3,1 jours en médiane**, seuls
+**29,9 %** ont un relevé de moins de 24 h. Qui lit un tableau de ses yeux détient, pour plusieurs
+jours, une route que les données publiques ne montrent pas.
+
+**L'alternative n'est pas « OCR ou rien », c'est « OCR ou saisir 45 valeurs ».** Une quinzaine de
+commodités × prix d'achat, prix de vente, volume. La saisie manuelle existe déjà dans la vue
+Corrections ; à ce volume, personne ne la fera. C'est ce rapport-là qui justifie l'OCR, pas
+l'élégance de la technique.
+
+### Ce que l'ADR-009 retire du problème
+
+C'est le cœur de cette décision. `LoadShopInventoryData` liste les commodités du comptoir dès
+l'ouverture du kiosque : mesuré sur **27 comptoirs**, **5 commodités en médiane**, 22 au maximum —
+dont la moitié sont munitions et carburant. Le vocabulaire réel d'un kiosque tourne autour de
+**10 noms, contre 206 dans le jeu**.
+
+| Difficulté chez `sc-trade-companion` | Ce que le journal fournit |
+|---|---|
+| Lire le lieu dans le panneau gauche — le module `CommodityLocationReader` en entier | le lieu, **avant** la capture |
+| Recaler chaque nom lu sur les 206 commodités, avec échec si trop loin | la liste des ~10 de **ce** kiosque |
+| Reconstituer « Available cargo size (SCU) » à coups de fusions de paragraphes | les tailles de caisse, déjà connues et **statiques** |
+| Vérifier que les nombres sont bien lus | si on achète, le prix exact au aUEC près, comme calibrage dans la même session |
+
+L'OCR n'a plus qu'un travail : **lire des nombres, dans une mise en page connue, pour une courte
+liste connue, à un endroit connu.** C'est un problème d'un autre ordre que celui que l'autre projet
+affronte depuis quatorze mois — et c'est la raison pour laquelle cet ADR vient *après* le 009 et
+non en même temps.
+
+### Ce que l'état de l'art coûte
+
+[`sc-trade-companion`](https://github.com/EtienneLamoureux/sc-trade-companion) a changé de moteur
+**quatre fois en quatorze mois** — Tesseract, puis PaddleOCR (PR #107), Windows OCR (#112, #116),
+OneOCR par wrapper .NET (#123), OneOCR par JNA (#125) — avec une cinquième PR ouverte (#126). Ses
+bugs sur écrans ultra-larges (#104) et sous Wayland (#84) sont toujours ouverts, et chaque patch qui
+bouge le kiosque a coûté une PR (#76 pour la mise en page 3.24, #131 pour le format des nombres).
+
+C'est un **impôt permanent**, pas un coût unique. Il est accepté ici en connaissance de cause,
+mais il commande deux choix de structure (§2 et §3).
+
+## Décision
+
+### 1. Le journal pré-sélectionne, l'utilisateur tranche toujours
+
+**Une station détectée est une proposition, jamais un fait.** L'écran de relecture affiche le
+terminal retenu et permet d'en choisir un autre à la main, sans quitter l'écran, sans recommencer
+la capture. Cela vaut aussi quand la détection a réussi : l'utilisateur peut la contredire.
+
+Ce n'est pas une soupape de secours ajoutée par prudence, c'est la règle. Trois cas la rendent
+obligatoire : les **portails**, indiscernables par les prix (les deux bouts d'un même saut affichent
+les mêmes tarifs) ; les **avant-postes**, non résolus par l'appariement de l'ADR-009 ; et les lieux
+sans terminal chez nous, comme `RR_JP_StantonMagnus`. Une correction manuelle **enrichit la table
+d'appariement** pour les fois suivantes.
+
+### 2. Le moteur OCR est derrière une interface, et l'interface est le livrable
+
+`lire(image) → MotSitué[]`, où un mot situé porte son texte et sa boîte englobante. Une seule
+implémentation au départ. On ne parie pas sur un moteur : on parie sur le fait qu'on en changera.
+
+*Écarté : appeler directement une bibliothèque depuis le code d'analyse.* C'est ce qui a rendu
+douloureux chacun des quatre changements de moteur du projet de référence.
+
+**Conséquence sur la CSP.** Un moteur WASM dans le navigateur exige `'wasm-unsafe-eval'` dans
+`script-src`, et la publication (§5) exige `https://api.uexcorp.uk` dans `connect-src`. Notre CSP est
+aujourd'hui `script-src 'self'` et `connect-src 'self'` : **l'app ne fait actuellement aucun appel
+réseau à l'exécution.** Ces deux assouplissements sont le vrai prix de cet ADR, et ils doivent être
+posés explicitement dans `index.html`, pas découverts en route.
+
+### 3. L'analyse est pure, et c'est elle qu'on teste
+
+Le découpage sépare ce qui touche une API de ce qui porte la difficulté :
+
+| Unité | Rôle | Pur ? |
+|---|---|---|
+| `capture/source` | collage, dépôt de fichier, ou dossier de captures du jeu | non |
+| `ocr/pretraitement` | gris égalisé, seuil adaptatif, agrandissement, sur canvas | **oui** |
+| `ocr/moteur` | l'interface du §2 | non |
+| `kiosque/analyse` | `MotSitué[]` → `LigneLue[]` : colonnes, appariement, nombres | **oui** |
+
+**Les fixtures sont des `MotSitué[]` en JSON, pas des images.** L'analyse spatiale — la partie qui
+casse à chaque patch — se teste en `node --test`, sans navigateur et sans moteur. Un petit jeu
+d'images de référence avec leur sortie OCR figée sert de garde-fou au moteur lui-même. En e2e, on
+injecte par le chemin « dépôt de fichier », seul chemin scriptable.
+
+On reprend de `sc-trade-companion` deux idées qui ont fait leurs preuves, et **pas leur code**
+(GPL-3.0 contre notre MIT) : la lecture **spatiale** — deux colonnes repérées par densité, appariées
+par recouvrement en Y — et le **recalage sur vocabulaire fermé**, qui devient ici presque trivial
+puisque le vocabulaire fait dix mots.
+
+*Écarté au départ : l'alignement homographique et la stratégie « meilleur effort » à N seuillages.*
+Ils y sont venus après avoir mesuré ; on fera pareil. La structure les accueille sans réécriture.
+
+### 4. Rien de lu n'entre dans l'état sans relecture
+
+Chaque ligne lue s'affiche **à côté de la valeur UEX connue** dans la vue Corrections, que
+l'ADR-003 a déjà rangée par station. Attention à ne pas confondre deux images : la photo que cette
+vue affiche déjà est celle **du terminal, publiée par UEX** (`screenshot`, présente sur 97 de nos
+114 terminaux) ; la vignette de notre capture est un **élément nouveau**, qui se pose à côté.
+Validation en bloc ou ligne à ligne. Ce qui est validé devient une correction locale, donc
+**périmée à 3 h** comme tout le reste, sans code supplémentaire.
+
+Une lecture douteuse ne coûte donc jamais plus qu'un rejet d'un clic — c'est ce qui rend acceptable
+un OCR imparfait.
+
+### 5. La publication UEX n'a pas besoin de savoir lire
+
+C'est le point qui a failli nous égarer. `POST https://api.uexcorp.uk/2.0/data_submit` réclame une
+capture en base64 pendant les 90 jours d'évaluation d'un nouveau datarunner — **comme preuve, pas
+comme source**. Rien n'exige qu'on ait *lu* l'image.
+
+L'envoi est **opt-in** et conditionné aux deux secrets saisis par l'utilisateur : sa `secret-key` de
+compte et son propre jeton d'application (`Authorization: Bearer`, créé sur « My Apps »). Chacun a
+ainsi son quota et répond de ses envois ; aucun secret ne vit dans le dépôt.
+
+**On n'envoie que ce que l'utilisateur a validé**, et **jamais la capture brute** : seul le
+recadrage sur la zone des listings part, celle que l'analyse vient de délimiter. Un écran complet
+porte le solde du joueur, son nom et le chat — le projet de référence en est réduit à demander
+« coupez le chat global » dans ses bonnes pratiques. Recadrage impossible → pas de publication.
+
+Préalable non négociable : **`build-data.mjs` ne conserve ni `id_terminal` ni `id_commodity`**,
+alors que l'API les exige. Un terminal y est `{name, code:"RODSF"}` et son index ; une commodité
+`{name, code:"ALUM"}`. Ce petit changement de pipeline précède tout le volet réseau.
+
+## Conséquences
+
+**Ce que ça change pour l'utilisateur.** Il peut faire un détour par un comptoir, prendre une
+capture, et repartir avec un tableau à jour que personne d'autre n'a — puis, s'il le veut, le rendre
+à la communauté.
+
+**Ce que ça coûte.** Deux assouplissements de CSP sur une app qui n'avait aucun appel réseau à
+l'exécution, un modèle WASM à charger, et l'impôt de maintenance décrit plus haut : chaque patch qui
+déplace le kiosque demandera une correction.
+
+**Ce que ça ne casse pas.** Sans capture, l'app fonctionne exactement comme avant ; sans secrets
+UEX, rien ne sort de la machine.
+
+**Le rapport au 009 est une dépendance, pas un ordre de confort.** Écrire cet ADR-là d'abord
+reviendrait à réimplémenter la lecture du lieu et le recalage sur 206 noms — c'est-à-dire les deux
+modules les plus coûteux du projet de référence, pour rien.
+
+## Ce que cet ADR ne tranche pas
+
+- **Le moteur OCR retenu.** Le §2 impose une interface, pas un choix. Il se fera sur mesure, sur des
+  captures réelles de kiosque, pas sur une réputation.
+- **Le raccourci de capture.** Un navigateur n'a pas de raccourci global ; la voie la plus prometteuse
+  — laisser la touche de capture du jeu écrire un fichier que l'app surveille — dépend des trois
+  inconnues de système de fichiers listées en ADR-009 §1.
+- **Les écrans ultra-larges**, bug ouvert chez le projet de référence, et la lecture des kiosques
+  d'équipement, hors sujet pour du fret.
+- **Le sort des lectures rejetées.** Une valeur qu'on refuse dit quelque chose sur le moteur ; rien
+  n'est décidé sur ce qu'on en garde.

--- a/docs/superpowers/specs/2026-08-15-veille-du-journal-de-jeu-adr.md
+++ b/docs/superpowers/specs/2026-08-15-veille-du-journal-de-jeu-adr.md
@@ -1,0 +1,226 @@
+# ADR-009 : La veille du journal de jeu — ce que j'ai fait, le jeu l'écrit déjà
+
+**Statut :** Accepté
+**Date :** 2026-08-15
+**Décideur :** 0xKestrelNova (propriétaire du dépôt)
+**Issue :** #100 · **Jalon :** v2.1.0 — Le journal de bord
+
+## Contexte
+
+Nos données viennent d'UEX, et UEX périme. Mesuré le 2026-08-12 sur 2 592 relevés : **un point est
+republié tous les 3,1 jours en médiane**, et seuls **29,9 %** ont un relevé de moins de 24 h. Tout
+le dispositif de corrections — la vue Corrections, la péremption à 3 h de la conception du
+2026-08-12, la soute déclarable de #55 — existe pour compenser ça **à la main**.
+
+Or Star Citizen écrit dans `Game.log` tout ce que le joueur fait à un comptoir de commodités, en
+clair, horodaté à la milliseconde. Ce n'est pas une hypothèse : c'est vérifié sur une installation
+réelle en **`sc-alpha-4.9.0`** (`FileVersion 4.9.188.23497`, `Changelist 12344265`, compilé le
+29 juillet 2026), sur **147 journaux archivés**.
+
+### Ce que le journal contient, mesuré
+
+```
+<2026-05-25T00:36:28.431Z> [Notice] <CEntityComponentCommodityUIProvider::SendCommodityBuyRequest>
+  Sending SShopCommodityBuyRequest - playerId[…] shopId[284221459803] shopName[SCShop_Admin_lt_base_g]
+  kioskId[284221459802] price[770740.000000] shopPricePerCentiSCU[34.408001]
+  resourceGUID[48c7080a-bbef-43d2-901a-698321ed4340] autoLoading[0] quantity[22400.000000 cSCU]
+  Cargo Box Data: boxSize[32.000000] | unitAmount[7] [Team_CoreGameplayFeatures][Shops][UI]
+```
+
+| Événement | Occurrences sur 147 journaux |
+|---|---|
+| `SendCommodityBuyRequest` | 99 |
+| `SendCommoditySellRequest` | 114 |
+| `RmToken_CommodityTransactionResponse` (niveau `[Error]`) | 15 |
+| `LoadShopInventoryData` | 7 131 |
+| `RequestLocationInventory` | présent avant **100 %** des 213 transactions |
+
+`shopPricePerCentiSCU × 100` donne le prix au SCU ; multiplié par la quantité en cSCU il redonne
+`price` **au aUEC près** sur tous les échantillons vérifiés. La ligne porte aussi la composition
+exacte en caisses, et `autoLoading[0|1]` — que le dépôt modélise déjà côté frais.
+
+### Ce que le journal ne contient pas
+
+**Il n'enregistre que ce qu'on fait.** Ni le stock disponible, ni la demande restante, ni le prix
+des commodités qu'on n'échange pas. Monter voir un kiosque sans y acheter ne laisse que des noms de
+commodités et des tailles de caisse. C'est le périmètre de l'ADR-010, et c'est la raison pour
+laquelle cet ADR-là existe.
+
+Deux familles qu'on aurait aimé avoir et qui **ne sont pas là** : `<Jump Drive State Changed>` —
+**0 occurrence sur 147 journaux**, donc pas de mesure des temps de trajet réels ; et les tailles de
+caisse ne trahissent pas le stock — sur **245 triplets** (lieu, comptoir, commodité) et 7 131
+lignes, **aucune ne varie dans le temps**. C'est une propriété statique du comptoir.
+
+### Ce que l'état de l'art nous apprend
+
+[`sc-trade-companion`](https://github.com/EtienneLamoureux/sc-trade-companion) (GPL-3.0 — on
+s'inspire, on ne copie pas de code sous licence MIT) lit le journal depuis sa PR #86 de
+décembre 2024. Son processeur exige `\[Team_NAPU\]\[Shops\]\[UI\]` en fin de ligne et n'a pas été
+touché depuis le **2025-02-08**. Or la même famille de lignes porte `[Team_CoreGameplayFeatures]`
+en 4.9. **Leur détection de comptoir est cassée, et personne ne s'en est aperçu** — parce qu'un
+ancrage trop précis échoue en silence.
+
+[`NexusApp`](https://github.com/T3SoD/NexusApp), maintenu (parseur de commodités mis à jour le
+2026-08-05), exclut délibérément le tag d'équipe de ses motifs. `all-slain` versionne ses
+gestionnaires par version de jeu. Les deux ont tiré la même leçon.
+
+## Décision
+
+### 1. Le journal se lit dans le navigateur, pas dans un compagnon natif
+
+La File System Access API donne un accès en lecture au fichier, conservable entre sessions par un
+handle en IndexedDB. Aucun second produit à construire, signer et mettre à jour ; le déploiement
+Pages reste inchangé.
+
+*Écarté : un compagnon local.* Meilleure ergonomie et OCR natif, mais c'est un deuxième logiciel,
+Windows seul, et ça rompt le « zéro dépendance de production » qui structure le dépôt depuis le
+début.
+
+**Trois inconnues à lever avant la première ligne de code** — elles conditionnent la faisabilité et
+aucune n'est vérifiée à ce jour :
+
+1. **Chromium refuse-t-il un dossier sous `C:\Program Files` ?** Une liste noire de répertoires
+   sensibles existe. Repli prévu : `showOpenFilePicker` sur le seul `Game.log`, qui ne demande pas
+   de permission de dossier, et à défaut le glisser-déposer du fichier.
+2. **Le fichier est-il lisible pendant que le jeu tourne ?** Star Citizen le tient ouvert en
+   écriture ; tout dépend du partage qu'il accorde.
+3. **La permission survit-elle au rechargement** sans redemander un geste utilisateur à chaque fois.
+
+Si la première tombe et que les replis coûtent un geste par session, la décision est à rouvrir.
+
+### 2. On n'ancre jamais un motif sur le tag d'équipe
+
+C'est la leçon payée par `sc-trade-companion`. Les motifs s'ancrent sur l'horodatage, le nom de
+classe (`CEntityComponentCommodityUIProvider`) et les champs nommés — jamais sur `[Team_…]`, qui a
+démontrablement dérivé (`[Team_NAPU]` en mars 2025 → `[Team_CoreGameplayFeatures]` en 2026).
+
+Corollaire : **un motif qui cesse de mordre doit se voir.** Chaque famille d'événements compte ses
+correspondances ; zéro correspondance sur un journal qui contient la classe attendue est une
+anomalie signalée, pas un silence.
+
+### 3. Le catalogue des événements retenus, et lui seul
+
+| Famille | Ce qu'on en tire |
+|---|---|
+| `SendCommodityBuyRequest` | commodité, prix/SCU, SCU, caisses, autoload, comptoir |
+| `SendCommoditySellRequest` | idem, prix déduit de `amount ÷ quantity` — **il n'y a pas de `shopPricePerCentiSCU` côté vente** |
+| `RmToken_CommodityTransactionResponse` (`[Error]`) | une transaction refusée, horodatée |
+| `LoadShopInventoryData` | les commodités du comptoir et leurs tailles de caisse |
+| `RequestLocationInventory` | la clé du lieu |
+
+Tout le reste est ignoré. `CSCLoadingPlatformManager` seul pèse **172 533 lignes** — un pré-filtre
+par `String.includes` avant toute expression régulière n'est pas une optimisation, c'est une
+condition de fonctionnement.
+
+### 4. `resourceGUID` → commodité : une table livrée avec le dépôt
+
+Le journal désigne la commodité par un GUID et **rien n'y associe jamais un nom**. Sur les journaux
+d'essai : 24 GUID distincts, **zéro ligne** portant à la fois un GUID et un `ResourceType`.
+
+Deux méthodes maison ont été essayées et **ont échoué** : l'intersection des offres par comptoir
+(4 résolutions sur 24, dont trois GUID différents tombant tous sur `ProcessedFood` — impossible), et
+le croisement des prix observés contre UEX (3 sur 21). Elles sont documentées ici pour qu'on ne les
+retente pas.
+
+Ce qui marche : [`scunpacked-data/resources/commodities.json`](https://github.com/StarCitizenWiki/scunpacked-data),
+206 entrées `UUID` → `Key`. **24 GUID sur 24 résolus.** La table est **figée dans le dépôt** — pas
+récupérée au vol — parce qu'elle appartient au même régime que `data/*.json` : une amorce
+régénérée dans son propre commit `chore(data): …`.
+
+### 5. Lieu → terminal : une table d'appariement, contrôlée par un test
+
+Ni `shopName` ni `shopId` ne désigne un terminal, et c'est contre-intuitif :
+
+- **`shopName` est un gabarit.** `SCShop_Admin_lt_base_g` couvre **32 `shopId` distincts** — c'est
+  l'archétype d'un bureau d'avant-poste, réutilisé partout.
+- **`shopId` est éphémère.** Sur 178 identifiants observés, **173 n'apparaissent que dans une seule
+  session**, 4 dans deux, 1 dans trois.
+
+La clé est `<RequestLocationInventory> … Location[…]`, présente avant **100 % des 213 transactions**,
+et le couple **(lieu, `shopName`)** désigne le guichet sans ambiguïté. Les 21 clés observées sont
+lisibles : `RR_HUR_LEO`, `RR_ARC_L1`, `RR_P6_L5`, `RR_JP_PyroStanton`, `Stanton4_NewBabbage`,
+`Nyx_Levski`…
+
+L'appariement vers nos 114 terminaux est **une table écrite à la main**, d'une trentaine de lignes.
+*Écarté : le dériver de scunpacked* — son `trade_locations.json` (965 entrées) n'apparie que **37 de
+nos 114 terminaux** par nom affiché, et rate justement Rod's Fuel, les Shubin SM0-xx et les portails.
+
+Ce qui rend la table défendable, c'est qu'elle **se vérifie toute seule** : chaque transaction
+portant une commodité et un prix, on confronte au prix UEX du terminal supposé.
+
+| Clé | Terminal | Accord |
+|---|---|---|
+| `RR_ARC_LEO` | Baijini Point | 10/10 |
+| `RR_HUR_LEO` | Everus Harbor | 24/26 |
+| `RR_MIC_L1` / `RR_MIC_L2` | MIC-L1 / MIC-L2 | 8/8 · 5/5 |
+| `RR_P5_L2` | Gaslight | 7/7 |
+| `RR_P6_LEO` | Ruin Station | 6/6 |
+
+**Ce test tourne en CI comme un test.** Une table fausse ou périmée le fait échouer.
+
+Trois limites connues, à consigner plutôt qu'à masquer : les **portails** sont indiscernables par
+le prix (`RR_JP_PyroStanton` donne Pyro Gateway et Stanton Gateway à 10/10 — les deux bouts d'un
+même saut affichent les mêmes prix ; le système courant tranche) ; **`RR_JP_StantonMagnus` n'a
+aucun terminal chez nous** ; et les **avant-postes** ne se résolvent pas par le prix
+(`Pyro3_Outpost_col_m_mng_indy_001` renvoie trois candidats à égalité) — ceux-là s'apparient à la
+main, ou restent non appariés.
+
+**Un lieu non apparié n'invente rien** : la transaction est lue, affichée, et attend que
+l'utilisateur désigne le terminal.
+
+### 6. Ce que la veille écrit : des corrections, jamais des données
+
+Une transaction lue devient une **correction locale**, dans le moteur existant. Elle hérite donc
+sans une ligne de code de la péremption à 3 h décidée le 2026-08-12, et de tout le dispositif de la
+vue Corrections. `data/market.json` n'est jamais touché : il reste l'instantané UEX, régénéré en CI.
+
+Trois écritures, et pas une de plus :
+
+1. **Prix** — `shopPricePerCentiSCU × 100` à l'achat, `amount ÷ quantity` à la vente.
+2. **Soute** — un achat absorbe, une vente retire, avec la composition en caisses. Le résidu se
+   construit sur `absorbe`, jamais sur `sellAllAt`, conformément à l'ADR-002.
+3. **Refus** — une réponse en `[Error]` de type `Selling` pose une saturation observée
+   **horodatée**. C'est exactement ce qui manque à #20, dont le marqueur `refuseHere` est éternel
+   faute de date, alors que la même information saisie à la main périme en 3 h.
+
+### 7. Ce qu'on ne lit pas du journal
+
+`playerId`, `Handle[…]`, `geid`, `accountId` sont **appariés puis jetés** — jamais capturés, jamais
+stockés, jamais affichés. Le journal contient l'identité du joueur et son historique de session ;
+on n'en a besoin pour rien.
+
+## Conséquences
+
+**Ce que ça change pour l'utilisateur.** La soute cesse d'être déclarative. Les prix qu'on a
+réellement payés corrigent l'app sans saisie. Un comptoir qui refuse une vente est enregistré avec
+sa date, donc il redevient disponible tout seul.
+
+**Ce que ça coûte.** Une permission de fichier à accorder, un mécanisme de veille et de lecture
+incrémentale, deux tables de correspondance à maintenir, et une dépendance à des formats de ligne
+que CIG peut changer à tout patch — d'où §2.
+
+**Ce que ça ne casse pas.** Aucune vue existante ne change de contrat. La veille est une source
+d'entrée supplémentaire pour le moteur de corrections ; sans permission accordée, l'app se comporte
+exactement comme aujourd'hui.
+
+**Régime de tests.** Les motifs et l'assemblage sont **purs** : les fixtures sont des lignes de
+journal en chaînes de caractères, testées en `node --test`, sans navigateur ni fichier. Seuls
+l'accès au système de fichiers et la veille touchent une API, derrière un adaptateur simulable. Le
+test d'appariement lieu → terminal tourne sur les données du dépôt.
+
+**Ordonnancement.** Après `v2.0.0 — Refonte`. Écrire ça dans l'`app.js` actuel paierait une
+troisième fois la taxe des dix coutures décrite en ADR-008.
+
+## Ce que cet ADR ne tranche pas
+
+- **La lecture d'écran** — stock, demande, et prix des lignes non échangées : c'est l'ADR-010,
+  qui s'appuie sur les acquis d'ici (le lieu, le vocabulaire réduit du kiosque, les tailles de
+  caisse) au lieu de les redécouvrir.
+- **La publication vers UEX.** Le journal fournit pourtant l'essentiel du formulaire `data_submit`
+  (`id_terminal` via §5, `price_buy`, la quantité, `container_sizes`). Restent à trancher : les
+  deux secrets à saisir, l'assouplissement de `connect-src`, et le fait que `build-data.mjs` ne
+  conserve **ni `id_terminal` ni `id_commodity`** — préalable obligatoire, non traité ici.
+- **L'appariement des avant-postes**, et le trou de `RR_JP_StantonMagnus`.
+- **Le sort des familles d'événements observées mais non retenues** — l'ascenseur à fret
+  (172 533 lignes), les changements de juridiction, la destruction de vaisseau. Elles existent ;
+  rien ne dit encore ce qu'on en ferait.


### PR DESCRIPTION
## Ce que ça change

Deux décisions de conception, dans un ordre qui est une dépendance technique et non un confort.
**ADR-009** : l'app lit `Game.log` et en tire ce que le joueur a payé, chargé et vendu — la soute
cesse d'être déclarative, les prix réels corrigent l'app sans saisie, un refus de vente arrive
horodaté. **ADR-010** : la lecture d'écran couvre ce que le journal ne peut pas donner — prix des
lignes qu'on n'échange pas, stock, demande — c'est-à-dire la prospection, et les routes que les
données publiques ne montrent pas.

Aucun code ne bouge. Deux jalons (`v2.1.0 — Le journal de bord`, `v2.2.0 — Lecture de comptoir`) et
deux issues (#100, #101) sont créés ; les travaux viennent après `v2.0.0 — Refonte`.

## Pourquoi

Nos données périment : UEX republie un point tous les **3,1 jours en médiane**, **29,9 %** ont moins
de 24 h. Tout le dispositif de corrections compense ça à la main.

Or `Game.log` porte les transactions de comptoir en clair. Vérifié sur une installation réelle en
**`sc-alpha-4.9.0`** (`Changelist 12344265`), **147 journaux** : 99 achats, 114 ventes, 15 réponses
en erreur. `shopPricePerCentiSCU × 100` donne le prix au SCU et redonne le total payé **au aUEC
près**.

Trois résultats ont dicté la forme des ADR, et aucun n'était prévisible :

1. **Ni `shopName` ni `shopId` ne désigne un terminal.** Le premier est un gabarit (32 `shopId`
   distincts pour `SCShop_Admin_lt_base_g`), le second est éphémère (173 des 178 vus dans une seule
   session). C'est `RequestLocationInventory` qui porte la clé — présent avant **100 % des 213
   transactions**.
2. **`resourceGUID` n'est jamais associé à un nom dans le journal.** Deux méthodes maison ont
   échoué (4/24 et 3/21) et sont documentées pour qu'on ne les retente pas ; la table scunpacked
   résout **24/24**.
3. **`sc-trade-companion` est cassé sur 4.9** parce qu'il ancre sur `[Team_NAPU]`, devenu
   `[Team_CoreGameplayFeatures]` — et l'échec est silencieux. D'où la règle « zéro correspondance
   est une anomalie signalée ».

L'appariement lieu → terminal se **vérifie par les prix** (Baijini Point 10/10, Everus Harbor 24/26,
MIC-L1 8/8) : c'est un test, pas une déclaration de foi.

Enfin, l'ADR-010 n'existe que parce que le journal n'enregistre **que ce qu'on fait** : prospecter
sans acheter n'y laisse rien d'exploitable. Et il est réaliste parce que l'ADR-009 réduit son
vocabulaire à **~10 noms contre 206** et lui donne le lieu — trois des quatre modules coûteux de la
référence tombent.

## Vérification

```
$ node --test
ℹ tests 475   ℹ pass 475   ℹ fail 0   ℹ duration_ms 341.6634

$ npx playwright test
  2 skipped
  182 passed (1.1m)
```

Ces deux commandes ont tourné sur la base d'origine ; la branche a ensuite été **rebasée sur `main`
à jour** (`d048e9d`, après la fusion de #99) et ne contient que deux fichiers Markdown neufs —
aucun fichier de code ni de test n'est touché.

Les affirmations chiffrées des deux ADR ont été produites en interrogeant les journaux réels d'une
installation 4.9 et `data/market.json`, pas des sources tierces.

## Ce qui n'est pas couvert

- **Trois inconnues bloquantes** sont consignées mais non levées (ADR-009 §1) : Chromium accepte-t-il
  un dossier sous `C:\Program Files`, le fichier est-il lisible pendant que le jeu tourne, la
  permission survit-elle au rechargement. Si la première tombe, la décision est à rouvrir.
- **L'appariement des avant-postes** n'est pas résolu, et `RR_JP_StantonMagnus` n'a aucun terminal
  chez nous.
- **La publication UEX** est décidée dans son principe (ADR-010 §5) mais son préalable ne l'est pas :
  `build-data.mjs` ne conserve ni `id_terminal` ni `id_commodity`, que l'API exige.
- **Le moteur OCR n'est pas choisi** — l'ADR impose une interface, pas une bibliothèque.
- Pas de `Jump Drive State Changed` en 4.9 (0 occurrence sur 147 journaux) : les temps de trajet
  réels sont hors de portée, et les familles observées mais non retenues (ascenseur à fret,
  juridictions) restent sans usage décidé.

Conception de #100 et #101 — ces issues portent l'implémentation et ne sont pas fermées par cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)