### PR TITLE
feat(socle): Vite fabrique le site, et les tests regardent enfin ce qu'il produit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ Thumbs.db
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+dist/

--- a/README.md
+++ b/README.md
@@ -119,8 +119,23 @@ npm run serve        # sert le dossier sur http://127.0.0.1:4173 (serveur maison
 Les `data/*.json` versionnés servent d'**amorce** pour le dev local. Pour les régénérer depuis UEX :
 
 ```bash
-npm run build        # = node scripts/build-data.mjs  (Node >= 20, fetch natif)
+npm run build:data   # = node scripts/build-data.mjs  (Node >= 20, fetch natif)
 ```
+
+Depuis le socle v2, il y a **deux** builds, et ils ne font pas la même chose. `build` seul les
+enchaîne, mais `.github/workflows/update-data.yml` appelle `node scripts/build-data.mjs` en clair :
+un workflow qui dépend d'un alias npm se casse en silence le jour où l'alias bouge.
+
+```bash
+npm run build:data   # régénère les données depuis UEX
+npm run build:site   # fabrique le site dans dist/ (Vite)
+npm run build        # les deux, dans cet ordre
+npm run dev          # serveur de développement Vite, avec rechargement à chaud
+```
+
+> **`dist/` n'est pas le site déployé.** La mise en ligne assemble encore `_site/` à partir des
+> fichiers sources (`update-data.yml`) : le socle v2 introduit la fabrication et la fait vérifier par
+> les tests, sans y basculer la production. Ce qui est en ligne aujourd'hui ne dépend pas de Vite.
 
 Lancer les tests :
 
@@ -558,6 +573,13 @@ Les relevés bruts et le raisonnement complet sont dans
   (carte vaisseau au reload, demande corrigée à 0, contrôles qui ne fuient plus, persistance des corrections,
   navigation, cible tactile du ▶, dépliant de chargement) et **cohérence des filtres par vue** (« légales » agit sur Trajets/Boucles/Commodités,
   « même système » contraint la Chaîne). Playwright est une dépendance **de dev uniquement** — le site livré reste sans dépendance.
+- **Socle de build** ([`e2e/socle.pw.mjs`](e2e/socle.pw.mjs)) : depuis la v2, la suite E2E sert
+  `dist/` — **ce que le build produit réellement**, et non les fichiers du dépôt. Servir les sources
+  laissait la suite verte sans jamais regarder la fabrication : elle aurait validé un `dist/` cassé.
+  Ces tests-là couvrent les pannes qui ne se voient qu'**en production** : un manifeste déplacé sous
+  `assets/` (l'app installée démarrerait sur `/assets/`), une icône hachée que le manifeste ne
+  retrouve plus, une liste de précache périmée (`caches.addAll` est atomique — une seule URL en 404
+  et le hors-ligne ne se dégrade pas, il disparaît), et la CSP de dev qui fuirait dans le build.
 - **CI** ([`ci.yml`](.github/workflows/ci.yml)) : unitaires + E2E sur chaque push/PR.
 
 ## Versions et déploiement

--- a/docs/superpowers/specs/2026-08-15-refonte-v2-vite-react-adr.md
+++ b/docs/superpowers/specs/2026-08-15-refonte-v2-vite-react-adr.md
@@ -53,6 +53,16 @@ annote, on ne refait pas.
 **176 tests e2e** — 174 verts, 2 ignorés, **1,2 min** en local — et **108 sélecteurs `#id`
 distincts**. « Fini » est déjà écrit, exécutable, et indépendant de l'implémentation.
 
+> **Amendement du 2026-08-15 (PR socle).** Ces chiffres étaient déjà périmés à la rédaction : le
+> jalon `v1.1.0` a livré `rail.pw.mjs` entre-temps. **184 collectés** (`playwright test --list` →
+> « Total: 184 tests in 6 files »), 182 verts, 2 ignorés. Le socle en ajoute 6 → **190**.
+>
+> Les **108 sélecteurs `#id`** sont exacts, mais deux d'entre eux sont des fragments d'URL et non
+> des sélecteurs : **106 réels**, dont **31 ne sont PAS dans `index.html`** — ils sont émis à
+> l'exécution par `app.js`. Et le contrat n'est chiffré qu'à moitié : la suite s'appuie aussi sur
+> ~109 sélecteurs de **classe** et 9 attributs `data-*` (`rail.pw.mjs` lit `dataset.view` sur
+> `.rail-nav .vbtn`). La structure de classes est un contrat au même titre que les `id`.
+
 > **Les `id` et les classes ne changent pas.** C'est ce qui transforme la suite e2e en **harnais de
 > migration** et en contrat anti-régression. Renommer les sélecteurs parce que la nouvelle pile
 > invite à le faire détruirait la seule raison objective de croire que cette refonte peut aboutir —
@@ -104,6 +114,21 @@ Le prix accepté : les correctifs v1 qui tombent pendant la migration sont à re
 
 **176/176 e2e sur le build Vite, sélecteurs inchangés.** Rien d'autre ne vaut « fini ». Les
 2 ignorés restent ignorés pour la même raison qu'aujourd'hui, ou l'ADR est amendé pour dire pourquoi.
+
+> **Amendement du 2026-08-15 (PR socle).** Le critère se reformule en **« tous les tests collectés
+> passent, aucun échec »**, avec le compte du jour comme repère (190 depuis le socle) — et non en
+> un rapport figé.
+>
+> Deux raisons, et la seconde est la vraie. D'abord `176` était périmé : un critère chiffré en dur
+> se déclare atteint **en perdant des tests**. Ensuite, « les 2 ignorés restent ignorés » n'était
+> pas vérifiable : ces deux-là (`smoke.pw.mjs:1719` et `:1759`) sont ignorés à cause des **DONNÉES**
+> — l'instantané `data/` committé n'offre aucune commodité rentable à suggérer sur ces chemins.
+> **Neuf autres tests** portent le même `test.skip` conditionnel et peuvent basculer d'un côté ou de
+> l'autre à la prochaine régénération, **sans qu'une ligne de code bouge**. Adosser le critère de
+> fusion de la refonte à un chiffre que le cron peut changer la nuit était une erreur.
+>
+> Le corollaire du §4 tient sans changement : la migration se fait vue par vue, chacune rendant vert
+> son sous-ensemble `-g` avant la suivante.
 
 Corollaire : la migration se fait **vue par vue à l'intérieur de la branche**, chacune rendant vert
 son sous-ensemble `-g` avant qu'on passe à la suivante. Une branche longue n'est tenable que si elle

--- a/e2e/socle.pw.mjs
+++ b/e2e/socle.pw.mjs
@@ -1,0 +1,108 @@
+import { test, expect } from "@playwright/test";
+
+// Le socle de build (ADR-008). Ces tests ne regardent PAS une fonctionnalité : ils regardent ce que
+// la fabrication produit. Ils n'ont de sens que parce que la suite sert désormais `dist/`
+// (playwright.config.mjs) — sur la racine du dépôt, ils passeraient sans rien prouver.
+//
+// Tout ce qui est ici est une panne qui NE SE VOIT QU'EN PRODUCTION : un nom de fichier haché, un
+// manifeste déplacé, une liste de précache périmée. Aucune n'aurait fait rougir les 184 tests
+// existants, et c'est précisément pour ça qu'ils sont écrits.
+
+test("Socle : le manifeste est servi à la RACINE, jamais haché sous assets/ (#96)", async ({ page }) => {
+  // Le piège mesuré pendant l'écriture du socle : Vite traite <link rel="manifest"> comme un asset
+  // et le range sous assets/ avec un nom haché. Son JSON, lui, n'est pas réécrit — « start_url »,
+  // « scope » et « icons[].src » y sont RELATIFS. Déplacé d'un cran, le manifeste faisait démarrer
+  // l'app installée sur /assets/ et lui faisait perdre son icône. Rien ne l'aurait signalé.
+  await page.goto("/index.html");
+  const href = await page.locator('link[rel="manifest"]').getAttribute("href");
+  expect(href, "le manifeste ne doit pas être haché").toBe("./manifest.webmanifest");
+
+  const reponse = await page.request.get("/manifest.webmanifest");
+  expect(reponse.status()).toBe(200);
+  const manifeste = await reponse.json();
+  expect(manifeste.start_url).toBe("./");
+  expect(manifeste.scope).toBe("./");
+
+  // L'icône que le manifeste désigne doit exister À L'ENDROIT où lui la cherche : à côté de lui.
+  const icone = await page.request.get("/" + manifeste.icons[0].src);
+  expect(icone.status(), `${manifeste.icons[0].src} introuvable à la racine`).toBe(200);
+});
+
+test("Socle : l'icône de la page est servie sous son nom d'origine (#96)", async ({ page }) => {
+  await page.goto("/index.html");
+  for (const rel of ["icon", "apple-touch-icon"]) {
+    const href = await page.locator(`link[rel="${rel}"]`).getAttribute("href");
+    expect(href, `${rel} ne doit pas être haché`).toBe("./icon.svg");
+  }
+  expect((await page.request.get("/icon.svg")).status()).toBe(200);
+});
+
+test("Socle : la CSP de PRODUCTION traverse le build intacte (#96)", async ({ page }) => {
+  // L'assouplissement de la CSP existe pour le serveur de développement, et pour lui seul. S'il
+  // fuyait dans le build, la page servie accepterait le script inline et l'eval — exactement ce
+  // que la politique du dépôt refuse, et sans qu'aucun test de source ne s'en aperçoive : ceux-ci
+  // lisent index.html à la racine, pas l'artefact.
+  await page.goto("/index.html");
+  const politique = await page.locator('meta[http-equiv="Content-Security-Policy"]').getAttribute("content");
+  // Directive par directive, et non par sous-chaîne : `style-src 'self' 'unsafe-inline'` est la
+  // politique LÉGITIME de production, et une recherche naïve d'« unsafe-inline » la confondrait
+  // avec une fuite du serveur de dev.
+  const directives = Object.fromEntries(
+    politique.split(";").map((d) => d.trim().split(/\s+/)).filter((p) => p[0]).map(([n, ...v]) => [n, v.join(" ")])
+  );
+  expect(directives["script-src"], "l'assouplissement de dev a fui dans le build").toBe("'self'");
+  expect(directives["connect-src"], "le ws: du rechargement à chaud a fui dans le build").toBe("'self'");
+  // `img-src` sans `data:` est ce qui impose assetsInlineLimit: 0. Les deux se tiennent : si la
+  // directive s'assouplit un jour, le réglage de Vite n'a plus de raison d'être — et inversement,
+  // si le réglage saute, cette directive fait disparaître la première icône inlinée EN PRODUCTION.
+  expect(directives["img-src"]).toBe("'self' https:");
+  expect(directives["img-src"], "data: rouvert -> assetsInlineLimit: 0 perd sa raison d'être").not.toContain("data:");
+});
+
+test("Socle : rail.js reste un script CLASSIQUE, et le rail replié ne clignote pas (#96)", async ({ page }) => {
+  // Invariant documenté dans index.html et dans rail.js depuis toujours, et qu'AUCUN test ne
+  // couvrait : rail.js doit s'exécuter pendant l'analyse du document, donc avant le module différé.
+  // En faire un module le rendrait différé lui aussi, et le rail s'afficherait déplié le temps d'un
+  // rendu. Le socle déplace ce fichier dans la fabrication : c'est le moment de l'attraper.
+  const balise = page.locator('script[src="rail.js"]');
+  await page.goto("/index.html");
+  await expect(balise).toHaveCount(1);
+  expect(await balise.getAttribute("type"), "rail.js ne doit pas devenir un module").toBeNull();
+
+  // Et la propriété qui compte vraiment, vue de l'utilisateur : rail déjà replié au tout premier
+  // rendu, sans passer par un état déplié.
+  await page.evaluate(() => localStorage.setItem("best-hauling-rail", "1"));
+  await page.goto("/index.html");
+  await expect(page.locator("#app")).toHaveClass(/rail-collapsed/);
+});
+
+test("Socle : l'app démarre aussi par « / », l'URL de l'app installée (#96)", async ({ page }) => {
+  // `start_url` du manifeste vaut « ./ » : une app installée démarre sur la racine, pas sur
+  // /index.html. Les 184 tests existants visent tous /index.html — cette entrée-là n'était
+  // couverte par rien, alors que le précache la traite comme une URL distincte.
+  await page.goto("/");
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+  await expect(page.locator(".rail-nav .vbtn")).toHaveCount(8);
+});
+
+test("Socle : le précache nomme des fichiers qui existent VRAIMENT (#96)", async ({ page }) => {
+  // `caches.addAll` est ATOMIQUE : une seule URL en 404 fait rejeter tout l'appel, et le mode
+  // hors-ligne ne se dégrade pas — il disparaît, en silence. C'est la panne que la liste écrite à
+  // la main garantissait dès le premier build, puisque Vite renomme les fichiers.
+  await page.goto("/index.html");
+  const sw = await (await page.request.get("/sw.js")).text();
+
+  const liste = JSON.parse(sw.match(/const SHELL = (\[[^\]]*\]);/)[1]);
+  expect(liste.length, "le précache doit être écrit par le build, pas rester la liste v1").toBeGreaterThan(9);
+  expect(liste).toContain("./");
+  expect(liste).toContain("./index.html");
+  expect(liste).toContain("./rail.js");
+
+  // Les données ont leur PROPRE stratégie dans sw.js (réseau d'abord) : les précacher les figerait.
+  expect(liste.filter((u) => u.includes("/data/"))).toHaveLength(0);
+
+  for (const url of liste) {
+    const r = await page.request.get(url === "./" ? "/" : url.replace(/^\.\//, "/"));
+    expect(r.status(), `${url} est précaché mais absent du site produit`).toBe(200);
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,21 @@
       "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
-        "@playwright/test": "^1.48.0"
+        "@playwright/test": "^1.48.0",
+        "vite": "^8.2.1"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.144.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
+      "integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@playwright/test": {
@@ -31,6 +42,297 @@
         "node": ">=18"
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
+      "integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz",
+      "integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz",
+      "integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz",
+      "integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
+      "integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",
+      "integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz",
+      "integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz",
+      "integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz",
+      "integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz",
+      "integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz",
+      "integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz",
+      "integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -44,6 +346,318 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/playwright": {
@@ -76,6 +690,188 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
+      "integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.144.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.4",
+        "@rolldown/binding-darwin-arm64": "1.2.4",
+        "@rolldown/binding-darwin-x64": "1.2.4",
+        "@rolldown/binding-freebsd-x64": "1.2.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.4",
+        "@rolldown/binding-linux-arm64-musl": "1.2.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-musl": "1.2.4",
+        "@rolldown/binding-openharmony-arm64": "1.2.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.4",
+        "@rolldown/binding-win32-x64-msvc": "1.2.4"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,13 +10,17 @@
     "node": ">=20"
   },
   "scripts": {
-    "build": "node scripts/build-data.mjs",
+    "build": "npm run build:data && npm run build:site",
     "serve": "node scripts/serve.mjs",
     "test": "node --test",
-    "e2e": "playwright test"
+    "e2e": "playwright test",
+    "build:data": "node scripts/build-data.mjs",
+    "build:site": "vite build",
+    "dev": "vite"
   },
   "devDependencies": {
-    "@playwright/test": "^1.48.0"
+    "@playwright/test": "^1.48.0",
+    "vite": "^8.2.1"
   },
   "repository": {
     "type": "git",

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -29,10 +29,20 @@ export default defineConfig({
     trace: "on-first-retry",
   },
   projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  // La suite tourne sur `dist/`, c'est-à-dire sur CE QUI EST RÉELLEMENT PRODUIT (ADR-008 §4).
+  // Servir la racine du dépôt la laissait verte sans jamais regarder le build : elle aurait validé
+  // un `dist/` cassé, et le critère de fusion « les e2e passent sur le build Vite » n'aurait rien
+  // voulu dire. Le build est donc DANS la commande — un `dist/` périmé ferait passer des tests sur
+  // un artefact qui n'est plus celui du code sous les yeux.
+  //
+  // `reuseExistingServer` hors CI reste vrai, mais il change de sens : le serveur relit le disque à
+  // chaque requête, donc un `npm run build:site` relancé à côté est pris en compte sans redémarrer.
+  // En revanche il ne reconstruit pas tout seul — après une modification de source, relancer la
+  // suite entière (qui rejoue la commande) ou rebâtir à la main.
   webServer: {
-    command: `node scripts/serve.mjs ${PORT}`,
+    command: `npm run build:site && node scripts/serve.mjs ${PORT} dist`,
     url: `${ORIGINE}/index.html`,
     reuseExistingServer: !process.env.CI,
-    timeout: 30_000,
+    timeout: 120_000,
   },
 });

--- a/scripts/serve.mjs
+++ b/scripts/serve.mjs
@@ -1,9 +1,13 @@
 #!/usr/bin/env node
 // Serveur statique minimal, sans dépendance — pour les tests Playwright et le dev local.
-// Usage : node scripts/serve.mjs [port]
+// Usage : node scripts/serve.mjs [port] [racine]
+//
+// La racine est un ARGUMENT depuis le socle v2 (ADR-008) : les tests servent désormais `dist/`,
+// c'est-à-dire ce que le build a réellement produit. Servir le dépôt les laissait passer au vert
+// sans jamais regarder le build — une suite qui ne peut pas échouer ne prouve rien.
 import { createServer } from "node:http";
 import { readFile } from "node:fs/promises";
-import { extname, join, normalize, sep } from "node:path";
+import { extname, join, normalize, resolve, sep } from "node:path";
 import { pathToFileURL } from "node:url";
 
 const port = Number(process.argv[2]) || 4173;
@@ -58,5 +62,13 @@ export function startStaticServer(listenPort = port, root = process.cwd()) {
   return createStaticServer(root).listen(listenPort, HOST);
 }
 
+// La racine passée en CLI est résolue ICI, pas dans startStaticServer : celle-ci garde son défaut
+// `process.cwd()`, ce dont dépendent scripts/serve.test.mjs et l'usage `npm run serve`.
+const racineCli = process.argv[3] ? resolve(process.argv[3]) : process.cwd();
+
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
-if (isMain) startStaticServer(port).on("listening", () => console.log(`serve → http://127.0.0.1:${port}`));
+if (isMain) {
+  startStaticServer(port, racineCli).on("listening", () =>
+    console.log(`serve → http://127.0.0.1:${port} (racine : ${racineCli})`)
+  );
+}

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,0 +1,236 @@
+import { defineConfig } from "vite";
+import { readFileSync, writeFileSync, readdirSync, statSync, mkdirSync, copyFileSync, existsSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+
+// Socle de build de la v2 (ADR-008). Ce fichier ne contient AUCUNE décision d'ergonomie : il ne
+// fait qu'une chose, faire traverser au site v1 une étape de fabrication sans rien casser de ce
+// que la production tient. Trois contraintes le dictent, toutes vérifiables :
+//
+//   1. Le site vit sous un SOUS-CHEMIN (https://0xkestrelnova.github.io/best-hauling/,
+//      .github/workflows/update-data.yml). Un `base` absolu casse la production seule ; un `base`
+//      « /best-hauling/ » casse les tests seuls, qui servent à la racine. Seul « ./ » satisfait
+//      les deux, et c'est déjà la convention de tout le reste (start_url et scope du manifeste,
+//      SHELL du service worker, les fetch de données).
+//   2. La CSP n'a PAS `data:` dans img-src (index.html). Vite inline en base64 tout asset sous
+//      4 ko : icon.svg fait 433 octets et disparaîtrait EN PRODUCTION SEULEMENT. D'où
+//      assetsInlineLimit à 0, qui n'est pas un réglage de confort mais le pendant mécanique
+//      d'une directive de sécurité.
+//   3. Le service worker précache une liste de fichiers. Vite les renomme. La liste doit donc
+//      être écrite par le build — voir le plugin `precache` plus bas, et son commentaire.
+//
+// La config reste en .mjs et non en .ts : le socle n'introduit pas TypeScript (tranché avec le
+// propriétaire), et tout l'outillage du dépôt est déjà en .mjs.
+
+// Ces trois fichiers portent un NOM SOUS CONTRAT et doivent traverser le build sans être renommés :
+// rail.js est nommé par un test de source (scripts/csp.test.mjs) et par la ligne d'assemblage du
+// déploiement ; icon.svg est désigné par le manifeste, un JSON que Vite ne réécrit pas ; le
+// manifeste lui-même est désigné par index.html. Un hachage rendrait ces références fausses sans
+// que rien ne le dise avant la production.
+//
+// Ils restent À LA RACINE plutôt que dans un `public/`, et c'est une décision, pas une facilité :
+// le déploiement actuel assemble le site en copiant les fichiers SOURCES
+// (`cp index.html app.js rail.js … _site/` dans .github/workflows/update-data.yml). Les déplacer
+// ferait échouer cette copie — donc casserait la mise en ligne — alors que le socle doit être
+// invisible pour la production tant que le déploiement n'a pas basculé. `publicDir` est désactivé
+// pour la même raison, et le build les copie lui-même.
+const FICHIERS_RACINE = ["rail.js", "icon.svg", "manifest.webmanifest"];
+
+// `data/` reste hors du bundler : scripts/build-data.mjs y écrit, le service worker route sur le
+// préfixe `/data/`, le mécanisme de non-redéploiement lit une URL publique en dur, et CLAUDE.md
+// veut que la régénération des JSON vive dans son propre commit. On copie à la fin du build, sans
+// rien faire passer par Vite.
+function copierHorsBundle(racine, dist) {
+  const copies = [];
+  for (const f of FICHIERS_RACINE) {
+    const src = join(racine, f);
+    if (!existsSync(src)) {
+      throw new Error(
+        `vite.config.mjs : ${f} est introuvable à la racine. Ce fichier porte un nom sous contrat ` +
+          `(index.html, sw.js, le manifeste ou la ligne d'assemblage le nomment). S'il a déménagé, ` +
+          `mettre à jour FICHIERS_RACINE **et** la ligne cp d'update-data.yml.`
+      );
+    }
+    copyFileSync(src, join(dist, f));
+    copies.push(f);
+  }
+
+  const srcData = join(racine, "data");
+  if (existsSync(srcData)) {
+    const destData = join(dist, "data");
+    mkdirSync(destData, { recursive: true });
+    for (const f of readdirSync(srcData)) {
+      if (!f.endsWith(".json")) continue;
+      copyFileSync(join(srcData, f), join(destData, f));
+      copies.push("data/" + f);
+    }
+  }
+  return copies;
+}
+
+// Liste récursive des fichiers d'un répertoire, en chemins relatifs à séparateurs `/` — le service
+// worker parle d'URL, pas de chemins Windows.
+function fichiersDe(racine, dossier = racine) {
+  const sortie = [];
+  for (const nom of readdirSync(dossier)) {
+    const chemin = join(dossier, nom);
+    if (statSync(chemin).isDirectory()) sortie.push(...fichiersDe(racine, chemin));
+    else sortie.push(relative(racine, chemin).split(sep).join("/"));
+  }
+  return sortie;
+}
+
+// Le manifeste de précache (ADR-008 §7). Sans lui, le premier `vite build` casserait le mode
+// hors-ligne EN SILENCE : sw.js nomme app.js, logic.mjs et style.css, que le build vient de
+// renommer. Et `caches.addAll` est ATOMIQUE — une seule URL en 404 fait rejeter l'ensemble. Le
+// hors-ligne ne se dégraderait pas, il disparaîtrait, sans erreur visible et en production seule.
+//
+// On réécrit donc le littéral `SHELL` de sw.js avec ce que le build a RÉELLEMENT émis. Le source
+// garde sa liste v1 en clair : il reste lisible, exécutable tel quel, et scripts/version.test.mjs
+// continue d'y lire `CACHE` sans rien savoir de ce plugin.
+//
+// `data/` est exclu à dessein : ces fichiers ont leur PROPRE stratégie dans sw.js (réseau d'abord,
+// cache en repli). Les précacher les figerait à la version du déploiement.
+const ANCRE_SHELL = /^const SHELL = \[[^\]]*\];$/m;
+
+// Vite traite `<link rel="icon">` et `<link rel="manifest">` comme des assets : il les hache et les
+// range sous assets/. Pour le manifeste, c'est une TRIPLE panne de production, invisible en test —
+// son JSON n'est pas réécrit, donc ses chemins relatifs se retrouvent résolus depuis assets/ :
+//
+//     "src": "icon.svg"   -> assets/icon.svg, qui n'existe pas (il est haché) : plus d'icône
+//     "start_url": "./"   -> l'app INSTALLÉE démarre sur /assets/
+//     "scope": "./"       -> la PWA ne contrôle plus les pages du site
+//
+// On sort donc ces fichiers du bundle et on remet les href d'origine dans la page. Le repérage se
+// fait par `originalFileNames`, ce que Rollup a réellement lu, et non par un motif sur les noms
+// hachés : un futur `icon-2.svg` légitime ne doit pas être emporté par erreur.
+function horsBundle() {
+  let racine = process.cwd();
+  let sortie = "dist";
+  return {
+    name: "best-hauling:hors-bundle",
+    apply: "build",
+    configResolved(config) {
+      racine = config.root;
+      sortie = config.build.outDir;
+    },
+    generateBundle(_options, bundle) {
+      for (const [nom, emis] of Object.entries(bundle)) {
+        const origines = emis.originalFileNames || (emis.originalFileName ? [emis.originalFileName] : []);
+        if (origines.some((o) => FICHIERS_RACINE.includes(o.split("/").pop()))) delete bundle[nom];
+      }
+    },
+    // La réécriture des href se fait sur le FICHIER PRODUIT, pas via transformIndexHtml : ce hook,
+    // même en `order: "post"`, passe avant la substitution finale des URL d'assets par Vite — on
+    // remplaçait donc des chaînes qui n'existaient pas encore, et dist/index.html sortait en
+    // pointant vers des fichiers que generateBundle venait de supprimer. Mesuré, pas supposé.
+    closeBundle() {
+      const page = join(racine, sortie, "index.html");
+      if (!existsSync(page)) return;
+      const avant = readFileSync(page, "utf8");
+      const apres = avant
+        .replace(/href="[^"]*manifest-[^"]+\.webmanifest"/g, 'href="./manifest.webmanifest"')
+        .replace(/href="[^"]*icon-[^"]+\.svg"/g, 'href="./icon.svg"');
+      if (apres === avant) return;
+      writeFileSync(page, apres);
+    },
+  };
+}
+
+function precache() {
+  let racine = process.cwd();
+  let sortie = "dist";
+  return {
+    name: "best-hauling:precache",
+    apply: "build",
+    configResolved(config) {
+      racine = config.root;
+      sortie = config.build.outDir;
+    },
+    closeBundle() {
+      const dist = join(racine, sortie);
+      // La copie vient AVANT le listage : ce qui n'est pas encore dans dist/ n'entrerait pas dans
+      // le manifeste, et `addAll` étant atomique, un seul oubli supprimerait tout le hors-ligne.
+      const horsBundle = copierHorsBundle(racine, dist);
+
+      const aPrecacher = fichiersDe(dist)
+        .filter((f) => !f.startsWith("data/") && f !== "sw.js")
+        .sort();
+      // « ./ » d'abord : c'est l'URL par laquelle une app installée démarre (start_url du
+      // manifeste), et elle est distincte de « ./index.html » pour le cache.
+      const shell = ["./", ...aPrecacher.map((f) => "./" + f)];
+
+      const source = readFileSync(join(racine, "sw.js"), "utf8");
+      if (!ANCRE_SHELL.test(source)) {
+        // Échec BRUYANT plutôt qu'un service worker silencieusement périmé : si l'ancre bouge,
+        // le build s'arrête au lieu de déployer un hors-ligne qui ne s'installe plus.
+        this.error(
+          "sw.js : ancre `const SHELL = [...];` introuvable — le manifeste de précache ne peut pas " +
+            "être injecté. Corrige l'ancre dans sw.js ou ANCRE_SHELL dans vite.config.mjs."
+        );
+      }
+      const injecte = source.replace(
+        ANCRE_SHELL,
+        "// Liste ÉCRITE PAR LE BUILD (vite.config.mjs, plugin best-hauling:precache).\n" +
+          "const SHELL = " + JSON.stringify(shell) + ";"
+      );
+      writeFileSync(join(dist, "sw.js"), injecte);
+
+      this.info(
+        `précache : ${shell.length} entrées, ${horsBundle.length} fichiers copiés hors bundle`
+      );
+    },
+  };
+}
+
+// La CSP de DÉVELOPPEMENT, et uniquement de développement. `script-src 'self'` interdit tout
+// script inline : c'est voulu, c'est la raison d'être de rail.js en fichier séparé, et
+// scripts/csp.test.mjs le verrouille. Mais le serveur de dev de Vite injecte son client de
+// rechargement à chaud EN INLINE — sans assouplissement, le dev est inutilisable.
+//
+// L'assouplissement vit ici, dans la réponse HTTP du serveur de dev, et NULLE PART ailleurs :
+//   - `apply: "serve"` fait que ce plugin n'existe pas au build ;
+//   - la réécriture porte sur la réponse, jamais sur le fichier — index.html sur disque garde sa
+//     politique stricte, donc scripts/csp.test.mjs continue de lire la vraie.
+//
+// Deux voies ont été écartées, et il faut le savoir pour ne pas les reprendre : `server.headers`
+// ajouterait une SECONDE politique, or deux CSP s'appliquent en INTERSECTION — un en-tête ne
+// relâche jamais une <meta>, et on finit par éditer index.html « juste pour le dev ». Et retirer
+// la <meta> du template pour l'injecter au build ferait échouer csp.test.mjs, à raison.
+function cspDev() {
+  return {
+    name: "best-hauling:csp-dev",
+    apply: "serve",
+    transformIndexHtml(html) {
+      return html.replace(
+        /(<meta http-equiv="Content-Security-Policy" content=")([^"]+)(")/,
+        (_, avant, politique, apres) => {
+          const assoupli = politique
+            .replace("script-src 'self'", "script-src 'self' 'unsafe-inline' 'unsafe-eval'")
+            .replace("connect-src 'self'", "connect-src 'self' ws:");
+          return avant + assoupli + apres;
+        }
+      );
+    },
+  };
+}
+
+export default defineConfig({
+  // Voir la contrainte 1 en tête de fichier. Ne jamais mettre « / » ni « /best-hauling/ ».
+  base: "./",
+  // Pas de `public/` : les fichiers à nom contractuel restent à la racine pour que la ligne
+  // d'assemblage du déploiement continue de les trouver (voir FICHIERS_RACINE ci-dessus).
+  publicDir: false,
+  build: {
+    outDir: "dist",
+    // Voir la contrainte 2. Ce zéro est la contrepartie de `img-src` sans `data:`.
+    assetsInlineLimit: 0,
+    emptyOutDir: true,
+  },
+  // Aucun port n'est décidé ici, et c'est délibéré : le port des tests est DÉRIVÉ de la copie de
+  // travail (scripts/port.mjs) et scripts/port.test.mjs interdit tout littéral dans
+  // playwright.config.mjs. Un port posé ici serait invisible à ce garde-fou.
+  // L'ordre compte : `horsBundle` retire les assets à nom contractuel et rétablit leurs href, et
+  // `precache` liste ensuite dist/ tel qu'il est réellement. Inverser produirait un manifeste qui
+  // précache des fichiers hachés que plus personne ne référence.
+  plugins: [cspDev(), horsBundle(), precache()],
+});


### PR DESCRIPTION
> **Base : `v2/main`, jamais `main`.** ADR-008 §3 — la refonte vit sur une branche longue, et `main`
> sert la v1 jusqu'à la bascule finale. Fusionner le socle dans `main` ferait construire la CI de la
> v1 avec Vite pour lancer ses e2e : la validation du site en production dépendrait d'une chaîne de
> build qu'il n'utilise pas, et un correctif v1 urgent pourrait s'y bloquer.

## Ce que ça change

Rien pour l'utilisateur, et c'est l'objectif. Le site v1 traverse désormais une **étape de
fabrication** (Vite) sans qu'un seul de ses comportements bouge — et cette fabrication est
**vérifiée**, ce qui est le vrai livrable.

Premier des quatre livrables de la refonte v2 ([ADR-008](docs/superpowers/specs/2026-08-15-refonte-v2-vite-react-adr.md), #96).
**Aucune vue migrée, aucune ligne de React, aucun TypeScript.** Le déploiement n'est pas touché :
ce qui est en ligne ne dépend toujours pas de Vite.

## Pourquoi

### Ce qui rend cette PR démontrable

La suite e2e sert maintenant **`dist/`**, c'est-à-dire ce que le build produit réellement
(`playwright.config.mjs`).

Sans ce changement, la PR ne vaudrait rien : les 184 tests auraient continué de servir les fichiers
du dépôt et seraient restés verts **sans jamais regarder la fabrication**. Ils auraient validé un
`dist/` cassé. Une suite qui ne peut pas échouer ne prouve rien.

`scripts/serve.mjs` acceptait déjà une racine — seule son entrée CLI ne la transmettait pas.

### Trois pannes de production que le build a révélées

Aucune n'aurait fait rougir un seul des 184 tests existants.

**1. Le manifeste PWA, trois pannes d'un coup.** Vite traite `<link rel="manifest">` comme un asset,
le hache et le range sous `assets/`. Son JSON, lui, n'est pas réécrit — et ses chemins sont
**relatifs** :

| dans le manifeste | résolu depuis `assets/` | conséquence |
|---|---|---|
| `"start_url": "./"` | `/assets/` | **l'app installée démarre sur `/assets/`** |
| `"scope": "./"` | `/assets/` | la PWA ne contrôle plus les pages du site |
| `"src": "icon.svg"` | `assets/icon.svg`, inexistant | l'app installée perd son icône |

Corrigé en sortant ces fichiers du bundle par `originalFileNames` — ce que Rollup a réellement lu,
et non un motif sur les noms hachés, pour qu'un futur `icon-2.svg` légitime ne soit pas emporté.

**2. Le mode hors-ligne, supprimé en silence.** `sw.js:11` nomme `app.js`, `logic.mjs`,
`style.css` — que le build renomme. Or `caches.addAll` est **atomique** : une seule URL en 404 fait
rejeter l'ensemble. Le hors-ligne ne se dégrade pas, il **disparaît**, sans erreur visible.
Le build écrit donc désormais la liste (ADR §7). Le source garde sa liste v1 en clair : il reste
lisible, exécutable tel quel, et `version.test.mjs` continue d'y lire `CACHE` sans rien savoir du
plugin. Les `data/*.json` en sont **exclus** — ils ont leur propre stratégie dans `sw.js` (réseau
d'abord), et les précacher les figerait à la version du déploiement.

**3. L'icône inlinée que la CSP rejette.** `img-src` n'a pas `data:`. Sans `assetsInlineLimit: 0`,
`icon.svg` (433 octets) part en base64 et la politique le bloque — **en production seulement**.

### Les décisions qui se lisent dans la config

- **`base: "./"`** — le site vit sous `/best-hauling/`. Un `base` absolu casse la production seule ;
  `"/best-hauling/"` casse les tests seuls, qui servent à la racine. Une seule valeur satisfait les
  deux, et c'est déjà la convention du `start_url`, du `SHELL` et des `fetch`.
- **Les fichiers à nom contractuel restent à la RACINE**, pas dans un `public/`. Je les y avais
  d'abord déplacés : la mise en ligne assemble `_site/` en copiant les **sources**
  (`cp … rail.js … _site/`), donc le déplacement aurait cassé le déploiement. Le socle doit rester
  invisible pour la production tant qu'elle n'a pas basculé.
- **La CSP de dev vit dans un plugin `apply: "serve"`**, qui n'existe pas au build. Deux voies
  écartées, et il faut savoir pourquoi pour ne pas les reprendre : `server.headers` ajouterait une
  **seconde** politique, or deux CSP s'appliquent en **intersection** — un en-tête ne relâche jamais
  une `<meta>`, et on finit par éditer `index.html` « juste pour le dev » ; et retirer la `<meta>`
  du template ferait échouer `csp.test.mjs`, à raison.
- **Aucun port n'est décidé dans `vite.config.mjs`** : le port des tests est dérivé de la copie de
  travail et `port.test.mjs` interdit tout littéral dans `playwright.config.mjs`. Un port posé dans
  la config Vite serait invisible à ce garde-fou.
- **`sw.js`, `update-data.yml` et les `<script>` d'`index.html` ne bougent pas** : les tests
  d'outillage gardent leurs ancres.

## Vérification

```
node --test           ℹ tests 475 · ℹ pass 475 · ℹ fail 0
npx playwright test   190 collectés · 188 passés · 2 ignorés (1,4 min)  SUR LE BUILD
```

Les 6 tests de `e2e/socle.pw.mjs` couvrent ce qu'aucun des 184 ne voyait. **Écrits après le
correctif, leur rouge a donc été prouvé à part** — plugin `horsBundle` retiré, rebuild :

```
2 failed
  Socle : le manifeste est servi à la RACINE, jamais haché sous assets/ (#96)
  Socle : l'icône de la page est servie sous son nom d'origine (#96)
4 passed
```

Une assertion de ces tests était fausse au premier jet et a été corrigée, pas contournée : elle
cherchait `unsafe-inline` en sous-chaîne et confondait le `style-src 'self' 'unsafe-inline'`
**légitime** de production avec une fuite du serveur de dev. Elle compare maintenant directive par
directive.

Deux tests comblent des trous anciens, sans rapport avec Vite mais que ce travail a mis au jour :

- **`rail.js` reste un script CLASSIQUE.** L'invariant est documenté dans `index.html` et dans
  `rail.js` depuis toujours — en faire un module le rendrait différé et le rail s'afficherait
  déplié le temps d'un rendu — et **aucun test ne le couvrait**. Le seul garde-fou était un
  commentaire.
- **L'app démarre aussi par `/`.** C'est l'URL par laquelle une app installée démarre
  (`start_url: "./"`), et les 184 tests visaient tous `/index.html`.

## Ce qui n'est pas couvert

- **Le déploiement n'est pas basculé** : `update-data.yml` assemble toujours `_site/` depuis les
  sources. C'est délibéré — une erreur de déploiement ne se voit qu'**après** fusion, sur le site
  réel, et le socle n'a pas à porter ce risque. `scripts/assembler.mjs` viendra à la PR qui bascule.
- **`csp.test.mjs` valide toujours `index.html` à la racine**, pas `dist/index.html`. L'écart est
  réel et l'ADR §7 l'annonce ; il est couvert en attendant par les tests e2e du socle, qui eux
  tournent sur l'artefact. Le déplacer demande un build dans le job `unit`, qui n'installe rien
  aujourd'hui — même arbitrage que TypeScript, à trancher à la PR `logic.ts`.
- **TypeScript n'entre pas** : le socle n'en a pas besoin pour prouver ce qu'il prouve, et la façon
  d'exécuter des tests `.ts` en CI se tranchera quand on pourra l'essayer pour de vrai.
- **Le dépôt passe de 5 à 44 paquets** dans le lock. C'est le coût assumé par l'ADR §9 : la chaîne
  de build est une surface d'attaque neuve, et la CSP ne protège pas le build.
- **`npm run dev` n'est pas couvert par les tests.** Le serveur de dev sert une CSP assouplie par
  construction ; c'est la raison d'être du plugin, et un test e2e vérifie l'inverse — que cet
  assouplissement ne fuit pas dans le build.

Refs #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)
