### PR TITLE
feat(logic): logic passe en TypeScript, annoté et non réécrit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,34 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
-          node-version: 20
+          # 24 et non 20 depuis que logic est en TypeScript : Node efface les annotations de type à
+          # l'exécution, SANS FLAG à partir de la 23 (la 22 l'exige encore). C'est ce qui permet à ce
+          # job de garder sa propriété — il n'installe toujours RIEN, pas de transpileur, pas de
+          # cache npm — et à `node --test` d'importer logic.ts tel quel.
+          # Attention : l'effacement de types ne VÉRIFIE rien, il retire. C'est le job `types`
+          # ci-dessous qui dit si les annotations sont vraies.
+          node-version: 24
       - name: Tests unitaires (fonctions pures)
         run: node --test
+
+  # Vérification des types, dans son propre job : `node --test` passerait au vert sur des
+  # annotations FAUSSES, puisqu'il les efface sans les lire. Séparé de `unit` pour que le signal
+  # reste lisible — « les types ne collent pas » n'est pas « un test échoue » — et parce que ce job,
+  # lui, doit installer TypeScript.
+  types:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: 24
+          cache: npm
+      - name: Installer les dépendances
+        run: npm ci --no-audit --no-fund
+      - name: Vérification des types
+        run: npm run typecheck
 
   e2e:
     runs-on: ubuntu-latest
@@ -35,9 +60,11 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
-          node-version: 20
+          node-version: 24
           # Cache du registre npm (~/.npm), clé sur package-lock.json. Le job `unit` n'installe
-          # rien — il lance `node --test` sur des modules sans dépendance — donc il n'en a pas besoin.
+          # toujours rien — il lance `node --test` sur des modules sans dépendance, TypeScript
+          # compris depuis que Node efface les types lui-même — donc il n'en a pas besoin. Le job
+          # `types`, lui, installe, et porte donc son propre cache.
           cache: npm
       # Le navigateur pèse plus lourd que les dépendances : sans cache, chaque run le retélécharge
       # et le job passait ~3 min. La clé porte le lockfile, donc un bump de Playwright invalide le

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -49,7 +49,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Tests
         run: node --test

--- a/README.md
+++ b/README.md
@@ -176,17 +176,27 @@ En cas d'échec, une **issue est ouverte automatiquement** (et refermée au reto
                             │ artefact Pages
 ┌─ Front (statique, navigateur) ────────────────────────────────┐
 │  index.html  (+ <meta> Content-Security-Policy)               │
-│    ├─ logic.mjs   ← fonctions PURES (calcul), testées         │
+│    ├─ logic.ts    ← fonctions PURES (calcul), testées         │
 │    ├─ app.js      ← module ES : rendu DOM, état, interactions │
 │    └─ rail.js     ← bascule du menu (script classique)        │
 │  sw.js (service worker) + manifest.webmanifest → PWA offline  │
 └───────────────────────────────────────────────────────────────┘
 ```
 
-**Séparation clé** : toute la logique de calcul sans DOM vit dans [`logic.mjs`](logic.mjs)
+**Séparation clé** : toute la logique de calcul sans DOM vit dans [`logic.ts`](logic.ts)
 (temps de trajet, score, `computeUnits`, **filtres partagés** par vue, corrections, remplissage glouton,
 chaîne, **graphe de marché**, **résumés de commodités**, décodage d'état…), importée à la fois par
 `app.js` (navigateur) et par les tests. `app.js` ne fait que le rendu et le câblage.
+
+Depuis la v2, ce fichier est en **TypeScript**, et le vocabulaire du domaine vit à côté dans
+[`types.ts`](types.ts) — relevé sur les usages et les données réelles, pas inventé. Deux
+conséquences qui ne se devinent pas :
+
+- **Node exécute le TypeScript directement**, en effaçant les annotations (d'où `node >= 24` dans
+  `engines`). Le job de tests de la CI n'installe donc toujours **rien** : ni transpileur, ni cache.
+- **Effacer n'est pas vérifier.** `node --test` passerait au vert sur des annotations fausses.
+  C'est `npm run typecheck` (`tsc --noEmit`) qui le dit, et il a son propre job en CI pour que le
+  signal reste lisible.
 
 **Content-Security-Policy** : l'app injecte des données **communautaires** (noms de terminaux et de
 commodités venus d'UEX) dans `innerHTML`. L'échappement (`esc`) reste la défense qui compte, mais
@@ -500,7 +510,7 @@ survivent pas à la confrontation avec UEX — les 15 points de vente de Quantai
 `scu_sell = 0`, et les 50 000 SCU annoncés à TDD Area 18 dépassent le 99ᵉ centile des capacités
 publiées (médiane 539 SCU). C'est pourquoi l'app ne tente **aucune** remontée progressive du stock :
 elle se contente de dire qu'au-delà de trois heures, ta valeur ne vaut plus rien. La durée vit dans
-`DUREE_VOL` (`logic.mjs`) et se passe en paramètre — elle n'a pas encore de réglage à l'écran.
+`DUREE_VOL` (`logic.ts`) et se passe en paramètre — elle n'a pas encore de réglage à l'écran.
 
 Contrepartie assumée : sur trois heures un comptoir vidé a très probablement déjà tout récupéré, donc
 l'app reste trop pessimiste pendant une partie du délai. En échange, une correction survit à une

--- a/app.js
+++ b/app.js
@@ -22,7 +22,7 @@ import {
   soldeDuPoint, poserChargement, retirerChargement, migrerChargements,
   encodeJourney, decodeJourney,
   migrerCorrections, exporterCorrections, exporterEntrepots,
-} from "./logic.mjs";
+} from "./logic.ts";
 
 // Libellé compact des caisses SCU standard, ex. « 8×32 · 1×16 · 1×4 · 1×2 · 1×1 ».
 // `maxBox` = plafond de caisse du terminal de CHARGEMENT, quand on le connaît : c'est une propriété

--- a/logic.test.mjs
+++ b/logic.test.mjs
@@ -28,7 +28,7 @@ import {
   stationTree, groupOverridesByTerminal,
   isoUTC, secDepuisISO, FORMAT_EXPORT, migrerCorrections,
   exporterCorrections, relireCorrections, exporterEntrepots,
-} from "./logic.mjs";
+} from "./logic.ts";
 
 // ---------- Temps de trajet ----------
 test("tripMinutes : manutention + distance + saut inter-système", () => {

--- a/logic.ts
+++ b/logic.ts
@@ -3,27 +3,49 @@
 
 // ---------- Temps de trajet estimé ----------
 // Constantes approximatives — servent surtout à classer les routes entre elles.
+// Le vocabulaire du domaine vit dans types.ts (refonte v2, ADR-008). `import type` et non
+// `import` : `verbatimModuleSyntax` l'exige, et c'est ce qui permet à Node d'effacer la ligne
+// entière à l'exécution — sans quoi il chercherait un module qui ne rend aucune valeur.
+import type {
+  Ancre, BornesK, Boucle, BoucleFiltrable, Caisse, CandidatChargement, Carte, Chaine,
+  ChaineChiffree, ChampCorrection, ChargementDuSaut, Chargements, ClassableParValeur,
+  CleDeValeur, Commodite, CommoditeChargeable, CommoditeIdentite, CompositionManifeste,
+  ContexteManifeste, Correction, CorrectionRelue, Cote, CoteMarche, CoteResolu, Destination,
+  DetailCommodite, EnteteExport, Entrepots, EtatDecode, EtatVoyageManifeste, ExportCorrections,
+  ExtremitesFrais, Filtres, FiltresBoard, FiltresListe, FiltresVolume, GrilleAutoload,
+  GroupeCorrections, GroupeSoute, InfoTerminal, IntentionLigne, ItemChargeable, Jambe,
+  JambeChaine, LigneChargement, LigneManifeste, Lot, Marche, MargeNette, MetriquesBoucle,
+  MetriquesRoute, MetriquesTrajet, NoeudSysteme, OptionsChaine, OptionsEcoulement,
+  OptionsTournee, PaireFrais, PalierValeur, Parcours, PointFrais, PointMarche, PointVente,
+  PorteursDeRang, Prise, Releves, Resolveur, ResolveurCorrections, ResolveurFrais,
+  RestantManifeste, ResumeCommodite, Retrait, RetraitArret, Route, RouteFiltrable, RouteResolue,
+  SansDebouche, SegmentResolu, Starmap, Station, StoreCorrections, SuggestionArret,
+  SystemeCarte, TarifTerminal, Terminal, TotauxManifeste, Tournee, Trajet, ValeurEffective,
+  ValeursEffectives, VenteEtape, VenteSoute, VueManifeste,
+  VenteAuTerminal, DisqueSysteme,
+} from "./types.ts";
+
 export const HANDLING = 3, PER_DIST = 0.06, JUMP = 4;
-export function tripMinutes(distance, cross) {
+export function tripMinutes(distance: number | null | undefined, cross: boolean): number {
   return 2 * HANDLING + (distance || 0) * PER_DIST + (cross ? JUMP : 0);
 }
-export function loopMinutes(distance, cross) {
+export function loopMinutes(distance: number | null | undefined, cross: boolean): number {
   return 4 * HANDLING + (distance || 0) * PER_DIST + (cross ? 2 * JUMP : 0);
 }
 
 // ---------- Fraîcheur ----------
 // Âge d'un relevé en jours (null si date inconnue). nowSec injectable pour les tests.
-export function ageDays(updated, nowSec = Date.now() / 1000) {
+export function ageDays(updated: number | null | undefined, nowSec: number = Date.now() / 1000): number | null {
   if (!updated) return null;
   return (nowSec - updated) / 86400;
 }
 // Âge d'une route/boucle = le relevé le plus ancien des deux extrémités.
-export function pairAge(a, b, nowSec = Date.now() / 1000) {
+export function pairAge(a: number | null | undefined, b: number | null | undefined, nowSec: number = Date.now() / 1000): number | null {
   const u = a && b ? Math.min(a, b) : a || b || 0;
   return ageDays(u, nowSec);
 }
 // Facteur de fraîcheur : 1.0 tout frais -> 0.2 au-delà de ~11 j ; 0.5 si date inconnue.
-export function freshnessFactor(age) {
+export function freshnessFactor(age: number | null): number {
   if (age == null) return 0.5;
   return Math.max(0.2, 1 - age / 14);
 }
@@ -44,14 +66,14 @@ export function freshnessFactor(age) {
 // Sans ce plancher, 81 % des routes afficheraient une fiabilité de 0, ce qui ne distinguerait plus
 // rien.
 export const CERTITUDE_PLANCHER = 0.5;
-export function certitudeVolume(scuConnus, scuTotal) {
+export function certitudeVolume(scuConnus: number, scuTotal: number): number {
   if (!(scuTotal > 0)) return CERTITUDE_PLANCHER;
   const part = Math.max(0, Math.min(1, scuConnus / scuTotal));
   return CERTITUDE_PLANCHER + (1 - CERTITUDE_PLANCHER) * part;
 }
 // Volume le plus contraignant de deux segments, en ignorant les capacités inconnues
 // (`Math.min(null, x)` vaudrait 0 et ferait passer un segment inconnu pour saturé).
-export function tighterVolume(a, b) {
+export function tighterVolume(a: number | null | undefined, b: number | null | undefined): number | null {
   if (a == null) return b ?? null;
   if (b == null) return a;
   return Math.min(a, b);
@@ -59,7 +81,7 @@ export function tighterVolume(a, b) {
 
 // ---------- Profit horaire & score brut (partagés routes/boucles) ----------
 // Profit par heure d'un trajet (null si le profit n'est pas borné = pas de contrainte de volume).
-export function profitPerHour(profit, minutes) {
+export function profitPerHour(profit: number | null, minutes: number): number | null {
   return profit == null ? null : (profit * 60) / minutes;
 }
 // FIABILITÉ d'une ligne, de 10 à 100. Ce n'est plus un classement : c'est ce qu'on sait de la
@@ -69,7 +91,7 @@ export function profitPerHour(profit, minutes) {
 // 16,7× appliqué à un montant qui s'étale sur plusieurs ordres de grandeur : la route la plus
 // rentable de l'instantané (1 759 500 aUEC) tombait ainsi au 8e rang, derrière une route qui
 // rapporte 2,7 fois moins. On sépare donc les deux questions au lieu de les mélanger.
-export function fiabiliteDe(age, scuConnus, scuTotal) {
+export function fiabiliteDe(age: number | null, scuConnus: number, scuTotal: number): number {
   return Math.round(100 * freshnessFactor(age) * certitudeVolume(scuConnus, scuTotal));
 }
 
@@ -79,12 +101,12 @@ export function fiabiliteDe(age, scuConnus, scuTotal) {
 // parent — la pire ligne du tableau portait ainsi la plus grosse barre. La fiabilité, elle, ne peut
 // plus sortir de [0, 100] par construction (ADR-005) ; ce garde reste en CEINTURE, et parce qu'un
 // score absent doit valoir 0 plutôt qu'un `width:NaN%` qui retomberait dans le même piège.
-export function scoreBarWidth(score) {
+export function scoreBarWidth(score: number | null | undefined): number {
   return Number.isFinite(score) ? Math.min(100, Math.max(0, score)) : 0;
 }
 
 // ---------- Tri (valeurs nulles en bas ; chaînes sensibles à la locale) ----------
-export function bySort(key, dir) {
+export function bySort<T extends Record<string, any> = Record<string, any>>(key: string, dir: number): (a: T, b: T) => number {
   return (a, b) => {
     const av = a[key], bv = b[key];
     if (av == null && bv == null) return 0;
@@ -98,7 +120,7 @@ export function bySort(key, dir) {
 // ---------- Filtrage partagé (routes simples, « En route », boucles) ----------
 // f = { sameOnly, noOutpost, legalOnly, sysFilter, maxAge, q }. sysFilter vide = pas de filtre système.
 // La vue « En route » passe sysFilter:"" (le système d'achat est déjà fixé par le terminal de départ).
-export function routePasses(r, f) {
+export function routePasses(r: RouteFiltrable, f: FiltresListe): boolean {
   if (f.sameOnly && !r.same_system) return false;
   if (f.noOutpost && (r.buy.outpost || r.sell.outpost)) return false;
   if (f.legalOnly && r.illegal) return false;
@@ -111,7 +133,7 @@ export function routePasses(r, f) {
   return true;
 }
 // Boucle A⇄B : le filtre système garde la boucle si A OU B correspond ; recherche sur les deux commodités.
-export function loopPasses(l, f) {
+export function loopPasses(l: BoucleFiltrable, f: FiltresListe): boolean {
   if (f.sameOnly && l.a.system !== l.b.system) return false;
   if (f.noOutpost && (l.a.outpost || l.b.outpost)) return false;
   if (f.legalOnly && (l.out.illegal || l.back.illegal)) return false;
@@ -127,7 +149,7 @@ export function loopPasses(l, f) {
 // ---------- Unités achetables selon les contraintes actives ----------
 // f = { cargo, budget, capStock, useCargo, useBudget }. Infinity si aucune contrainte de volume.
 // demandKnown = true si la demande est fiable (corrigée par l'utilisateur) -> un 0 plafonne à 0.
-export function computeUnits(price, stock, demand, f, demandKnown = false) {
+export function computeUnits(price: number, stock: number, demand: number | null, f: Filtres, demandKnown: boolean = false): number {
   const byCargo = f.useCargo ? f.cargo : Infinity;
   const byBudget = f.useBudget && f.budget > 0 ? Math.floor(f.budget / price) : Infinity;
   let units = Math.min(byCargo, byBudget);
@@ -151,7 +173,7 @@ export function computeUnits(price, stock, demand, f, demandKnown = false) {
 // terminaux) ; null = interrupteur inactif -> `fees` à 0 et profit BRUT, comme avant.
 // Une route non bornée n'a pas de volume : aucun frais n'y est calculable (son profit est déjà
 // null), et son score reste donc assis sur la marge brute par SCU.
-export function routeMetrics(m, f, autoload = null) {
+export function routeMetrics(m: RouteResolue, f: FiltresVolume, autoload: PaireFrais | null = null): MetriquesRoute {
   const units = computeUnits(m.buyPrice, m.buyStock, m.sellDemand, f, m.demandKnown);
   const bounded = isFinite(units);
   const fees = bounded ? haulFee(units, autoload) : 0;
@@ -179,7 +201,7 @@ export function routeMetrics(m, f, autoload = null) {
 // opérations facturées : charge en A + décharge en B pour l'aller, charge en B + décharge en A
 // pour le retour. Les paires sont inversées entre les deux jambes parce que les caisses de chaque
 // jambe sont faites à SON terminal de départ (hypothèse 1).
-export function loopMetrics(out, back, distance, cross, f, autoload = null) {
+export function loopMetrics(out: SegmentResolu, back: SegmentResolu, distance: number | null | undefined, cross: boolean, f: FiltresVolume, autoload: ExtremitesFrais | null = null): MetriquesBoucle {
   const loopMargin = out.margin + back.margin;
   const uOut = computeUnits(out.buyPrice, out.stock, out.demand, f, out.demandKnown);
   const uBack = computeUnits(back.buyPrice, back.stock, back.demand, f, back.demandKnown);
@@ -216,7 +238,7 @@ export function loopMetrics(out, back, distance, cross, f, autoload = null) {
 // aucun frais (interrupteur éteint, ou terminal sans autoload), et volume inconnu — une route non
 // bornée (soute et budget coupés) n'a pas de SCU sur quoi étaler un coût fixe.
 // Le ROI se déduit de la marge nette : (marge × units − frais) / (achat × units) = marge_nette / achat.
-export function netMarginRoi(margin, buyPrice, units, fees) {
+export function netMarginRoi(margin: number, buyPrice: number, units: number | null, fees: number): MargeNette {
   const net = fees > 0 && units > 0 ? margin - fees / units : margin;
   return { margin: net, roi: buyPrice > 0 ? Math.round((net / buyPrice) * 1000) / 10 : 0 };
 }
@@ -239,7 +261,7 @@ export const DUREE_VOL = 3 * 3600;
 //   `staleVol` = le volume a dépassé sa durée de vie -> lui seul est mort, le prix survit.
 // Deux drapeaux et non un objet : `stale` garde exactement son sens d'avant, donc un lecteur qu'on
 // aurait oublié de mettre à jour perd la nouveauté au lieu de lire un objet toujours vrai.
-export function effValue(o, price, vol, dataUpdated, nowSec = Date.now() / 1000, dureeVol = DUREE_VOL) {
+export function effValue(o: Correction | null | undefined, price: number | null, vol: number | null, dataUpdated?: number | null, nowSec: number = Date.now() / 1000, dureeVol: number = DUREE_VOL): ValeursEffectives {
   if (!o) return { price, vol, oprice: false, ovol: false, stale: false, staleVol: false };
   const base = o.base != null ? o.base : o.ts != null ? o.ts : Infinity; // legacy: ts ; sinon jamais périmé
   if (dataUpdated && base !== Infinity && dataUpdated > base) {
@@ -263,7 +285,7 @@ export function effValue(o, price, vol, dataUpdated, nowSec = Date.now() / 1000,
 // `items` déjà triés par ordre de priorité — par marge décroissante quand la soute est la seule
 // contrainte, par rendement du capital quand le budget borne (`manifestsFrom` essaie les deux et
 // garde le meilleur). Plafonné par stock/demande ET budget.
-export function fillCargo(items, cargo, budget) {
+export function fillCargo(items: ItemChargeable[], cargo: number, budget: number): { lines: LigneChargement[]; profit: number } {
   let cargoLeft = cargo;
   let budgetLeft = budget;
   const lines = [];
@@ -295,7 +317,7 @@ export function fillCargo(items, cargo, budget) {
 // été chargée au départ.
 // L'investissement, lui, reste le capital immobilisé à l'achat : les frais sont une charge
 // d'exploitation, pas de la marchandise.
-export function manifestTotals(lines, autoload = null) {
+export function manifestTotals(lines: Partial<LigneManifeste>[], autoload: PaireFrais | null = null): TotauxManifeste {
   let profit = 0, invest = 0, scu = 0, fees = 0;
   for (const l of lines) {
     const u = l.units || 0;
@@ -314,7 +336,7 @@ export function manifestTotals(lines, autoload = null) {
 //   - stock non fini : rien à acheter sur place (butin trouvé ailleurs) — proposer une soute pleine
 //     d'un fret introuvable au terminal de départ chiffrerait un profit qui n'existe pas.
 // Dans les deux cas -> 1 SCU, et l'utilisateur ajuste la quantité à ce qu'il a réellement.
-export function freeAddUnits(stock, cargoLeft) {
+export function freeAddUnits(stock: number | null, cargoLeft: number): number {
   if (!Number.isFinite(stock)) return 1;
   const u = Number.isFinite(cargoLeft) ? Math.max(0, cargoLeft) : 0;
   return Math.max(1, Math.min(u, stock));
@@ -330,7 +352,7 @@ export function freeAddUnits(stock, cargoLeft) {
 // commodité qu'aucun terminal de départ ne vend est classée `acquired` — butin, coût nul — et son
 // profit compte la revente ENTIÈRE comme gain. C'est juste pour du minage ou du salvage, et faux
 // de 250 % pour du fret acheté ailleurs qu'on transporte encore (cf. ADR-002).
-export function manifestLine(c, buy, sell, buyUpdated, sellUpdated, units, cap, paid = null) {
+export function manifestLine(c: CommoditeIdentite, buy: CoteResolu | null, sell: CoteResolu | null, buyUpdated: number, sellUpdated: number, units: number, cap: number, paid: number | null = null): LigneManifeste {
   const porte = paid != null && paid >= 0;          // fret embarqué dont on connaît le coût
   const buyPrice = porte ? paid : buy ? buy.price : 0;
   return {
@@ -353,7 +375,7 @@ export function manifestLine(c, buy, sell, buyUpdated, sellUpdated, units, cap, 
 // Résout les deux côtés d'une commodité entre deux terminaux (corrections locales comprises).
 // `null` d'un côté = ce terminal ne traite pas cette commodité — cas NORMAL, pas une erreur :
 // on charge un fret pour l'écouler ailleurs, ou on transporte un butin acquis ailleurs.
-function resolveSides(market, fromIdx, toIdx, c, resolve) {
+function resolveSides(market: Marche, fromIdx: number, toIdx: number, c: Commodite, resolve: ResolveurCorrections): { b?: PointMarche; s?: PointMarche; eb: ValeursEffectives | null; es: ValeursEffectives | null } {
   const ft = market.terminals[fromIdx], tt = market.terminals[toIdx];
   const b = c.buys.find((x) => x[0] === fromIdx);
   const s = c.sells.find((x) => x[0] === toIdx);
@@ -367,7 +389,7 @@ function resolveSides(market, fromIdx, toIdx, c, resolve) {
 // Ligne de manifeste pour un ajout LIBRE : l'utilisateur choisit la commodité, les unités
 // remplissent l'espace restant. Partagée par « En route » et par les jambes de voyage, qui en
 // tenaient deux copies divergentes — l'une testait le doublon avant de muter l'état, l'autre après.
-export function freeManifestLine(market, fromIdx, toIdx, c, cargoLeft, resolve) {
+export function freeManifestLine(market: Marche, fromIdx: number, toIdx: number, c: Commodite, cargoLeft: number, resolve: ResolveurCorrections): LigneManifeste {
   const { b, s, eb, es } = resolveSides(market, fromIdx, toIdx, c, resolve);
   const u = freeAddUnits(eb ? eb.vol : Infinity, cargoLeft);
   return manifestLine(c, eb, es, b ? b[3] : 0, s ? s[3] : 0, u, u);
@@ -377,7 +399,7 @@ export function freeManifestLine(market, fromIdx, toIdx, c, cargoLeft, resolve) 
 // On ne persiste JAMAIS d'instantané de marché : figé, il continuerait d'afficher le prix du jour
 // de l'édition longtemps après qu'UEX l'ait republié, avec une pastille de fraîcheur qui vieillit
 // sans jamais refléter le vrai relevé. Prix, stock, demande et dates sont donc relus à chaque rendu.
-export function hydrateManifestLine(market, fromIdx, toIdx, c, units, resolve) {
+export function hydrateManifestLine(market: Marche, fromIdx: number, toIdx: number, c: Commodite, units: number, resolve: ResolveurCorrections): LigneManifeste {
   const { b, s, eb, es } = resolveSides(market, fromIdx, toIdx, c, resolve);
   const cap = tighterVolume(eb ? eb.vol : Infinity, es ? es.vol : null);
   return manifestLine(c, eb, es, b ? b[3] : 0, s ? s[3] : 0, units, cap);
@@ -389,8 +411,8 @@ export function hydrateManifestLine(market, fromIdx, toIdx, c, units, resolve) {
 // ne peut pas sortir une caisse de 32, et le nombre de caisses est ce qui décide des frais
 // d'autoload. Absent ou inexploitable (sous la plus petite caisse), on garde la grille complète :
 // mieux vaut une décomposition optimiste qu'un volume qui s'évapore faute de caisse capable.
-export const SCU_BOX_SIZES = [32, 24, 16, 8, 4, 2, 1];
-export function scuBoxes(n, maxBox) {
+export const SCU_BOX_SIZES: number[] = [32, 24, 16, 8, 4, 2, 1];
+export function scuBoxes(n: number | null | undefined, maxBox?: number | null): Caisse[] {
   n = Math.max(0, Math.floor(n || 0));
   const sizes = maxBox >= 1 ? SCU_BOX_SIZES.filter((s) => s <= maxBox) : SCU_BOX_SIZES;
   const out = [];
@@ -407,7 +429,7 @@ export function scuBoxes(n, maxBox) {
 // caisses de 8, pas une de 32) — et ce décompte sert à EXPLIQUER un montant que manifestTotals
 // facture, lui, une ligne à la fois. Un « 📦 1×32 » à côté d'un montant calculé sur quatre caisses
 // serait l'incohérence la plus visible qui soit.
-export function cargoBoxes(lines, maxBox) {
+export function cargoBoxes(lines: Partial<LigneManifeste>[], maxBox?: number | null): Caisse[] {
   const parTaille = new Map();
   for (const l of lines) {
     for (const b of scuBoxes(l.units, maxBox)) parTaille.set(b.size, (parTaille.get(b.size) || 0) + b.count);
@@ -428,11 +450,11 @@ export function cargoBoxes(lines, maxBox) {
 //                qui est précisément ce qui autorise à réduire la station à un simple facteur.
 // `k` est ce facteur : 1 = tarif Endgame (l'ancrage), 1,4 = Ruin Station. Le modèle colle aux
 // 18 relevés à 2,8 % près : c'est une ESTIMATION, tout montant affiché doit porter un « ≈ ».
-export const AUTOLOAD = { base: 150, perBox: 30, perScu: 20 };
+export const AUTOLOAD: GrilleAutoload = { base: 150, perBox: 30, perScu: 20 };
 
 // Frais d'UNE opération (un chargement ou un déchargement) de `scu` SCU dans un terminal plafonné
 // à `maxBox` SCU par caisse, au coefficient de station `k`. Renvoie un entier d'aUEC.
-export function autoloadFee(scu, maxBox, k) {
+export function autoloadFee(scu: number | null, maxBox: number | null | undefined, k: number): number {
   const units = Math.max(0, Math.floor(scu || 0));
   // Rien à manutentionner, ou station qui ne facture pas (k = 0) : aucun frais. La base de 150
   // paie une transaction, pas une visite — la faire payer à vide grèverait un trajet qu'on
@@ -447,7 +469,7 @@ export function autoloadFee(scu, maxBox, k) {
 // facture. k = montant payé / montant que la formule prédirait à l'ancrage (k = 1), au plafond de
 // caisse du terminal. null quand la mesure ne dit rien : sans quantité il n'y a pas de référence à
 // diviser, sans montant il n'y a rien de mesuré (un champ vide donne Number("") = 0, un texte NaN).
-export function kFromReading(amount, scu, maxBox) {
+export function kFromReading(amount: number, scu: number | null, maxBox: number | null | undefined): number | null {
   const ref = autoloadFee(scu, maxBox, 1);
   if (!(ref > 0) || !(amount > 0)) return null;
   return Math.round((amount / ref) * 1000) / 1000;
@@ -463,8 +485,8 @@ export function kFromReading(amount, scu, maxBox) {
 // décalage. Hors bornes, l'appelant fait CONFIRMER, il ne refuse pas — une borne qui perdrait un
 // relevé véritablement surprenant serait pire que le tarif faux qu'elle corrige, et c'est justement
 // parce qu'elle ne coûte qu'un clic qu'on peut la serrer autant.
-export const K_PLAUSIBLE = { min: 0.25, max: 4 };
-export const kPlausible = (k) => k >= K_PLAUSIBLE.min && k <= K_PLAUSIBLE.max;
+export const K_PLAUSIBLE: BornesK = { min: 0.25, max: 4 };
+export const kPlausible = (k: number | null): boolean => k >= K_PLAUSIBLE.min && k <= K_PLAUSIBLE.max;
 
 // ---------- Contexte de frais : un point par terminal, une paire par chargement ----------
 // Tout le moteur reçoit ce contexte en PARAMÈTRE OPTIONNEL, et son absence (null) est le chemin
@@ -476,7 +498,7 @@ export const kPlausible = (k) => k >= K_PLAUSIBLE.min && k <= K_PLAUSIBLE.max;
 // lui qui décide de la taille des caisses, même quand c'est le joueur qui les empile à la main.
 // Les deux champs peuvent manquer du terminal (instantané de market.json antérieur au build qui
 // les ajoute, ou coquille servie depuis le cache du service worker) : lecture défensive.
-export function autoloadPoint(terminal, k) {
+export function autoloadPoint(terminal: Terminal | null | undefined, k: number): PointFrais | null {
   if (!terminal) return null;
   return { maxBox: terminal.maxBox, k: terminal.autoload === true ? k : 0 };
 }
@@ -488,7 +510,7 @@ export function autoloadPoint(terminal, k) {
 // qu'on a — seul le tarif change — d'où le maxBox du terminal d'ACHAT des deux côtés. Le passer
 // en paramètre plutôt que de le laisser au site d'appel évite l'erreur symétrique (re-caisser la
 // cargaison en vol au plafond du terminal d'arrivée), qu'aucune signature ne saurait interdire.
-export function haulFee(scu, pair) {
+export function haulFee(scu: number, pair?: PaireFrais | null): number {
   if (!pair) return 0;
   const { buy, sell } = pair;
   const maxBox = buy ? buy.maxBox : sell && sell.maxBox; // sans achat connu, le seul plafond connu
@@ -505,7 +527,7 @@ export function haulFee(scu, pair) {
 // L'extrémité qui ne manutentionne rien passe à k = 0 au lieu d'être retirée de la paire : elle
 // garde ainsi son `maxBox`, donc le décompte de caisses reste celui du terminal de chargement
 // (hypothèse 1) — c'est-à-dire exactement celui que le « 📦 » de la ligne affiche.
-export function lineHaulFee(units, line, pair) {
+export function lineHaulFee(units: number, line: Partial<LigneManifeste> | null | undefined, pair: PaireFrais | null): number {
   if (!pair) return 0;
   const { carry, acquired } = line || {};
   if (!carry && !acquired) return haulFee(units, pair);
@@ -524,7 +546,7 @@ export function lineHaulFee(units, line, pair) {
 // Elle est NÉGATIVE quand les frais mangent la marge — ce n'est pas un cas limite mais le cas
 // qu'on cherche : c'est exactement à ce signe qu'on reconnaît une ligne qu'il vaut mieux laisser
 // au sol. Tout affichage doit donc porter le signe réel, jamais un « + » posé d'office.
-export function lineNet(units, line, pair) {
+export function lineNet(units: number, line: Partial<LigneManifeste>, pair: PaireFrais | null): number {
   return units * (line.margin || 0) - lineHaulFee(units, line, pair);
 }
 
@@ -544,14 +566,14 @@ export function lineNet(units, line, pair) {
 // Le chargement mono se dit dans la MÊME forme qu'un manifeste — une liste de lignes : la vue
 // Chaîne et le voyage n'ont ainsi qu'un seul format de saut à lire, que l'arc porte le manifeste
 // pré-calculé par buildChainAdjacency ou ce repli à une commodité.
-const ligneDuSaut = (leg, units) => (units <= 0 ? [] : [{
+const ligneDuSaut = (leg: JambeChaine, units: number): LigneManifeste[] => (units <= 0 ? [] : [{
   name: leg.commodity, kind: leg.kind, illegal: leg.illegal,
   buyPrice: leg.buyPrice, sellPrice: leg.sellPrice, margin: leg.margin,
   stock: leg.stock, demand: leg.demand, demandKnown: leg.demandKnown,
   buyUpdated: leg.buyUpdated || 0, sellUpdated: leg.sellUpdated || 0,
   units, cap: units,
 }]);
-export function chainLegNet(leg, cargo) {
+export function chainLegNet(leg: JambeChaine, cargo: number): ChargementDuSaut {
   // Chargement PRÉ-CALCULÉ à la construction de l'adjacence : on le rend tel quel, c'est ce qui
   // tient le coût du faisceau (cf. estampillerManifestes). La soute fait partie de la clé parce que
   // rien n'oblige l'appelant à passer à bestChain celle qui a bâti le graphe : un chargement composé
@@ -573,7 +595,7 @@ export function chainLegNet(leg, cargo) {
 // contre 0,9 ms à faisceau 40 : imperceptible, là où la sous-optimalité, elle, se voyait. Depuis
 // #56 le chargement de chaque saut est pré-calculé (`leg.net`) : le prix du manifeste se paie une
 // fois, à la construction de l'adjacence, et le faisceau n'y touche plus.
-export function bestChain(adj, start, hops, { cargo = Infinity, beam = 400 } = {}) {
+export function bestChain(adj: Map<number, JambeChaine[]>, start: number, hops: number, { cargo = Infinity, beam = 400 }: OptionsChaine = {}): Chaine | null {
   let paths = [{ path: [start], visited: new Set([start]), profit: 0, legs: [] }];
   let best = null;
   for (let h = 0; h < hops; h++) {
@@ -610,7 +632,7 @@ export function bestChain(adj, start, hops, { cargo = Infinity, beam = 400 } = {
 }
 
 // ---------- Unités ajoutables d'une commodité candidate (suggestions) ----------
-export function addableUnits(it, rem) {
+export function addableUnits(it: CommoditeChargeable, rem: RestantManifeste): number {
   let u = rem.cargoLeft;
   u = Math.min(u, it.stock);                          // stock 0 = vide -> non suggéré
   if (it.demand != null || it.demandKnown) u = Math.min(u, it.demand); // null = inconnu ; 0 = saturé
@@ -620,13 +642,13 @@ export function addableUnits(it, rem) {
 
 // ---------- Corrections locales : opérations sur un store injectable ----------
 // Le store est un objet { "commodité|terminal|side": { price?, vol?, base } }.
-export const ovKey = (commodity, terminal, side) => `${commodity}|${terminal}|${side}`;
+export const ovKey = (commodity: string, terminal: string, side: CoteMarche): string => `${commodity}|${terminal}|${side}`;
 
 // Valeur effective (corrigée si besoin) + retrait de ce qui est périmé.
 // Renvoie { price, vol, oprice, ovol, stale, staleVol }. Effets de bord, et rien d'autre :
 //   UEX a republié -> la clé entière part ; le volume a vieilli -> lui seul part, et la clé avec
 //   s'il ne restait que lui.
-export function effFromStore(store, key, price, vol, dataUpdated, nowSec = Date.now() / 1000, dureeVol = DUREE_VOL) {
+export function effFromStore(store: StoreCorrections, key: string, price: number, vol: number, dataUpdated: number, nowSec: number = Date.now() / 1000, dureeVol: number = DUREE_VOL): ValeurEffective {
   const r = effValue(store[key], price, vol, dataUpdated, nowSec, dureeVol);
   if (r.stale) delete store[key];
   else if (r.staleVol) {
@@ -640,7 +662,7 @@ export function effFromStore(store, key, price, vol, dataUpdated, nowSec = Date.
 
 // Enregistre/efface une correction. field = "price"|"vol". value null/"" efface ce champ.
 // baseUpdated = date UEX du point (ancre de fraîcheur). Supprime la clé si plus rien de corrigé.
-export function setInStore(store, key, field, value, baseUpdated, nowSec = Date.now() / 1000) {
+export function setInStore(store: StoreCorrections, key: string, field: ChampCorrection, value: string | number | null | undefined, baseUpdated: number, nowSec: number = Date.now() / 1000): StoreCorrections {
   const o = store[key] || {};
   const n = value == null || value === "" ? NaN : Math.max(0, Math.round(Number(value)));
   if (Number.isFinite(n)) o[field] = n;
@@ -682,7 +704,7 @@ export function setInStore(store, key, field, value, baseUpdated, nowSec = Date.
 // affichée. Les corrections des autres stations ne sont donc jamais interrogées, donc jamais
 // purgées : sans cette passe, leur compteur annoncerait des corrections déjà mortes jusqu'à ce qu'on
 // clique dessus. La bande promet un décompte juste ; c'est ici qu'elle le tient.
-export function groupOverridesByTerminal(store, actif, nowSec = Date.now() / 1000, dureeVol = DUREE_VOL) {
+export function groupOverridesByTerminal(store: StoreCorrections, actif: string | null, nowSec: number = Date.now() / 1000, dureeVol: number = DUREE_VOL): GroupeCorrections[] {
   const parTerminal = new Map();
   for (const cle of Object.keys(store || {})) {
     const seg = cle.split("|");
@@ -719,7 +741,7 @@ export function groupOverridesByTerminal(store, actif, nowSec = Date.now() / 100
 //      de les périmer, et ici on refuse aussi de les rajeunir.
 //
 // Renvoie { store, migres } ; `migres` à 0 = rien à persister (même forme que `migrerRefus`).
-export function migrerCorrections(store) {
+export function migrerCorrections(store: StoreCorrections): { store: StoreCorrections; migres: number } {
   const s = store || {};
   let migres = 0;
   for (const cle of Object.keys(s)) {
@@ -733,16 +755,16 @@ export function migrerCorrections(store) {
 }
 
 // ---------- État partageable (URL / localStorage) ----------
-export const safeKey = (k) => typeof k === "string" && /^[a-zA-Z]+$/.test(k); // anti-injection de sélecteur
+export const safeKey = (k: unknown): boolean => typeof k === "string" && /^[a-zA-Z]+$/.test(k); // anti-injection de sélecteur
 
 // Encode un objet d'état en query-string (ignore les valeurs vides/nulles).
-export function encodeState(obj) {
+export function encodeState(obj: Record<string, any>): string {
   const p = new URLSearchParams();
   Object.entries(obj).forEach(([k, v]) => { if (v !== "" && v != null) p.set(k, v); });
   return p.toString();
 }
 // Décode une query-string en objet (null si vide).
-export function decodeState(str) {
+export function decodeState(str: string | null | undefined): EtatDecode | null {
   return str ? Object.fromEntries(new URLSearchParams(str)) : null;
 }
 
@@ -757,7 +779,7 @@ export function decodeState(str) {
 // null = interrupteur inactif, et c'est le défaut : aucun frais n'est alors calculé nulle part.
 
 // Construit un objet « route » (compatible evaluate/routeRowHTML) depuis un achat + une vente bruts.
-export function dealFrom(market, c, b, s) {
+export function dealFrom(market: Marche, c: Commodite, b: PointMarche, s: PointMarche): Route {
   const bt = market.terminals[b[0]], st = market.terminals[s[0]];
   const margin = s[1] - b[1];
   return {
@@ -780,7 +802,7 @@ export function dealFrom(market, c, b, s) {
 // commodité, la meilleure en net n'entrait jamais dans la liste — le tableau montrait alors une
 // destination pendant que la carte Manifeste, sur le MÊME écran, en affichait une autre.
 // Sans eux — donc par défaut — le critère reste le prix de vente le plus élevé, à l'identique.
-export function enRouteDeals(market, origin, destSystem, destTerminal = null, f = null, autoloadFor = null) {
+export function enRouteDeals(market: Marche, origin: number, destSystem: string, destTerminal: number | null = null, f: Filtres | null = null, autoloadFor: ResolveurFrais | null = null): Route[] {
   const deals = [];
   const buyPoint = autoloadFor ? autoloadFor(market.terminals[origin]) : null;
   market.commodities.forEach((c) => {
@@ -823,7 +845,7 @@ export function enRouteDeals(market, origin, destSystem, destTerminal = null, f 
 // de remplissage. Les deux en tenaient chacune une copie, et elles avaient divergé : la boîte de
 // suggestions ne filtrait que « légales », si bien qu'elle proposait — et permettait d'insérer —
 // des commodités que le manifeste venait d'écarter pour relevé trop vieux ou avant-poste exclu.
-export function pairEligible(f, c, sellTerminal, buyUpdated, sellUpdated) {
+export function pairEligible(f: Filtres, c: Commodite, sellTerminal: Terminal, buyUpdated: number, sellUpdated: number): boolean {
   if (f.legalOnly && c.illegal) return false;
   if (f.noOutpost && sellTerminal.outpost) return false;
   // Fraîcheur : ignore les relevés trop vieux (0 = filtre inactif -> comportement inchangé).
@@ -834,7 +856,7 @@ export function pairEligible(f, c, sellTerminal, buyUpdated, sellUpdated) {
 // Commodités qui pourraient remplir l'espace libre d'un manifeste (même origine -> même
 // destination), hors celles déjà chargées, triées par marge décroissante.
 // `m` = contexte de manifeste { lines, originIdx, destIdx, origin, dest, f }.
-export function suggestionsFrom(market, m, resolve) {
+export function suggestionsFrom(market: Marche, m: ContexteManifeste, resolve: Resolveur): CandidatChargement[] {
   const have = new Set(m.lines.map((l) => l.name));
   const st = market.terminals[m.destIdx];
   const out = [];
@@ -860,7 +882,7 @@ export function suggestionsFrom(market, m, resolve) {
 // gagnante se décide, un net calculé après coup par l'appelant arriverait trop tard. Chaque trajet
 // emporte le contexte de frais qui l'a produit (`fee`), pour que tripMetrics et les recalculs de
 // manifeste d'app.js n'aient pas à le reconstruire — ni à risquer de le reconstruire autrement.
-export function manifestsFrom(market, origin, destSystem, f, resolve, destTerminal = null, autoloadFor = null) {
+export function manifestsFrom(market: Marche, origin: number, destSystem: string, f: Filtres, resolve: Resolveur, destTerminal: number | null = null, autoloadFor: ResolveurFrais | null = null): Trajet[] {
   if (!f.useCargo || !(f.cargo > 0)) return [];
   const ot = market.terminals[origin];
   const byDest = new Map();
@@ -973,7 +995,7 @@ export function manifestsFrom(market, origin, destSystem, f, resolve, destTermin
 // `origin`, soute remplie par marge décroissante (fillCargo). Toujours plafonné par stock/demande
 // (ce qui force à diversifier). Null si la soute n'est pas contrainte.
 // `destTerminal` (index) force un terminal d'arrivée précis ; sinon `destSystem` filtre par système.
-export function bestManifest(market, origin, destSystem, f, resolve, destTerminal = null, autoloadFor = null) {
+export function bestManifest(market: Marche, origin: number, destSystem: string, f: Filtres, resolve: Resolveur, destTerminal: number | null = null, autoloadFor: ResolveurFrais | null = null): Trajet | null {
   return manifestsFrom(market, origin, destSystem, f, resolve, destTerminal, autoloadFor)[0] || null;
 }
 
@@ -990,7 +1012,7 @@ export function bestManifest(market, origin, destSystem, f, resolve, destTermina
 // une jambe de voyage ne doit pas figer une marge nette dans le parcours, où elle se cumulerait
 // avec les marges brutes des jambes venues des autres vues — et où elle survivrait à l'extinction
 // de l'interrupteur, jusque dans le permalien `j=`.
-export function tripMetrics(trip) {
+export function tripMetrics(trip: Trajet): MetriquesTrajet {
   const { profit, invest, scu, fees } = manifestTotals(trip.lines, trip.fee);
   const minutes = tripMinutes(0, trip.cross);
   const profitHour = profitPerHour(profit, minutes);
@@ -1025,7 +1047,7 @@ export function tripMetrics(trip) {
 // La jambe retient la marge de MARCHÉ (`marginGross`), jamais la marge nette : elle est persistée
 // et voyage dans le permalien `j=`, où des frais estimés au moment du clic n'auraient plus aucun
 // sens — l'interrupteur peut être éteint depuis, ou le tarif de la station avoir changé.
-export function legFromTrip(t) {
+export function legFromTrip(t: Omit<Trajet, "lines"> & { lines: any[]; margin?: number; marginGross?: number }): Jambe {
   const top = t.lines[0] || {};
   return {
     from: t.origin.name, fromSystem: t.origin.system, to: t.dest.name, toSystem: t.dest.system,
@@ -1042,7 +1064,7 @@ export function legFromTrip(t) {
 // avec les marges brutes des jambes venues des autres vues. Sans ce calcul, legFromTrip retomberait
 // sur `t.margin` absent -> une jambe à 0 figée dans le lien.
 // Ne PAS dériver la marge de `man.profit` : il est déjà net des frais.
-export function legFromManifest(man) {
+export function legFromManifest(man: Trajet): Jambe {
   return legFromTrip({ ...man, marginGross: tripMetrics(man).marginGross });
 }
 
@@ -1057,8 +1079,11 @@ export function legFromManifest(man) {
 // ultérieur ne réordonne que ces `limit` meilleurs trajets par profit). Ce profit est le NET dès
 // que `autoloadFor` est fourni : la troncature décide QUELS trajets existent, un trajet meilleur
 // en net serait donc coupé par le garde-fou avant même d'atteindre le tableau.
-export function multiTrips(market, f, resolve, limit = 300, minLines = 2, autoloadFor = null) {
-  const origins = new Set();
+export function multiTrips(market: Marche, f: Filtres, resolve: Resolveur, limit = 300, minLines = 2, autoloadFor: ResolveurFrais | null = null): Trajet[] {
+  // `Set<number>` et non `new Set()` : ces valeurs sont des INDEX de terminaux (b[0] d'un point de
+  // marché), et sans annotation TypeScript infère `unknown` — market.terminals[origin] devient
+  // alors inindexable. Le type dit ce que la donnée est, il ne la change pas.
+  const origins = new Set<number>();
   market.commodities.forEach((c) => c.buys.forEach((b) => origins.add(b[0])));
   const out = [];
   for (const origin of origins) {
@@ -1087,7 +1112,7 @@ export function multiTrips(market, f, resolve, limit = 300, minLines = 2, autolo
 // que la commodité voisine, elle, remplissait la soute et rapportait. On classe donc sur le profit
 // net au volume emportable dès que les frais sont actifs, et sur la marge sinon : le critère
 // historique est conservé au caractère près tant que l'interrupteur est inactif.
-export function buildChainAdjacency(market, f, resolve, autoloadFor = null) {
+export function buildChainAdjacency(market: Marche, f: Filtres, resolve: Resolveur, autoloadFor: ResolveurFrais | null = null): Map<number, JambeChaine[]> {
   const best = new Map(); // Map<u, Map<v, leg>>
   const cargo = f.useCargo && f.cargo > 0 ? f.cargo : Infinity;
   // Un seul segment survit par paire de terminaux : le retenir sur la marge nue évince pour de bon
@@ -1165,7 +1190,7 @@ export function buildChainAdjacency(market, f, resolve, autoloadFor = null) {
 // entre les sauts d'une même chaîne. Deux sauts peuvent acheter la même commodité à deux terminaux
 // différents, et le multi-commodités multiplie ces croisements — c'était déjà le cas avant #56, et
 // rien dans les données d'UEX ne dit à quel rythme un terminal se recharge.
-function estampillerManifestes(market, best, f, resolve, autoloadFor, cargo) {
+function estampillerManifestes(market: Marche, best: Map<number, Map<number, JambeChaine>>, f: Filtres, resolve: Resolveur, autoloadFor: ResolveurFrais | null, cargo: number): void {
   // Budget neutralisé : la chaîne l'ignore par construction (README, matrice des filtres, note ¹),
   // et le laisser borner le remplissage ferait dire à la vue l'inverse de ce qu'elle annonce.
   const sansBudget = { ...f, useBudget: false };
@@ -1195,7 +1220,7 @@ function estampillerManifestes(market, best, f, resolve, autoloadFor, cargo) {
 // classait et coloriait sur les prix BRUTS d'UEX : on corrigeait un prix dans un tableau, et la
 // tuile de la commodité — sa marge, sa couleur, son rang — continuait d'afficher l'ancien chiffre.
 // Optionnel pour rester pur par défaut (les tests l'appellent sans).
-export function commoditySummaries(market, f = {}, resolve = null) {
+export function commoditySummaries(market: Marche, f: FiltresBoard = {}, resolve: Resolveur | null = null): ResumeCommodite[] {
   const loot = f.board === "loot";
   const out = [];
   const prix = (c, p, side) => (resolve ? resolve(c.name, market.terminals[p[0]].name, side, p[1], p[2], p[3]).price : p[1]);
@@ -1229,7 +1254,7 @@ export function commoditySummaries(market, f = {}, resolve = null) {
 // `resolve` : mêmes corrections locales que partout ailleurs (cf. commoditySummaries). Le tri
 // « moins cher d'abord » / « mieux payé d'abord » porte donc sur les valeurs CORRIGÉES — sinon la
 // liste se serait ordonnée sur des prix que l'utilisateur venait justement de démentir.
-export function commodityPoints(market, name, f = {}, resolve = null) {
+export function commodityPoints(market: Marche, name: string, f: Filtres = {}, resolve: Resolveur | null = null): DetailCommodite | null {
   const c = market.commodities.find((x) => x.name === name);
   if (!c) return null;
   const T = (i) => market.terminals[i];
@@ -1254,7 +1279,7 @@ export function commodityPoints(market, name, f = {}, resolve = null) {
 // Le classement se fait sur la VALEUR, jamais sur l'ordre d'affichage : trier par code A→Z ne
 // doit pas recolorer le board. Les ex æquo partagent donc le rang du premier d'entre eux
 // (classement « olympique ») : à prix égal, même palier, quel que soit l'ordre reçu.
-export function valueTiers(rows, key = "bestSell") {
+export function valueTiers(rows: ClassableParValeur[], key: CleDeValeur = "bestSell"): Map<string, PalierValeur> {
   const tiers = new Map();
   const ranked = [];
   for (const r of rows) {
@@ -1273,7 +1298,7 @@ export function valueTiers(rows, key = "bestSell") {
 }
 
 // Notation compacte K/M pour les tuiles du board (ex. 9600 -> "9.6K", 1_600_000 -> "1.6M").
-export function compactValue(n) {
+export function compactValue(n: number | null): string {
   if (n == null || !isFinite(n)) return "—";
   const a = Math.abs(n);
   if (a >= 1e6) return Math.round(n / 1e5) / 10 + "M";
@@ -1286,7 +1311,7 @@ export function compactValue(n) {
 // « Copper » (échangeable) et « Copper (Ore) » (butin, aucun point d'achat). Une recherche par
 // `find()` sur nom-ou-code renvoyait donc toujours la première et rendait l'autre inatteignable.
 // D'où : le nom exact prime, et un code ambigu ne résout RIEN plutôt que d'en désigner une au hasard.
-export function resolveCommodity(commodities, query) {
+export function resolveCommodity(commodities: Commodite[], query: string | null | undefined): Commodite | null {
   const q = String(query ?? "").trim().toLowerCase();
   if (!q) return null;
   const byName = commodities.find((c) => c.name.toLowerCase() === q);
@@ -1297,7 +1322,7 @@ export function resolveCommodity(commodities, query) {
 
 // Codes portés par PLUSIEURS commodités de la liste. Le board n'affiche le code seul que s'il
 // identifie sa commodité : sinon deux tuiles seraient rigoureusement indiscernables à l'écran.
-export function ambiguousCodes(rows) {
+export function ambiguousCodes(rows: { code?: string }[]): Set<unknown> {
   const seen = new Set(), dup = new Set();
   for (const r of rows) {
     if (!r.code) continue;
@@ -1310,10 +1335,10 @@ export function ambiguousCodes(rows) {
 // ---------- Libellé canonique d'une station « Nom — Système » ----------
 // Clé unique des datalists et des maps terminal (originMap/stationMap) côté app. Un seul endroit
 // définit le format -> pas de divergence entre les ~15 sites qui le construisaient à la main.
-export const stationLabel = (name, system) => `${name} — ${system}`;
+export const stationLabel = (name: string, system: string): string => `${name} — ${system}`;
 // Sépare un libellé en { name, system }. Coupe au PREMIER « — » (le nom prime), cohérent avec
 // l'ancien `label.split(" — ")[0]`. Renvoie system:"" si le séparateur est absent.
-export function parseStationLabel(label) {
+export function parseStationLabel(label: string | null | undefined): Station {
   const s = String(label ?? "");
   const i = s.indexOf(" — ");
   return i < 0 ? { name: s, system: "" } : { name: s.slice(0, i), system: s.slice(i + 3) };
@@ -1332,7 +1357,7 @@ const ORDRE_SYSTEMES = ["Stanton", "Pyro", "Nyx"];
 // test « orbite ≠ nom » était donc vrai partout, et la règle fausse sur 11 des 12. Le champ
 // n'achetait qu'un seul libellé utile — « Delamar » pour Levski — au prix de cette erreur : on y a
 // renoncé, et les 12 tombent ensemble dans « Espace profond ».
-const zoneDe = (t) => t.planet || "Espace profond";
+const zoneDe = (t: Terminal): string => t.planet || "Espace profond";
 
 // Range les terminaux en système › zone › station, pour un sélecteur qui se parcourt à l'œil.
 // Fonction PURE : elle reçoit le tableau, ne lit aucune globale, et ne le modifie pas.
@@ -1340,7 +1365,7 @@ const zoneDe = (t) => t.planet || "Espace profond";
 // Chaque station porte `i`, son index dans le tableau d'ENTRÉE : c'est la seule clé fiable, `code`
 // n'étant pas unique (PYROG désigne les deux Pyro Gateway). `label` est pré-calculé parce que c'est
 // lui, et lui seul, que le champ doit recevoir — resolveStation résout par correspondance exacte.
-export function stationTree(terminals) {
+export function stationTree(terminals: Terminal[] | null): NoeudSysteme[] {
   const parSysteme = new Map();
   (terminals || []).forEach((t, i) => {
     const systeme = t.system || "?";
@@ -1374,7 +1399,7 @@ export function stationTree(terminals) {
 //   va de stations[current] à stations[current+1].
 
 // Construit une jambe depuis un trajet évalué (vue Trajets / En route).
-export function legFromRoute(r) {
+export function legFromRoute(r: Route): Jambe {
   return {
     from: r.buy.terminal, fromSystem: r.buy.system, to: r.sell.terminal, toSystem: r.sell.system,
     commodity: r.commodity, buyPrice: r.buy.price, sellPrice: r.sell.price, margin: r.margin,
@@ -1383,7 +1408,7 @@ export function legFromRoute(r) {
 // Les filtres de la vue, appliqués à une destination candidate du VOYAGE. `sysFilter` borne le
 // système d'ACHAT : dans un parcours l'origine est imposée par la jambe précédente, pas choisie
 // dans le menu — le neutraliser ici, comme le fait « En route », est la seule différence.
-const legPasses = (r, f) => routePasses(r, { ...f, sysFilter: "" });
+const legPasses = (r: Route, f: Filtres): boolean => routePasses(r, { ...f, sysFilter: "" });
 
 // Destinations rentables depuis `origin` (index de terminal), pour proposer un arrêt de voyage :
 // une entrée par terminal d'arrivée, celle de meilleure marge, les `limit` premières.
@@ -1392,7 +1417,7 @@ const legPasses = (r, f) => routePasses(r, { ...f, sysFilter: "" });
 // « légales uniquement » est coché, avant-poste exclu, relevé périmé — et la jambe ajoutée
 // s'affichait « aucun fret rentable », son manifeste étant filtré, lui, par pairEligible.
 // Même divergence de règles que celle qui a donné pairEligible : une seule source, partagée.
-export function stopSuggestions(market, origin, f, limit = 4) {
+export function stopSuggestions(market: Marche, origin: number, f: Filtres, limit: number = 4): SuggestionArret[] {
   const byDest = new Map();
   for (const d of enRouteDeals(market, origin, "", null, f)) {
     if (!legPasses(d, f)) continue;
@@ -1406,7 +1431,7 @@ export function stopSuggestions(market, origin, f, limit = 4) {
 }
 // Meilleure jambe entre deux terminaux (commodité de marge max), filtres appliqués comme
 // ci-dessus, ou null si aucun fret éligible : l'appelant pose alors une jambe « à vide ».
-export function bestLegBetween(market, fromIdx, toIdx, f) {
+export function bestLegBetween(market: Marche, fromIdx: number, toIdx: number, f: Filtres): Jambe | null {
   const deals = enRouteDeals(market, fromIdx, "", toIdx, f).filter((d) => legPasses(d, f));
   if (!deals.length) return null;
   return legFromRoute(deals.reduce((a, b) => (b.margin > a.margin ? b : a)));
@@ -1416,7 +1441,7 @@ export function bestLegBetween(market, fromIdx, toIdx, f) {
 // `startAt` = terminal par lequel entrer dans le cycle : une boucle A⇄B se parcourt aussi bien
 // B->A->B que A->B->A. Sans lui, on partirait toujours de `a`, et une boucle raccordée au parcours
 // par son `b` ne s'enchaînerait pas -> addToJourney REMPLACERAIT le voyage au lieu de l'étendre.
-export function legsFromLoop(l, startAt) {
+export function legsFromLoop(l: Boucle, startAt?: string | null): [Jambe, Jambe] {
   const out = { from: l.a.terminal, fromSystem: l.a.system, to: l.b.terminal, toSystem: l.b.system, commodity: l.out.commodity, buyPrice: l.out.buyPrice, sellPrice: l.out.sellPrice, margin: l.out.margin };
   const back = { from: l.b.terminal, fromSystem: l.b.system, to: l.a.terminal, toSystem: l.a.system, commodity: l.back.commodity, buyPrice: l.back.buyPrice, sellPrice: l.back.sellPrice, margin: l.back.margin };
   return startAt === l.b.terminal && startAt !== l.a.terminal ? [back, out] : [out, back];
@@ -1426,7 +1451,7 @@ export function legsFromLoop(l, startAt) {
 // trajet multi-commodité (legFromTrip), la jambe ne retient donc que la ligne de TÊTE en libellé, et
 // la vue Voyage recompose le chargement complet à l'affichage (legManifest). Prendre la tête du
 // manifeste plutôt que le repli mono de l'arc est ce qui fait dire la même commodité aux deux vues.
-export function legsFromChain(chain, terminals) {
+export function legsFromChain(chain: ChaineChiffree, terminals: Terminal[]): Jambe[] {
   return chain.legs.map((leg, i) => {
     const from = terminals[chain.path[i]], to = terminals[chain.path[i + 1]];
     const tete = (leg.lines && leg.lines[0]) || { name: leg.commodity, buyPrice: leg.buyPrice, sellPrice: leg.sellPrice, margin: leg.margin };
@@ -1435,18 +1460,18 @@ export function legsFromChain(chain, terminals) {
 }
 
 // Démarre un parcours neuf à partir de jambes (position au départ).
-export function startJourney(legs) {
+export function startJourney(legs: Jambe[]): Parcours {
   return { legs: legs.slice(), current: 0 };
 }
 // Démarre un parcours « de zéro » : juste un point de départ, sans jambe encore.
 // On construit ensuite le parcours en ajoutant des arrêts (addToJourney).
-export function startJourneyAt(station) {
+export function startJourneyAt(station: Station | null | undefined): Parcours | null {
   if (!station || !station.name) return null;
   return { legs: [], current: 0, start: { name: station.name, system: station.system } };
 }
 // Stations ordonnées du parcours : [{ name, system }, …] (legs.length + 1 entrées).
 // Cas « de zéro » : pas de jambe mais un point de départ -> une seule station.
-export function journeyStations(journey) {
+export function journeyStations(journey: Parcours | null): Station[] {
   if (!journey) return [];
   if (!journey.legs.length) return journey.start ? [{ name: journey.start.name, system: journey.start.system }] : [];
   const st = [{ name: journey.legs[0].from, system: journey.legs[0].fromSystem }];
@@ -1454,17 +1479,17 @@ export function journeyStations(journey) {
   return st;
 }
 // Dernière station (fin du parcours planifié), ou null.
-export function journeyEnd(journey) {
+export function journeyEnd(journey: Parcours | null): Station | null {
   const st = journeyStations(journey);
   return st.length ? st[st.length - 1] : null;
 }
 // Les nouvelles jambes s'enchaînent-elles à la fin du parcours ? (leur départ == dernière station)
-export function journeyConnects(journey, legs) {
+export function journeyConnects(journey: Parcours | null, legs: { from: string }[]): boolean {
   const end = journeyEnd(journey);
   return !!(end && legs.length && legs[0].from === end.name);
 }
 // Politique produit : ÉTENDRE si ça s'enchaîne (ajoute à la fin, garde la position), sinon REMPLACER.
-export function addToJourney(journey, legs) {
+export function addToJourney(journey: Parcours | null, legs: Jambe[]): Parcours {
   if (journeyConnects(journey, legs)) return { legs: journey.legs.concat(legs), current: journey.current };
   return startJourney(legs);
 }
@@ -1487,7 +1512,7 @@ export function addToJourney(journey, legs) {
 // vérité, qui suivra son durcissement éventuel. Comme elle — et comme legKey — on compare les NOMS
 // de station seuls : introduire ici une seconde règle d'identité (nom + système) ferait diverger
 // deux définitions du même mot.
-export function manifestJourneyState(journey, origin, dest) {
+export function manifestJourneyState(journey: Parcours | null, origin: { name: string }, dest: { name: string }): EtatVoyageManifeste {
   if (!journey) return { etat: "ajouter" };
   if (journeyConnects(journey, [{ from: origin.name }])) return { etat: "ajouter" };
   const cur = currentLeg(journey);
@@ -1519,7 +1544,7 @@ export function manifestJourneyState(journey, origin, dest) {
 // `chargees` par défaut vide : un appelant qui l'oublierait ne fige RIEN plutôt que de retomber en
 // silence sur l'ancienne règle. Ne pas figer se rattrape tout seul au rendu suivant ; figer à tort
 // ne se défait qu'à la main, par un « ↺ optimal » qui emporte aussi les ajustements légitimes.
-export function legsToPin(legs, lignesPar, commodity, terminal, side, chargees = []) {
+export function legsToPin(legs: Jambe[], lignesPar: { name: string }[][], commodity: string, terminal: string, side: Cote, chargees: boolean[] = []): number[] {
   const bouts = legs.map((l) => (side === "buy" ? l.from : l.to));
   return legs.map((_, i) => i).filter((i) =>
     chargees[i] && bouts[i] === terminal && (lignesPar[i] || []).some((l) => l.name === commodity)
@@ -1531,12 +1556,12 @@ export function legsToPin(legs, lignesPar, commodity, terminal, side, chargees =
 // continuerait d'afficher le prix du jour de l'édition longtemps après qu'UEX l'ait republié.
 // Aucun filtre sur `units` : un 0 posé volontairement est une décision de l'utilisateur
 // (editLegQty l'autorise explicitement) et doit survivre.
-export function manifestIntent(lines) {
+export function manifestIntent(lines: IntentionLigne[]): IntentionLigne[] {
   return lines.map((l) => ({ name: l.name, units: l.units }));
 }
 // Deux intentions décrivent-elles le même chargement ? Sert à ne RIEN persister quand le manifeste
 // n'a pas été touché : la jambe reste alors branchée sur le marché et sur les filtres.
-export function sameIntent(a, b) {
+export function sameIntent(a: IntentionLigne[], b: IntentionLigne[]): boolean {
   return a.length === b.length && a.every((l, i) => l.name === b[i].name && l.units === b[i].units);
 }
 
@@ -1551,7 +1576,7 @@ export function sameIntent(a, b) {
 // filtre de système d'arrivée ("" s'il est vide).
 // Une composition SANS ligne en est une : vider le manifeste pour le recomposer à soi est un geste,
 // et lui rendre l'optimal au prochain rendu serait exactement le défaut qu'on corrige.
-export function manifestIntentSurvives(edit, vue) {
+export function manifestIntentSurvives(edit: CompositionManifeste | null, vue: VueManifeste): boolean {
   if (!edit || !Array.isArray(edit.lines)) return false;
   if (edit.from !== vue.from.name || edit.fromSystem !== vue.from.system) return false;
   if (vue.dest && (vue.dest.name !== edit.to || vue.dest.system !== edit.toSystem)) return false;
@@ -1564,7 +1589,7 @@ export function manifestIntentSurvives(edit, vue) {
 // Renvoie { legs, current, removedFrom, removedCount, insertedCount }, plus `start` quand il ne
 // reste qu'un arrêt (parcours « départ posé »), ou null quand il ne reste plus rien du tout.
 // Les trois compteurs servent à réindexer les manifestes édités par jambe.
-export function removeJourneyStop(journey, stopIndex, bridge) {
+export function removeJourneyStop(journey: Parcours, stopIndex: number, bridge?: Jambe | null): RetraitArret | null {
   const legs = journey.legs;
   // Parcours déjà réduit à son point de départ : retirer ce dernier arrêt efface tout.
   if (!legs.length) return null;
@@ -1611,7 +1636,7 @@ export function removeJourneyStop(journey, stopIndex, bridge) {
 // a disparu du parcours. Une clé illisible ressort INTACTE : on ne renumérote pas ce qu'on n'a pas
 // su lire, et surtout on n'écrit pas de « NaN| » dans un store persisté.
 // `retrait` = ce que removeJourneyStop vient de renvoyer.
-export function cleApresRetrait(cle, { removedFrom, removedCount, insertedCount = 0 }) {
+export function cleApresRetrait(cle: string, { removedFrom, removedCount, insertedCount = 0 }: Retrait): string | null {
   const s = String(cle), sep = s.indexOf("|");
   const i = sep < 0 ? NaN : Number(s.slice(0, sep));
   if (!Number.isInteger(i) || i < 0) return cle;
@@ -1620,7 +1645,7 @@ export function cleApresRetrait(cle, { removedFrom, removedCount, insertedCount 
   return `${i - (removedCount - insertedCount)}${s.slice(sep)}`; // après : recule d'autant
 }
 
-const sansEtiquette = (lot) => { const { leg, ...reste } = lot; return reste; };
+const sansEtiquette = (lot: Lot): Lot => { const { leg, ...reste } = lot; return reste; };
 
 // Réindexe LES QUATRE PORTEURS d'un seul appel — c'est tout l'intérêt : ils ne peuvent plus
 // diverger, et un appelant ne peut plus en oublier un. Les STORES perdent l'entrée d'une jambe
@@ -1631,7 +1656,7 @@ const sansEtiquette = (lot) => { const { leg, ...reste } = lot; return reste; };
 // Le registre suit la même règle que les stores : la déduction d'une jambe disparue reste posée sur
 // le rayon — le fret est parti avec, il n'est pas revenu — mais plus rien ne peut l'annuler, comme
 // pour les lots qu'on vient de délier.
-export function reindexerRangsJambe({ edits = {}, pins = {}, lots = [], chargements = {} }, retrait) {
+export function reindexerRangsJambe({ edits = {}, pins = {}, lots = [], chargements = {} }: PorteursDeRang, retrait: Retrait): Required<PorteursDeRang> {
   const decale = (store) => {
     const suivant = {};
     for (const [k, v] of Object.entries(store)) {
@@ -1656,7 +1681,7 @@ export function reindexerRangsJambe({ edits = {}, pins = {}, lots = [], chargeme
 // fret payé (ADR-002). Sans ça, un voyage ultérieur dont la jambe 0 relie les deux mêmes terminaux
 // s'affichait « ⬢ à bord » et le clic déchargeait les lots de l'ancien — la résurrection déjà
 // corrigée pour les manifestes édités, à laquelle les étiquettes avaient échappé.
-export function detacherLotsDeJambe(lots) {
+export function detacherLotsDeJambe(lots: Lot[]): Lot[] {
   return lots.map((l) => (l.leg == null ? l : sansEtiquette(l)));
 }
 
@@ -1686,7 +1711,7 @@ export function detacherLotsDeJambe(lots) {
 // La `ref` retenue est la PLUS GRANDE : deux prises au même point la partagent par construction,
 // sauf après migration d'une soute ancienne où chaque lot portait le stock déjà amputé qu'il avait
 // lu. La plus grande est alors la plus ancienne, donc ce que la station annonçait vraiment.
-export function soldeDuPoint(chargements, name, terminal, sauf = null) {
+export function soldeDuPoint(chargements: Chargements | null, name: string, terminal: string, sauf: string | null = null): { ref: number | null; pris: number } {
   let ref = null, pris = 0;
   for (const [cle, prises] of Object.entries(chargements || {})) {
     if (cle === sauf || !Array.isArray(prises)) continue;
@@ -1699,14 +1724,14 @@ export function soldeDuPoint(chargements, name, terminal, sauf = null) {
   return { ref, pris };
 }
 
-export function poserChargement(chargements, cle, prises) {
+export function poserChargement(chargements: Chargements, cle: string, prises: Prise[] | null): Chargements {
   return {
     ...chargements,
     [cle]: (prises || []).map((p) => ({ name: p.name, terminal: p.terminal, ref: p.ref, units: p.units })),
   };
 }
 
-export function retirerChargement(chargements, cle) {
+export function retirerChargement(chargements: Chargements | null, cle: string): Chargements {
   const { [cle]: _parti, ...reste } = chargements || {};
   return reste;
 }
@@ -1717,7 +1742,7 @@ export function retirerChargement(chargements, cle) {
 // rien touché. Aucune correction n'est écrite : on ne fait que retrouver qui a pris quoi.
 // `avant` est ensuite retiré des lots — le registre le porte, et deux sources divergeraient.
 // Renvoie { chargements, lots, change } ; `change` faux = rien à persister.
-export function migrerChargements(chargements, lots) {
+export function migrerChargements(chargements: Chargements | null, lots: Lot[] | null): { chargements: Chargements; lots: Lot[]; change: boolean } {
   const connus = chargements || {};
   const source = lots || [];
   const ajout = {};
@@ -1738,15 +1763,15 @@ export function migrerChargements(chargements, lots) {
 }
 
 // Déplace la position courante (bornée à 0..legs.length).
-export function setJourneyPosition(journey, i) {
+export function setJourneyPosition(journey: Parcours, i: number): Parcours {
   return { ...journey, current: Math.max(0, Math.min(journey.legs.length, i | 0)) };
 }
 // Jambe courante (stations[current] -> [current+1]), ou null si on est à la dernière station.
-export function currentLeg(journey) {
+export function currentLeg(journey: Parcours | null): Jambe | null {
   return journey && journey.current < journey.legs.length ? journey.legs[journey.current] : null;
 }
 // Profit total du parcours = somme des marges (les unités sont décidées ailleurs par vue).
-export function journeyMargin(journey) {
+export function journeyMargin(journey: Parcours | null): number {
   return journey ? journey.legs.reduce((a, l) => a + (l.margin || 0), 0) : 0;
 }
 
@@ -1763,7 +1788,7 @@ export function journeyMargin(journey) {
 // Charge un manifeste dans la soute : un lot par ligne, au prix que l'app venait d'afficher.
 // Les lignes sans quantité ne créent pas de lot (on n'a rien chargé), et une ligne déjà à bord
 // (`aBord`) n'est pas rechargée — elle ne fait que traverser le manifeste.
-export function loadHold(hold, lignes, from, at) {
+export function loadHold(hold: Lot[], lignes: LigneManifeste[], from: string, at: number): Lot[] {
   const lots = lignes
     .filter((l) => (l.units || 0) > 0 && !l.aBord)
     .map((l) => ({ name: l.name, units: l.units, paid: l.buyPrice || 0, from: from || "", at: at || 0 }));
@@ -1791,7 +1816,7 @@ export function loadHold(hold, lignes, from, at) {
 // NÉGATIF est ramené à 0 : un achat ne rapporte pas d'argent, le pire cas est le coût nul.
 // Sans nom ou sans quantité, on rend la MÊME soute : l'identité dit « rien n'a bougé », et
 // l'appelant y rend la main sans écrire — même convention que `storeFromHold`.
-export function declarerLot(hold, { name, units, paid } = {}, at = 0) {
+export function declarerLot(hold: Lot[], { name, units, paid }: { name?: string; units?: number; paid?: number } = {}, at: number = 0): Lot[] {
   const nom = typeof name === "string" ? name.trim() : "";
   const scu = Math.floor(Number(units) || 0);
   if (!nom || scu <= 0) return hold;
@@ -1799,12 +1824,12 @@ export function declarerLot(hold, { name, units, paid } = {}, at = 0) {
 }
 
 // SCU à bord, toutes commodités confondues — donc la place qu'il reste pour charger.
-export const holdScu = (hold) => hold.reduce((s, l) => s + (l.units || 0), 0);
-export const freeCargo = (hold, cargo) => Math.max(0, (cargo || 0) - holdScu(hold));
+export const holdScu = (hold: Lot[]): number => hold.reduce((s, l) => s + (l.units || 0), 0);
+export const freeCargo = (hold: Lot[], cargo: number): number => Math.max(0, (cargo || 0) - holdScu(hold));
 
 // Regroupe les lots par commodité, pour l'affichage : un total, et le détail dessous.
 // `paidMoyen` n'est calculé QUE pour l'affichage — les ventes, elles, consomment lot par lot.
-export function holdByCommodity(hold) {
+export function holdByCommodity(hold: Lot[]): GroupeSoute[] {
   const par = new Map();
   hold.forEach((l, i) => {
     if (!par.has(l.name)) par.set(l.name, { name: l.name, units: 0, invest: 0, lots: [] });
@@ -1827,7 +1852,7 @@ export function holdByCommodity(hold) {
 // `refuse: <station>` et sont alors SAUTÉS. C'est ce qui protège le résidu de la vente implicite
 // déclenchée en avançant d'une étape. Un geste EXPLICITE, lui, ne passe pas `at` et vend quand
 // même : l'intention de l'utilisateur prime toujours sur un marqueur posé plus tôt.
-export function sellFromHold(hold, name, units, price, at = null, nowSec = Date.now() / 1000) {
+export function sellFromHold(hold: Lot[], name: string, units: number, price: number, at: string | null = null, nowSec: number = Date.now() / 1000): VenteSoute {
   let reste = Math.max(0, Math.floor(units || 0));
   const suivant = [], consommes = [];
   let vendu = 0, cout = 0;
@@ -1852,7 +1877,7 @@ export function sellFromHold(hold, name, units, price, at = null, nowSec = Date.
 // `null` en entrée (capacité inconnue) ressort `null` : on ne déduit pas d'un chiffre qu'on n'a pas.
 // En pratique les 494 points d'achat de l'instantané publient tous leur stock, mais la vente, elle,
 // ne le fait que dans 15,6 % des cas — la fonction sert aussi là.
-export function stockApres(stock, units) {
+export function stockApres(stock: number | null, units: number): number | null {
   if (stock == null) return null;
   return Math.max(0, stock - Math.max(0, Math.floor(units || 0)));
 }
@@ -1867,7 +1892,7 @@ export function stockApres(stock, units) {
 // information saisie à la main dans la vue Corrections périmait déjà en 3 h. Sans date ici, le
 // refus était éternel : deux durées de vie pour un seul fait, dont l'une n'avait été décidée par
 // personne.
-export function refuseHere(hold, name, station, at = Date.now() / 1000) {
+export function refuseHere(hold: Lot[], name: string, station: string, at: number = Date.now() / 1000): Lot[] {
   return hold.map((l) => (l.name === name ? { ...l, refuse: station, refuseAt: at } : l));
 }
 
@@ -1875,7 +1900,7 @@ export function refuseHere(hold, name, station, at = Date.now() / 1000) {
 // — sinon ils divergent, ce qui est précisément le défaut qu'on corrige.
 // Réemploie `DUREE_VOL`, l'horloge des volumes corrigés : le refus décrit le même phénomène (« ce
 // comptoir ne prend plus »), il n'a aucune raison de vieillir autrement.
-export function refusActif(lot, station, nowSec = Date.now() / 1000, dureeVol = DUREE_VOL) {
+export function refusActif(lot: Lot | null, station: string, nowSec: number = Date.now() / 1000, dureeVol: number = DUREE_VOL): boolean {
   if (!lot || lot.refuse !== station) return false;
   // Marqueur sans date : hérité d'avant #20. `migrerRefus` les date au chargement ; si l'un passe
   // malgré tout, on le tient pour périmé plutôt qu'éternel — un refus d'âge inconnu ne prouve rien.
@@ -1889,7 +1914,7 @@ export function refusActif(lot, station, nowSec = Date.now() / 1000, dureeVol = 
 // maintenant : c'est le seul choix qui ne perd rien.
 // Renvoie { hold, migres } — `migres` vaut 0 quand il n'y avait rien à faire, ce qui permet à
 // l'appelant de n'écrire dans localStorage que s'il le faut.
-export function migrerRefus(hold, nowSec = Date.now() / 1000) {
+export function migrerRefus(hold: Lot[] | null, nowSec: number = Date.now() / 1000): { hold: Lot[]; migres: number } {
   let migres = 0;
   const suivant = (hold || []).map((l) => {
     if (!l || !l.refuse || l.refuseAt > 0) return l;
@@ -1902,7 +1927,7 @@ export function migrerRefus(hold, nowSec = Date.now() / 1000) {
 // Prix et capacité d'une commodité à un terminal donné, corrections appliquées. null si ce
 // terminal ne la reprend pas. `demand` peut valoir null : capacité INCONNUE, ce qui n'est ni zéro
 // ni l'infini — 84 % des points de vente sont dans ce cas.
-export function sellableAt(market, terminalIdx, name, resolve) {
+export function sellableAt(market: Marche, terminalIdx: number, name: string, resolve: Resolveur | null): VenteAuTerminal | null {
   const c = market.commodities.find((x) => x.name === name);
   if (!c) return null;
   const s = c.sells.find((x) => x[0] === terminalIdx);
@@ -1915,7 +1940,7 @@ export function sellableAt(market, terminalIdx, name, resolve) {
 // Vend à ce terminal TOUT ce que la soute peut y écouler — c'est la vente implicite : quitter une
 // escale sous-entend qu'on y a fait son affaire. Ce qu'une vente partielle y a explicitement laissé
 // (`refuse`) traverse l'étape intact. Renvoie { hold, ventes, recette, cout, profit }.
-export function sellAllAt(hold, market, terminalIdx, resolve, nowSec = Date.now() / 1000) {
+export function sellAllAt(hold: Lot[], market: Marche, terminalIdx: number, resolve: Resolveur | null, nowSec: number = Date.now() / 1000): VenteEtape {
   const t = market.terminals[terminalIdx];
   if (!t) return { hold, ventes: [], recette: 0, cout: 0, profit: 0 };
   let courant = hold;
@@ -1968,7 +1993,7 @@ export function sellAllAt(hold, market, terminalIdx, resolve, nowSec = Date.now(
 //     faux pour une tournée : la station où l'on se trouve peut être le meilleur premier arrêt, à
 //     coût de déplacement nul — on vient justement d'y ramasser le butin ;
 //   `comparer` — le tri par profit reste le défaut ; la tournée injecte son tri par couverture.
-export function offloadPlan(market, hold, originIdx, f = {}, resolve = null, autoloadFor = null, limit = 6, opts = {}) {
+export function offloadPlan(market: Marche, hold: Lot[], originIdx: number, f: Filtres = {}, resolve: Resolveur | null = null, autoloadFor: TarifTerminal | null = null, limit: number = 6, opts: OptionsEcoulement = {}): Destination[] {
   if (!hold || !hold.length) return [];
   const inclureOrigine = !!opts.inclureOrigine;
   const origine = market.terminals[originIdx];
@@ -2064,7 +2089,7 @@ export function offloadPlan(market, hold, originIdx, f = {}, resolve = null, aut
 // dernier, et c'est l'ENCAISSEMENT, pas le profit : le prix payé est coulé et identique quelle que
 // soit la destination — sur une soute mixte, le profit comparerait des bases de coût hétérogènes
 // et pénaliserait la ligne réellement achetée, donc la destination qui l'écoule.
-const parCouverture = (a, b) =>
+const parCouverture = (a: Destination, b: Destination): number =>
   b.lignes.length - a.lignes.length ||
   (a.cross === b.cross ? 0 : a.cross ? 1 : -1) ||
   b.scu - a.scu ||
@@ -2072,7 +2097,7 @@ const parCouverture = (a, b) =>
 
 // Agrège une suite d'arrêts. `certitude` vaut « connue » seulement si TOUS les arrêts le sont :
 // 16,3 % des points de vente publient leur capacité, donc un total est presque toujours un pari.
-function bilanTournee(arrets, reste, sansDebouche) {
+function bilanTournee(arrets: Destination[], reste: Lot[], sansDebouche: SansDebouche[]): Tournee {
   const somme = (cle) => arrets.reduce((s, a) => s + a[cle], 0);
   const connus = arrets.filter((a) => a.certitude === "connue").length;
   return {
@@ -2093,7 +2118,7 @@ function bilanTournee(arrets, reste, sansDebouche) {
 // L'autre moitié du problème — ordonner les arrêts choisis — est dégénérée ici : sans matrice de
 // distances (aucune coordonnée dans market.json, 161 routes sur 316 portant une distance), il n'y
 // a rien à ordonner. Tout le NP-difficile est dans le CHOIX des comptoirs.
-export function tourneeEcoulement(market, hold, originIdx, f = {}, resolve = null, autoloadFor = null, opts = {}) {
+export function tourneeEcoulement(market: Marche, hold: Lot[], originIdx: number, f: Filtres = {}, resolve: Resolveur | null = null, autoloadFor: TarifTerminal | null = null, opts: OptionsTournee = {}): Tournee {
   const maxArrets = opts.maxArrets || 5;
   const tous = market.terminals.length; // jamais de `limit` ici : on filtre nous-mêmes, après
   // Les lignes qui ne s'écoulent NULLE PART dans la portée, sorties du calcul avant la boucle et
@@ -2132,7 +2157,7 @@ export function tourneeEcoulement(market, hold, originIdx, f = {}, resolve = nul
 // rend l'arbitrage à qui a le contexte.
 // L'alternative se cherche en FORÇANT un autre premier arrêt, puis en déroulant le même glouton :
 // borné à `k` essais, c'est le faisceau étroit de l'ADR, appliqué au seul endroit qui en a besoin.
-export function tourneesEcoulement(market, hold, originIdx, f = {}, resolve = null, autoloadFor = null, opts = {}) {
+export function tourneesEcoulement(market: Marche, hold: Lot[], originIdx: number, f: Filtres = {}, resolve: Resolveur | null = null, autoloadFor: TarifTerminal | null = null, opts: OptionsTournee = {}): { tournee: Tournee; alternative: Tournee | null } {
   const tournee = tourneeEcoulement(market, hold, originIdx, f, resolve, autoloadFor, opts);
   const k = opts.k || 3;
   const premiers = offloadPlan(market, hold, originIdx, f, resolve, autoloadFor, market.terminals.length,
@@ -2165,7 +2190,7 @@ export function tourneesEcoulement(market, hold, originIdx, f = {}, resolve = nu
 // chargement que `sellFromHold` laisse tomber en reconstruisant les lots consommés. Sans cette date,
 // une liste « j'ai laissé 170 SCU d'or à Ruin Station » ne dit pas si c'était hier ou il y a trois
 // patchs. Absente (0), elle s'exporte « date inconnue » : on n'invente pas celle du jour.
-export function storeFromHold(hold, entrepots, name, units, station, at) {
+export function storeFromHold(hold: Lot[], entrepots: Entrepots, name: string, units: number, station: string, at?: number): { hold: Lot[]; entrepots: Entrepots } {
   const r = sellFromHold(hold, name, units, 0); // même consommation FIFO, sans recette
   if (!r.vendu) return { hold, entrepots };
   const deja = entrepots[station] || [];
@@ -2185,7 +2210,7 @@ export function storeFromHold(hold, entrepots, name, units, station, at) {
 // n'est pas acheter. `sellFromHold` reconstruit les lots consommés en { name, units, paid, from } —
 // le lot rendu à la soute n'a donc ni `at` de chargement ni `deposeAt`, ce qui est exactement juste :
 // il n'a pas été chargé maintenant, et il n'est plus déposé nulle part.
-export function takeFromStore(hold, entrepots, name, units, station) {
+export function takeFromStore(hold: Lot[], entrepots: Entrepots, name: string, units: number, station: string): { hold: Lot[]; entrepots: Entrepots } {
   const stock = entrepots[station];
   if (!stock || !stock.length) return { hold, entrepots };
   const r = sellFromHold(stock, name, units, 0); // même consommation FIFO, sans recette
@@ -2213,14 +2238,14 @@ export const CARTE = { largeur: 680, hauteur: 296, marge: 26 };
 // sont légitimes et ne fusionneront pas : une liste déroulante se parcourt du plus fourni au moins
 // fourni, une carte se lit dans l'ordre où les systèmes sont posés dans l'espace.
 const ORDRE_CARTE = ["Nyx", "Pyro", "Stanton"];
-const rangCarte = (nom) => {
+const rangCarte = (nom: string): number => {
   const i = ORDRE_CARTE.indexOf(nom);
   return i === -1 ? ORDRE_CARTE.length : i;
 };
 
 // Angle déterministe dérivé d'un nom : deux terminaux d'une même planète ne se superposent pas,
 // et la carte ne bouge pas d'un rendu à l'autre (aucun hasard, donc aucun scintillement).
-export function nameAngle(nom) {
+export function nameAngle(nom: string): number {
   let h = 0;
   for (let i = 0; i < nom.length; i++) h = (h * 31 + nom.charCodeAt(i)) % 360;
   return h;
@@ -2229,10 +2254,10 @@ export function nameAngle(nom) {
 // Les rayons réels s'étalent de 0,55 à 13 UA : à l'échelle, tout se tasserait sur l'étoile. On
 // compresse par une racine — l'ORDRE et les écarts relatifs survivent, la lisibilité aussi.
 // C'est le seul endroit où la carte s'écarte du réel, et c'est assumé (cf. ADR « schéma »).
-const rayonRelatif = (au, auMax) => 0.24 + 0.72 * Math.sqrt(Math.max(au, 0) / (auMax || 1));
+const rayonRelatif = (au: number, auMax: number): number => 0.24 + 0.72 * Math.sqrt(Math.max(au, 0) / (auMax || 1));
 
 // Position d'une ancre (corps ou passerelle) dans le disque de son système.
-function posAncre(sys, ancre) {
+function posAncre(sys: SystemeCarte, ancre: Ancre): { x: number; y: number } {
   const rr = rayonRelatif(ancre.au, sys.auMax);
   const rad = (ancre.lon * Math.PI) / 180;
   return { x: sys.cx + Math.cos(rad) * rr * sys.r, y: sys.cy + Math.sin(rad) * rr * sys.r };
@@ -2240,12 +2265,12 @@ function posAncre(sys, ancre) {
 
 // Nom de la passerelle qui, DEPUIS `de`, mène vers `vers`. UEX les nomme « <destination> Gateway
 // (<système courant>) » — le nom porte donc le lien, sans donnée supplémentaire.
-export const nomPasserelle = (de, vers) => `${vers} Gateway (${de})`;
+export const nomPasserelle = (de: string, vers: string): string => `${vers} Gateway (${de})`;
 
 // Projette le parcours. `stations` = journeyStations(journey) ; `infoTerminal(nom)` rend
 // { system, planet } ou null ; `starmap` = data/starmap.json.
 // Renvoie tout ce qu'il faut dessiner, en pixels du viewBox — jamais de HTML.
-export function journeyMap(stations, current, starmap, infoTerminal, enVol = false) {
+export function journeyMap(stations: Station[], current: number, starmap: Starmap, infoTerminal: InfoTerminal, enVol: boolean = false): Carte | null {
   if (!stations || !stations.length) return null;
   const { largeur, hauteur, marge } = CARTE;
 
@@ -2262,7 +2287,7 @@ export function journeyMap(stations, current, starmap, infoTerminal, enVol = fal
   ordre.sort((a, b) => rangCarte(a) - rangCarte(b));
   const n = ordre.length;
   const rayon = Math.min((largeur - marge * 2) / (n * 2.35), (hauteur - marge * 2) / 2);
-  const systemes = ordre.map((nom, i) => ({
+  const systemes: DisqueSysteme[] = ordre.map((nom, i) => ({
     nom,
     cx: (largeur / n) * (i + 0.5),
     cy: hauteur / 2,
@@ -2404,7 +2429,7 @@ export function journeyMap(stations, current, starmap, infoTerminal, enVol = fal
 
 // Encode un parcours en chaîne compacte auto-suffisante (pour localStorage / URL partageable).
 // Chaque jambe -> tuple [from, fromSystem, to, toSystem, commodity, buyPrice, sellPrice, margin].
-export function encodeJourney(journey) {
+export function encodeJourney(journey: Parcours | null): string {
   if (!journey) return "";
   // Parcours « de zéro » : encode juste le point de départ.
   if (!journey.legs.length) return journey.start ? JSON.stringify({ c: 0, s: [journey.start.name, journey.start.system] }) : "";
@@ -2414,7 +2439,7 @@ export function encodeJourney(journey) {
   });
 }
 // Reconstruit un parcours depuis la chaîne (null si vide/invalide). Robuste aux entrées malformées.
-export function decodeJourney(str) {
+export function decodeJourney(str: string | null): Parcours | null {
   if (!str) return null;
   try {
     const p = JSON.parse(str);
@@ -2454,26 +2479,26 @@ export const FORMAT_EXPORT = 1;
 // Une date, écrite pour être relue sur une autre machine, dans un autre fuseau, des mois plus tard.
 // `null` quand la date n'existe pas — JAMAIS l'heure courante en remplacement : c'est la règle
 // commune aux deux exports, et le seul moyen de distinguer « déposé hier » de « je n'en sais rien ».
-export function isoUTC(sec) {
+export function isoUTC(sec: number | null | undefined): string | null {
   const n = Number(sec);
   if (!(n > 0) || !Number.isFinite(n)) return null;
   // TRONQUÉE, pas arrondie : la seconde PENDANT laquelle le geste a eu lieu. Arrondir daterait un
   // dépôt de 20:13:20,7 à 20:13:21, une seconde après qu'il s'est produit.
   return new Date(Math.floor(n) * 1000).toISOString().replace(/\.\d{3}Z$/, "Z");
 }
-export function secDepuisISO(iso) {
+export function secDepuisISO(iso: string | null): number | null {
   if (!iso) return null;
   const t = Date.parse(iso);
   return Number.isFinite(t) ? Math.round(t / 1000) : null;
 }
 // En-tête commun aux deux sorties : le numéro de format d'abord (sans lui, la première évolution
 // casse tous les fichiers déjà émis), la date d'émission ensuite.
-export const enteteExport = (type, nowSec) => ({ v: FORMAT_EXPORT, type, emis: isoUTC(nowSec) });
+export const enteteExport = (type: string, nowSec: number): EnteteExport => ({ v: FORMAT_EXPORT, type, emis: isoUTC(nowSec) });
 
 // Séparateur de milliers DÉTERMINISTE (espace simple). `toLocaleString("fr-FR")` aurait fait
 // l'affaire à l'écran, mais son séparateur dépend de l'ICU embarquée : un export comparé en test
 // deviendrait vert ou rouge selon la build de Node. Un export doit être reproductible.
-const milliers = (n) => String(Math.round(Number(n) || 0)).replace(/\B(?=(\d{3})+(?!\d))/g, " ");
+const milliers = (n: number): string => String(Math.round(Number(n) || 0)).replace(/\B(?=(\d{3})+(?!\d))/g, " ");
 
 // L'export des corrections : un OBJET sérialisable, parce que celui-ci est fait pour être relu par
 // la machine (cf. relireCorrections) autant que par un humain.
@@ -2484,7 +2509,7 @@ const milliers = (n) => String(Math.round(Number(n) || 0)).replace(/\B(?=(\d{3})
 // Seules les clés à TROIS segments sortent : les relevés de tarif d'autoload vivent dans un store
 // séparé sous une clé à deux segments, et n'ont ni date UEX de référence ni péremption (même
 // frontière que `groupOverridesByTerminal`).
-export function exporterCorrections(overrides, nowSec) {
+export function exporterCorrections(overrides: StoreCorrections | null, nowSec: number): ExportCorrections {
   const store = overrides || {};
   const corrections = [];
   for (const cle of Object.keys(store)) {
@@ -2530,14 +2555,14 @@ export function exporterCorrections(overrides, nowSec) {
 // finiraient par diverger, et c'est la relecture qui aurait tort sans qu'on le voie.
 // `releves` = { "Commodité|Terminal|side": date UEX courante du point }. Un point absent n'est pas
 // rejeté : ne pas connaître le relevé n'est pas la même chose que le savoir plus récent.
-export function relireCorrections(exporte, releves = {}, nowSec = Date.now() / 1000, dureeVol = DUREE_VOL) {
+export function relireCorrections(exporte: ExportCorrections | null, releves: Releves = {}, nowSec: number = Date.now() / 1000, dureeVol: number = DUREE_VOL): CorrectionRelue[] {
   const entrees = exporte && Array.isArray(exporte.corrections) ? exporte.corrections : [];
   return entrees.map((c) => {
     const side = c.cote === "achat" ? "buy" : "sell";
     const saisi = secDepuisISO(c.saisi);
     // `base` null couvre deux cas indistinguables à l'export (ancre à 0, ancre absente) ; on les
     // relit comme le store les écrit — `setInStore` pose toujours `Number(baseUpdated) || 0`.
-    const o = { base: secDepuisISO(c.base) || 0 };
+    const o: Correction = { base: secDepuisISO(c.base) || 0 };
     if (c.champ === "prix") o.price = c.valeur;
     else { o.vol = c.valeur; if (saisi != null) o.pris = saisi; }
     const r = effValue(o, null, null, releves[ovKey(c.commodite, c.terminal, side)], nowSec, dureeVol);
@@ -2555,7 +2580,7 @@ export function relireCorrections(exporte, releves = {}, nowSec = Date.now() / 1
 // UNE LIGNE PAR LOT, pas par commodité : deux lots de la même commodité peuvent avoir été déposés
 // des jours d'écart et venir de stations différentes — les regrouper effacerait précisément ce que
 // cet export existe pour dire.
-export function exporterEntrepots(entrepots, nowSec) {
+export function exporterEntrepots(entrepots: Entrepots | null, nowSec: number): string {
   const e = entrepots || {};
   const stations = Object.keys(e)
     .filter((s) => Array.isArray(e[s]) && e[s].length)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.48.0",
+        "typescript": "^7.0.2",
         "vite": "^8.2.1"
       },
       "engines": {
@@ -304,6 +305,346 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -779,6 +1120,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "private": true,
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "scripts": {
     "build": "npm run build:data && npm run build:site",
@@ -16,10 +16,12 @@
     "e2e": "playwright test",
     "build:data": "node scripts/build-data.mjs",
     "build:site": "vite build",
-    "dev": "vite"
+    "dev": "vite",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@playwright/test": "^1.48.0",
+    "typescript": "^7.0.2",
     "vite": "^8.2.1"
   },
   "repository": {

--- a/sw.js
+++ b/sw.js
@@ -6,9 +6,12 @@
 // visite, tandis que rail.js, lui, serait déjà là. `activate` purge tout cache au nom différent :
 // le bump garantit que la nouvelle page et son script arrivent ENSEMBLE.
 const CACHE = "best-hauling-v1.1.0";
-// Coquille précachée. Les woff2 (mêmes-origine depuis fonts/) sont mis en cache au premier
-// rendu par le gestionnaire fetch ci-dessous (stale-while-revalidate) -> hors-ligne complet.
-const SHELL = ["./", "./index.html", "./app.js", "./rail.js", "./logic.mjs", "./style.css", "./fonts/fonts.css", "./icon.svg", "./manifest.webmanifest"];
+// Coquille précachée. Cette liste est un DÉFAUT DE REPLI : en production, le build la remplace par
+// ce qu'il a réellement émis, noms hachés compris (vite.config.mjs, plugin best-hauling:precache).
+// `logic.mjs` n'y figure plus depuis qu'il est devenu `logic.ts` (ADR-008 §5) — un fichier
+// TypeScript n'est pas servi au navigateur, il est bundlé dans l'entrée. Le laisser aurait fait
+// rejeter `addAll` EN BLOC, qui est atomique, et supprimé tout le hors-ligne au lieu de le dégrader.
+const SHELL = ["./", "./index.html", "./app.js", "./rail.js", "./style.css", "./fonts/fonts.css", "./icon.svg", "./manifest.webmanifest"];
 
 self.addEventListener("install", (e) => {
   e.waitUntil(caches.open(CACHE).then((c) => c.addAll(SHELL)).then(() => self.skipWaiting()));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,39 @@
+{
+  "//": [
+    "Vérification de types SEULEMENT — jamais d'émission. C'est Vite qui construit, et Node 24 qui",
+    "efface les types à l'exécution ; `tsc` ne sert ici qu'à dire si les annotations sont vraies.",
+    "Sans lui, annoter n'apporterait RIEN : l'effacement de types ne vérifie rien du tout, il retire.",
+    "",
+    "La sévérité est un ESCALIER, et chaque marche est mesurée. logic.ts vient d'être renommé depuis",
+    "du JavaScript : tout activer d'un coup produit des erreurs sur du code dont 475 tests prouvent",
+    "qu'il marche, et noie les vraies sous les artefacts de réglage. Mesuré le 2026-08-15 :",
+    "",
+    "    strictNullChecks: true   -> 152 erreurs, dont 125 du seul motif `never[]`",
+    "                                (TS cesse d'inférer un tableau vide en `any[]` évolutif)",
+    "    strictNullChecks: false  ->  27 erreurs, presque toutes le MÊME motif utile :",
+    "                                un paramètre d'options `= {}` inféré comme objet vide",
+    "",
+    "On prend donc la seconde marche d'abord : ces 27-là se règlent en ANNOTANT les signatures,",
+    "c'est-à-dire en faisant le travail, pas en le contournant. `strictNullChecks` puis",
+    "`noImplicitAny` viendront ensuite, chacun dans sa PR — sinon on ne saurait plus quelle marche",
+    "a cassé quoi.",
+    "",
+    "app.js et les scripts/ ne sont PAS inclus : ils restent du JavaScript tant que la migration ne",
+    "les a pas atteints, et `allowJs` les ferait entrer avec tout leur bruit."
+  ],
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "strictNullChecks": false,
+    "noImplicitAny": false,
+    "forceConsistentCasingInFileNames": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["logic.ts", "types.ts"]
+}

--- a/types.ts
+++ b/types.ts
@@ -1,0 +1,1011 @@
+// Vocabulaire de types du domaine (refonte v2, ADR-008).
+//
+// Ces types ne sont pas inventés : ils ont été relevés sur les USAGES RÉELS — logic.ts, les 425
+// tests de logic.test.mjs, app.js — et sur les DONNÉES réelles de data/*.json, jamais sur ce qu'on
+// imagine que la donnée devrait être.
+//
+// Deux règles de lecture, qui expliquent la plupart des choix ci-dessous :
+//
+//   `?` (facultatif) ne veut PAS dire « rare ». Il veut dire : un instantané data/ DÉJÀ PUBLIÉ a
+//   pu ne pas porter ce champ. Le service worker sert les données en « réseau d'abord, cache en
+//   repli » (sw.js), donc une coquille antérieure peut revenir à tout moment — le critère est donc
+//   l'historique du dépôt, pas le contenu du fichier d'aujourd'hui.
+//
+//   `| null` n'est PAS `?`. Dans ce domaine, `null` porte un SENS : « UEX ne publie pas cette
+//   capacité » — ce qui n'est ni zéro ni l'infini. Les confondre inverse la lecture : un 0 CONNU
+//   dit « saturé, ne prend plus rien », un `null` dit « on ne sait pas ».
+//
+// Fichier séparé de logic.ts à dessein : app.js le rejoindra en TypeScript, et le vocabulaire doit
+// pouvoir être importé sans traîner les 2 584 lignes de calcul.
+
+
+// ==============================================================================================
+// Trajets, boucles, filtres et fraîcheur
+// ==============================================================================================
+
+/** Les contraintes de CHARGEMENT lues par `computeUnits`. Les cinq champs voyagent ensemble :
+ *  `readFilters()` (app.js:434) les produit d'un bloc, et `F()` (logic.test.mjs:219) aussi. */
+export type FiltresVolume = {
+  cargo: number;
+  budget: number;
+  capStock: boolean;
+  useCargo: boolean;
+  useBudget: boolean;
+};
+
+/** Les filtres de la VUE (barre du haut), lus par `routePasses` / `loopPasses`.
+ *  Tous OPTIONNELS : chaque lecture est un test de véracité (`if (f.maxAge)`), et les appelants
+ *  qui ne filtrent pas — routeMetrics via logic.test.mjs:4419 — n'en portent aucun. */
+export type FiltresListe = {
+  sameOnly?: boolean;
+  noOutpost?: boolean;
+  legalOnly?: boolean;
+  /** "" = pas de filtre système (la vue « En route » le neutralise, logic.ts:1386). */
+  sysFilter?: string;
+  /** en JOURS ; 0 = filtre inactif. */
+  maxAge?: number;
+  /** sous-chaîne DÉJÀ en minuscules (app.js:446 `.trim().toLowerCase()`). */
+  q?: string;
+};
+
+/** L'objet de filtres UNIQUE : celui que `readFilters()` (app.js:434-453) fabrique et que TOUTES les
+ *  vues font circuler tel quel, parfois dérivé d'un seul champ par recopie — `{ ...f, useBudget: false }`
+ *  (logic.ts:1173), `{ ...f, sysFilter: "" }` (app.js:1282), `{ ...f, cargo: libre }` (app.js:1234),
+ *  `{ ...readFilters(), board: commBoard }` (app.js:3577).
+ *  C'est POUR ces recopies qu'il n'y a qu'un type et pas deux jeux séparés : TypeScript contrôle les
+ *  propriétés écrites EN CLAIR dans un littéral, même à côté d'un spread (mesuré). Un `Filtres`
+ *  amputé refuserait `useBudget: false` en logic.ts:1173 — du code que 475 tests prouvent juste.
+ *
+ *  TOUT est optionnel, et ce n'est pas du laxisme : quatre fonctions déclarent `f = {}` en défaut
+ *  (commoditySummaries:1198, commodityPoints:1232, offloadPlan:1971, tourneeEcoulement:2096) et les
+ *  tests passent des sous-ensembles nus — `pairEligible({}, …)` (logic.test.mjs:3389),
+ *  `{ sameOnly: true }` (:1162), `{ maxAge: 3 }` (:1168), `fEcouler()` à 5 champs (:2180). Chaque
+ *  champ n'est d'ailleurs lu qu'après un test de vérité (logic.ts:102-110, 115-123, 131-139,
+ *  864-886, 1066-1071, 1995-1997) : « absent » et « faux » y disent la même chose.
+ *
+ *  Les trois familles ci-dessous ne sont PAS trois types. logic.ts:99 et :128 les décrivent
+ *  séparément parce que chaque fonction n'en lit qu'une — mais l'objet, lui, est un seul, et le
+ *  découper forcerait chaque recopie à choisir une moitié qu'elle ne contrôle pas. */
+export type Filtres = {
+  // — VOLUME : ce qui borne le remplissage de la soute (computeUnits, logic.ts:128-139).
+  //   `useCargo`/`useBudget` sont les INTERRUPTEURS : éteints, la contrainte vaut Infinity, pas 0.
+  cargo?: number;              // SCU
+  budget?: number;             // aUEC
+  capStock?: boolean;          // plafonner au stock publié / à la demande publiée
+  useCargo?: boolean;
+  useBudget?: boolean;
+
+  // — LISTE : ce qui écarte des lignes (routePasses:101, loopPasses:113, pairEligible:826).
+  sameOnly?: boolean;
+  noOutpost?: boolean;
+  legalOnly?: boolean;
+  sysFilter?: string;          // "" = pas de filtre système, et non « le système nommé "" »
+  maxAge?: number;             // âge du relevé en JOURS (7 / 3 / 1 ; 0 = inactif — index.html:165-170)
+  q?: string;                  // recherche, DÉJÀ minusculée par readFilters (app.js:446)
+
+  // — VUE : réglages qu'aucune fonction de logic.ts ne lit, mais qui voyagent dans le même objet.
+  //   Ils sont déclarés ici pour que `readFilters()` puisse un jour s'annoter `: Filtres` : son
+  //   littéral les écrit en clair, et un type qui les ignore le rejetterait (mesuré).
+  multi?: boolean;             // app.js s'en sert pour CHOISIR la fonction à appeler, pas pour filtrer
+  multiAll?: boolean;
+  autoload?: boolean;
+
+  // `board`, lui, EST lu (logic.ts:1199) alors qu'il ne vient PAS de readFilters : app.js:3577 le
+  //   greffe après coup. Deux valeurs et deux seulement, garanties par le garde d'app.js:3567.
+  board?: "market" | "loot";
+};
+
+/** Ce qu'UN terminal facture. `k = 0` = ne facture rien, mais le `maxBox` SURVIT : c'est encore
+ *  lui qui décide de la taille des caisses (logic.ts:474-482).
+ *  `maxBox` optionnel : un instantané de market.json antérieur au build qui l'ajoute n'en a pas. */
+export type PointFrais = { maxBox?: number; k: number };
+
+/** Le contexte de frais d'UN chargement : on charge au terminal d'ACHAT, on décharge au terminal
+ *  de VENTE, chacun au tarif de SA station (`haulFee`, logic.ts:491-496).
+ *
+ *  Les deux clés sont TOUJOURS ÉCRITES ; c'est leur VALEUR qui peut être `null`. Les sept sites de
+ *  construction posent l'objet complet — logic.ts:800, :899, :1129, :2022, :513-516, app.js:265
+ *  et :971 — et `autoloadPoint` (:479) rend `null` dès que le terminal manque. Un côté `null` dit
+ *  donc « terminal inconnu », jamais « gratuit » : un terminal connu qui ne facture rien garde son
+ *  point avec `k: 0` (:481), précisément pour CONSERVER son `maxBox` — c'est encore lui qui décide
+ *  de la taille des caisses, même quand le joueur les empile à la main.
+ *
+ *  L'objet ENTIER `null` est une TOUTE autre chose : l'interrupteur d'autoload éteint, le chemin
+ *  par défaut de tout le moteur. Ce `null`-là appartient au PARAMÈTRE, pas au type —
+ *  `haulFee(scu, pair: PaireFrais | null)`, `manifestTotals(lines, autoload: PaireFrais | null)`,
+ *  `routeMetrics(m, f, autoload: PaireFrais | null)`, `trip.fee: PaireFrais | null`, et
+ *  `leg.fee?: PaireFrais | null` sur la jambe de chaîne (une fixture historique omet carrément la
+ *  clé : logic.test.mjs:4138). Le faire entrer dans le type dispenserait chaque appelant de dire
+ *  lequel des deux `null` il veut, et c'est exactement la distinction qui porte l'interrupteur.
+ *
+ *  À NE PAS confondre avec l'`autoload` de `loopMetrics` (:182-189) : une boucle n'a pas un
+ *  terminal d'achat et un de vente, elle a deux EXTRÉMITÉS qui sont tour à tour l'un et l'autre.
+ *  Sa paire est `{ a, b }`, et elle se RETOURNE entre l'aller et le retour (les caisses se font au
+ *  départ de chaque jambe). Même famille, autre forme — ce n'est pas une PaireFrais. */
+export type PaireFrais = { buy: PointFrais | null; sell: PointFrais | null };
+
+/** Les points de frais des deux STATIONS d'une boucle. Une boucle n'a pas un terminal d'achat et
+ *  un de vente : elle a deux extrémités qui sont tour à tour l'un et l'autre (logic.ts:177-181). */
+export type ExtremitesFrais = { a: PointFrais | null; b: PointFrais | null };
+
+/** Une extrémité de route telle que la sert data/routes.json. `stock` n'existe QUE côté achat,
+ *  `demand` QUE côté vente — d'où deux champs optionnels plutôt qu'un type par côté.
+ *  `demand: null` = capacité inconnue chez UEX (1 572 relevés sur data/market.json), PAS zéro. */
+export type PointRoute = {
+  terminal: string;
+  system: string;
+  planet: string;
+  price: number;
+  outpost: boolean;
+  /** secondes epoch ; 0 = date inconnue. */
+  updated: number;
+  status: number;
+  stock?: number;
+  demand?: number | null;
+};
+
+// ---------- Vue « Trajets » : une route d'arbitrage à UNE commodité ----------
+/** Extrémité d'ACHAT d'une route : un terminal localisé, et ce qu'UEX y a relevé.
+ *  `stock` n'est JAMAIS null, et ce n'est pas une facilité de typage : les 494 points d'achat de
+ *  l'instantané publient tous le leur (0 null sur 494, mesuré sur data/market.json), quand 1 572
+ *  des 1 879 points de vente taisent leur capacité. C'est cette asymétrie que `computeUnits`
+ *  encode en plafonnant par le stock SANS garde (logic.ts:136) et par la demande derrière un
+ *  `!= null` (logic.ts:139). Écrire `stock: number | null` effacerait la seule distinction sur
+ *  laquelle repose tout le calcul de volume — et le dépôt, lui, la tient pour son fait central.
+ *  `planet` vaut "" quand le terminal n'orbite rien (18 des 316 achats) : dans ce dépôt l'absence
+ *  s'écrit chaîne vide, jamais `undefined`. */
+export type PointAchat = {
+  terminal: string; system: string; planet: string; outpost: boolean;
+  price: number; stock: number; updated: number; status: number;
+};
+
+/** Une ligne de data/routes.json (316 entrées) — ET la sortie de `dealFrom` (logic.ts:763-771).
+ *  UN seul type pour les deux, parce que c'est un invariant du dépôt et non une commodité :
+ *  `routePasses` (l.101), `legFromRoute` (l.1377), `routeRowHTML` (app.js:576) et `evaluate`
+ *  (app.js:387) reçoivent indifféremment une route du fichier (vue « Trajets », app.js:469) ou une
+ *  route fabriquée à la volée (vue « En route », app.js:1287) — le même tableau les rend déjà.
+ *  Rien n'est optionnel : le générateur écrit les onze clés sans condition
+ *  (scripts/build-data.mjs:204-216), et `dealFrom` aussi.
+ *  `distance: null` n'est pas une précaution — 138 des 316 routes n'ont AUCUNE distance connue,
+ *  l'API UEX ne répondant pas pour certaines paires d'orbites (build-data.mjs:410-423, qui rend
+ *  `null` sur échec). C'est POURQUOI `tripMinutes` écrit `distance || 0` (l.8). `dealFrom`, lui,
+ *  pose 0 : hors routes.json la distance exacte n'existe pas, et l'estimation l'assume.
+ *  `kind` reste `string` : 20 catégories dans l'instantané, UEX en ajoute quand il veut — une
+ *  union figerait ici une liste que personne ne maintient.
+ *  `refBuy`/`refSell` = prix de référence UEX (0 quand inconnu), toujours écrits ; seul
+ *  `suspectTag` les lit, derrière un `> 0` (app.js:156). */
+export type Route = {
+  commodity: string; kind: string; illegal: boolean;
+  buy: PointAchat; sell: PointVente;
+  refBuy: number; refSell: number;
+  margin: number; roi: number; same_system: boolean;
+  distance: number | null;
+};
+
+/** Le SOUS-ENSEMBLE que `routePasses` lit vraiment. Volontairement structurel et minimal :
+ *  `Route` lui est assignable, un deal de `dealFrom` aussi, et les fixtures de test partielles
+ *  (logic.test.mjs:145-151) le restent le jour où les tests seront typés. */
+export type RouteFiltrable = {
+  commodity: string;
+  illegal: boolean;
+  same_system: boolean;
+  buy: { system: string; outpost: boolean; updated: number };
+  sell: { outpost: boolean; updated: number };
+};
+
+/** Une station d'une boucle A⇄B, telle que la sert data/loops.json. */
+export type ExtremiteBoucle = { terminal: string; system: string; planet: string; outpost: boolean };
+
+/** Une jambe de boucle (aller ou retour) telle que la sert data/loops.json. */
+export type SegmentBoucle = {
+  commodity: string;
+  kind: string;
+  illegal: boolean;
+  buyPrice: number;
+  sellPrice: number;
+  margin: number;
+  stock: number;
+  /** null = capacité inconnue chez UEX. */
+  demand: number | null;
+  updated: number;
+};
+
+/** Une ligne de data/loops.json (160 entrées) : le couple de terminaux qui se rentabilise dans les
+ *  DEUX sens, pour ne pas repartir à vide. Produite uniquement par le générateur — logic.ts n'en
+ *  fabrique aucune, il ne fait que les filtrer (`loopPasses` l.114) et en tirer des jambes
+ *  (`legsFromLoop` l.1419).
+ *  `distance` est ici un `number` NU, contrairement à celle d'une `Route` : le générateur l'écrit
+ *  `(d1 || 0) + (d2 || 0)` (build-data.mjs:472), si bien qu'un aller-retour dont l'API ignore les
+ *  distances vaut 0 et jamais null. 160/160 sont des nombres dans l'instantané. Ne pas aligner les
+ *  deux « par symétrie » : ce sont deux calculs différents, et c'est le second qui absorbe l'échec.
+ *  `loopMargin` = out.margin + back.margin, toujours écrit, et c'est une colonne triable de la vue
+ *  (app.js:672, `bySort`) — pas un extra dont on pourrait se passer. */
+export type Boucle = {
+  a: ExtremiteBoucle; b: ExtremiteBoucle;
+  out: SegmentBoucle; back: SegmentBoucle;
+  loopMargin: number; distance: number;
+};
+
+/** Le sous-ensemble que `loopPasses` lit vraiment ; `Boucle` lui est assignable. */
+export type BoucleFiltrable = {
+  a: { system: string; outpost: boolean };
+  b: { system: string; outpost: boolean };
+  out: { illegal: boolean; commodity: string; updated: number };
+  back: { illegal: boolean; commodity: string; updated: number };
+};
+
+/** L'entrée de `routeMetrics` : une route dont les prix et volumes sont DÉJÀ résolus
+ *  (corrections locales appliquées en amont par `evaluate`, app.js:389).
+ *  `demandKnown` optionnel : la demande n'est « connue » que si l'utilisateur l'a corrigée. */
+export type RouteResolue = {
+  buyPrice: number;
+  buyStock: number;
+  sellDemand: number | null;
+  margin: number;
+  distance: number | null;
+  sameSystem: boolean;
+  buyUpdated: number;
+  sellUpdated: number;
+  demandKnown?: boolean;
+};
+
+/** Ce que rend `routeMetrics`. `null` = NON BORNÉ (aucune contrainte de volume), jamais « zéro ». */
+export type MetriquesRoute = {
+  age: number | null;
+  partVolume: number;
+  units: number | null;
+  investment: number | null;
+  profit: number | null;
+  minutes: number;
+  profitHour: number | null;
+  fiabilite: number;
+  fees: number;
+};
+
+/** Une jambe de boucle prête au calcul (`out` / `back` de `loopMetrics`).
+ *  Minimal à dessein : `effLeg` (app.js:615-617) rend un objet PLUS large, et les fixtures
+ *  logic.test.mjs:878-879 un objet exactement de cette forme. */
+export type SegmentResolu = {
+  buyPrice: number;
+  stock: number;
+  demand: number | null;
+  margin: number;
+  updated: number;
+  demandKnown?: boolean;
+};
+
+/** Ce que rend `loopMetrics`. `investment` = le MAX des deux jambes, pas leur somme :
+ *  le capital d'une jambe est libéré avant que l'autre ne le mobilise (logic.ts:207). */
+export type MetriquesBoucle = {
+  loopMargin: number;
+  age: number | null;
+  partVolume: number;
+  unitsOut: number | null;
+  unitsBack: number | null;
+  units: number | null;
+  investment: number | null;
+  profit: number | null;
+  minutes: number;
+  profitHour: number | null;
+  fiabilite: number;
+  fees: number;
+};
+
+/** Marge par SCU et ROI en %, frais d'autoload déduits. Même paire de noms que `dealFrom`
+ *  (logic.ts:767) : la colonne garde sa définition d'un mode à l'autre. */
+export type MargeNette = { margin: number; roi: number };
+
+
+// ==============================================================================================
+// Manifeste, soute, caisses et frais d'autoload
+// ==============================================================================================
+
+/** Une entrée de `market.terminals` (data/market.json), telle que `buildMarket` la publie —
+ *  scripts/build-data.mjs:265-269. 114 entrées dans l'instantané courant.
+ *  L'INDEX dans ce tableau est la seule clé fiable : `code` n'est PAS unique (PYROG désigne les
+ *  deux Pyro Gateway), d'où les tuples de marché qui référencent une position, jamais un nom.
+ *
+ *  REQUIS vs OPTIONNEL ne se lit pas sur l'instantané — les 9 champs y sont présents à 114/114 —
+ *  mais sur l'HISTOIRE du fichier : le service worker sert data/*.json en « réseau d'abord, cache
+ *  en repli » (sw.js), donc une coquille ANTÉRIEURE peut revenir à tout moment. Sont donc `?`
+ *  exactement les champs qu'un instantané déjà publié a pu ne pas porter :
+ *    - `autoload`/`maxBox`, ajoutés le 2026-08-11 (36d5833) — logic.ts:477-479 le dit déjà en
+ *      toutes lettres, et autoloadPoint:481 les lit défensivement ;
+ *    - `code`/`shot`/`shotBy`, ajoutés le 2026-08-13 (b2ddf9a), soit deux jours : le cas est tout
+ *      sauf théorique.
+ *  `name`/`system`/`planet`/`outpost` datent de la création du fichier (063a59a, 2026-07-13) :
+ *  aucun instantané publié n'a jamais existé sans eux — ils restent REQUIS. */
+export type Terminal = {
+  name: string;
+  /** Système stellaire. Le builder replie sur "?" quand UEX se tait : jamais vide, jamais absent. */
+  system: string;
+  /** "" pour 12 des 114 terminaux (7 portes de saut, 4 PSS, Levski). C'est une SENTINELLE, pas une
+   *  absence — `zoneDe` (logic.ts:1335) la traduit en « Espace profond ». Le passer en `?` mentirait
+   *  sur la donnée ET ferait remonter un `string | undefined` dans `dealFrom` (logic.ts:765-766) et
+   *  `commodityPoints` (logic.ts:1241), qui le recopient tel quel dans un champ `planet: string`. */
+  planet: string;
+  /** Avant-poste de surface = élévateur de fret peu fiable ; c'est ce que filtre `noOutpost`. */
+  outpost: boolean;
+  /** Le terminal (dé)charge tout seul — donc il FACTURE. Absent d'un instantané antérieur au
+   *  2026-08-11 : `autoloadPoint` retombe alors sur k = 0, aucun frais, pas un crash. */
+  autoload?: boolean;
+  /** Plus grosse caisse acceptée (16, 24 ou 32 dans l'instantané) : c'est elle qui décide en combien
+   *  de caisses la cargaison se découpe, donc combien de forfaits l'autoload facture. `undefined`
+   *  traverse volontairement `autoloadPoint` — logic.test.mjs:3444 EXIGE `{ maxBox: undefined, k: 0 }` —
+   *  et `scuBoxes` retombe sur la grille complète. */
+  maxBox?: number;
+  /** Code court UEX (ARCL1, LEVSKI…). Jamais une clé : ni index, ni Map, ni déduplication.
+   *  Lu en `t.code || ""` (logic.ts:1353, app.js:3335). */
+  code?: string;
+  /** Photo du terminal soumise par un joueur, URL UEX recopiée VERBATIM (deux hôtes CDN, deux
+   *  formes d'URL). "" pour 17 des 114. */
+  shot?: string;
+  /** Auteur de la photo, INDÉPENDANT de `shot` : 97 terminaux ont une photo mais 89 seulement un
+   *  crédit — d'où le `t.shot && t.shotBy` d'app.js:3338, qui ne signe que ce qui est signé. */
+  shotBy?: string;
+};
+
+/** Un point de marché de data/market.json : le tuple compact écrit par `buildMarket`
+ *  (scripts/build-data.mjs:283-284) et déjà décrit en logic.ts:752 comme
+ *  « [idxTerminal, prix, volume, updated, statut] ».
+ *  Mesuré : 2 373 tuples, TOUS de longueur 5 — d'où un tuple nommé et non `number[]`, pour que
+ *  `p[5]` soit une erreur et que les libellés s'affichent au survol.
+ *  Le premier élément est un INDEX dans `market.terminals`, jamais un nom : le nommer `terminal`
+ *  induirait précisément l'erreur que `market.terminals[p[0]]` répare partout. */
+export type PointMarche = [
+  idxTerminal: number,
+  /** aUEC par SCU. Entier et > 0 sur les 2 373 points (minimum relevé : 115). */
+  prix: number,
+  /** À l'ACHAT : le stock disponible — 0 = terminal vide, et `computeUnits` plafonne alors à 0.
+   *  À la VENTE : la capacité RESTANTE, et `null` = capacité INCONNUE, ce qui n'est ni zéro ni
+   *  l'infini. 1 572 des 1 879 points de vente (84 %) sont dans ce cas, contre 0 des 494 points
+   *  d'achat : c'est ce déséquilibre — et lui seul — qui justifie `certitudeVolume` (logic.ts:38-47)
+   *  et les deux chiffres d'`offloadPlan` (absorbe / garanti). Confondre `null` et `0` inverse le
+   *  sens : un 0 CONNU dit « saturé, ne prend plus rien ». */
+  volume: number | null,
+  /** Date du relevé UEX, epoch en SECONDES (l'instantané court du 2026-07-16 au 2026-08-13).
+   *  C'est ce que le domaine appelle ensuite `buyUpdated`/`sellUpdated`, et ce que `pairAge` date. */
+  releve: number,
+  /** Statut d'inventaire UEX, 1..7 — et son sens DÉPEND DU CÔTÉ : à la vente 7 = plein donc saturé
+   *  (les 13 points de statut 7 ont tous une capacité publiée à 0, et réciproquement — c'est le seul
+   *  zéro fiable du jeu de données, et logic.ts:2015 s'en sert pour ça) ; à l'achat 7 = bien
+   *  approvisionné, 251 points sur 494. 0 = UEX n'a rien dit, d'où le `b[4] || 0` de logic.ts:1212.
+   *  Pas d'union `1|2|…|7` : elle interdirait justement ce 0. */
+  statut: number,
+];
+
+/** Le MÊME tuple, côté ACHAT, où le volume est un stock TOUJOURS publié : 494 sur 494 dans
+ *  l'instantané, et par construction — `numField` rend toujours un nombre
+ *  (scripts/build-data.mjs:137) là où `sellDemand` (l.139-142) rend `null` à dessein.
+ *  Assignable à `PointMarche` (un `number` entre dans un `number | null`), donc les consommateurs
+ *  qui prennent les DEUX côtés ne bougent pas : `prix()` logic.ts:1201, `point()` logic.ts:1237.
+ *  Ce qu'il achète : `computeUnits(b[1], b[2], …)` (logic.ts:798) et `stock: b[2]` (dealFrom,
+ *  logic.ts:765) cessent de propager un `null` fantôme le jour où `strictNullChecks` passera. */
+export type PointAchatMarche = [idxTerminal: number, prix: number, stock: number, releve: number, statut: number];
+
+export type CommoditeIdentite = { name: string; kind: string; illegal: boolean };
+
+/** Une entrée de `market.commodities` (data/market.json), publiée par `buildMarket`
+ *  — scripts/build-data.mjs:281-285. 113 entrées dans l'instantané courant.
+ *  ATTENTION au sosie : `commodityPoints` (logic.ts:1247) et `commoditySummaries` (l.1219) rendent
+ *  des objets qui portent name/code/kind/illegal et même buys/sells, mais dont les buys/sells sont
+ *  des OBJETS de localisation, pas ces tuples. Ce ne sont PAS des `Commodite` — les annoter ainsi
+ *  serait la faute que cette définition doit empêcher. */
+export type Commodite = {
+  name: string;
+  /** Code officiel UEX (AGRI, LARA…), et jamais une clé : COPP désigne À LA FOIS « Copper »
+   *  (échangeable) et « Copper (Ore) » (butin) — `resolveCommodity` (logic.ts:1289-1296) refuse
+   *  donc de trancher sur un code ambigu plutôt que d'en désigner une au hasard.
+   *  Optionnel : ajouté le lendemain de la création du fichier (59bbd78, 2026-07-14), donc un
+   *  instantané servi depuis le cache du service worker peut en être dépourvu — et le code se
+   *  défend déjà partout : `c.code || ""` (logic.ts:1219, 1247), `c.code &&` (l.1294). */
+  code?: string;
+  /** Catégorie UEX normalisée en minuscules, casse et fautes de frappe corrigées, repli "other"
+   *  (scripts/build-data.mjs:110-121) : ni vide, ni absente. 25 valeurs distinctes dans
+   *  l'instantané — `string` et non une union, UEX en ajoute sans prévenir et une union ferait
+   *  échouer le typecheck sur une donnée parfaitement valide. */
+  kind: string;
+  illegal: boolean;
+  /** Où l'ACHETER. VIDE pour 36 des 113 : le butin (minerai raffiné, salvage, drogues de wreck) ne
+   *  s'achète nulle part, et c'est justement ce que le mode « Butin » chiffre (logic.ts:1206-1207).
+   *  Le tableau, lui, existe toujours : `c.buys.find(...)` n'est gardé nulle part (logic.ts:358). */
+  buys: PointAchatMarche[];
+  /** Où la VENDRE. Jamais vide : une commodité sans point de vente n'entre pas dans le fichier
+   *  (scripts/build-data.mjs:280) — sans vente, il n'y a rien à en dire. */
+  sells: PointMarche[];
+};
+
+export type Marche = { terminals: Terminal[]; commodities: Commodite[] };
+
+export type Correction = { price?: number; vol?: number; base?: number; ts?: number; pris?: number; saisiPrix?: number };
+
+export type ValeursEffectives = {
+  price: number | null; vol: number | null;
+  oprice: boolean; ovol: boolean; stale: boolean; staleVol: boolean;
+};
+
+export type ResolveurCorrections = (
+  commodite: string, terminal: string, cote: "buy" | "sell",
+  price: number, vol: number | null, dataUpdated: number,
+) => ValeursEffectives;
+
+export type CoteResolu = { price: number; vol: number | null; ovol?: boolean };
+
+export type ItemChargeable = {
+  name: string; kind?: string; illegal?: boolean;
+  buyPrice: number; stock: number | null; demand: number | null; demandKnown?: boolean;
+  sellPrice?: number | null; margin: number; buyUpdated?: number; sellUpdated?: number;
+};
+
+export type LigneChargement = ItemChargeable & { units: number; cap: number };
+
+/** UNE ligne de chargement : une commodité, ses deux prix, et ce qu'on en embarque.
+ *  TROIS fabriques la produisent, et c'est leur INTERSECTION qui décide de ce qui est requis :
+ *    - `manifestLine` (logic.ts:333-351) — carte « En route » et ajouts libres : les 16 champs ;
+ *    - `fillCargo` (logic.ts:278) sur les candidates de `manifestsFrom` (:882) et de
+ *      `suggestionsFrom` (:851) — le manifeste OPTIMAL : 13 champs, jamais les trois drapeaux ;
+ *    - `ligneDuSaut` (logic.ts:547-553) — repli mono d'un saut de chaîne : les 13 mêmes.
+ *  D'où la règle : tout est requis SAUF `carry`/`acquired`/`aBord`.
+ *
+ *  Les trois drapeaux absents valent FALSE, et ce n'est pas un confort d'écriture : les deux
+ *  fabriques qui ne les posent pas ne composent que des lignes dont les DEUX côtés existent
+ *  (`manifestsFrom` exige un achat, une vente et une marge > 0). Il n'y a rien à baliser. Leurs
+ *  lecteurs le savent déjà : `lineHaulFee` (:510) déstructure `line || {}`, `loadHold` (:1768)
+ *  teste `!l.aBord`. Les rendre requis casserait `fillCargo` et `ligneDuSaut` ; les mettre en
+ *  `| null` mentirait — ici « pas posé » veut dire « non », pas « on ne sait pas ». */
+export type LigneManifeste = {
+  name: string;
+  /** Catégorie UEX (metal, gas, drug…) recopiée de la commodité — porte l'icône (app.js:1121). */
+  kind: string;
+  illegal: boolean;
+  /** Prix payé au SCU. 0 quand rien n'a été acheté ici (butin) — d'où `acquired`, sans quoi ce 0
+   *  se lirait comme un vrai relevé UEX. Avec `paid` (ADR-002), c'est le coût réel du fret
+   *  déjà embarqué : 2 170 SCU achetés 1 000 comptaient 1 400 de marge au lieu de 400. */
+  buyPrice: number;
+  /** Ce qu'on peut encore acheter ici. TROIS valeurs, trois sens qu'il ne faut pas confondre :
+   *    un nombre — le stock publié (494 points d'achat sur 494 en publient un, market.json) ;
+   *    Infinity  — aucun point d'achat ici : on ne charge rien, on transporte (logic.ts:338) ;
+   *    null      — volume inconnu du résolveur. L'instantané UEX n'en produit aucun côté achat,
+   *                mais c'est le type de `ValeurResolue.vol` et une fixture l'écrit noir sur
+   *                blanc (logic.test.mjs:1893). `fillCargo` le traite déjà comme 0 par
+   *                `Math.min` : quand `strictNullChecks` passera, c'est LÀ qu'il faudra trancher. */
+  stock: number | null;
+  /** null = ce terminal ne reprend PAS la commodité -> ligne `carry`. Ce n'est pas un prix nul :
+   *  `lineProfitText` (app.js:340) et le tag « vend ailleurs » (app.js:2399) testent `== null`. */
+  sellPrice: number | null;
+  /** null = capacité INCONNUE chez UEX (1 572 des 1 879 points de vente), et surtout PAS zéro :
+   *  `fillCargo` (:275) ne plafonne que si `demand != null || demandKnown`, `tripMetrics` (:1008)
+   *  ne compte les SCU « connus » que si `demand != null`. Un 0 ici dit saturé, donc exclut. */
+  demand: number | null;
+  /** La capacité vient d'une CORRECTION locale (`ovol`) et non d'UEX : elle plafonne même à 0 —
+   *  l'utilisateur a vu le comptoir de ses yeux. C'est le seul cas où `demand: 0` fait foi. */
+  demandKnown: boolean;
+  /** `sellPrice − buyPrice`, ou 0 si la ligne ne se vend pas ici. Marge de MARCHÉ, jamais nette :
+   *  la marge nette vit dans `lineNet`, et une marge nette figée survivrait à l'interrupteur. */
+  margin: number;
+  /** Dates UEX des deux relevés ; 0 = inconnue (`pairAge` rend alors null). Les trois fabriques
+   *  les normalisent (`|| 0`) : jamais absentes, jamais nulles. */
+  buyUpdated: number;
+  sellUpdated: number;
+  /** SCU réellement embarqués. Ajustable à la main dans l'interface, y compris AU-DELÀ de `cap`
+   *  (vol de fret, relevé périmé) : ne jamais supposer `units <= cap`. */
+  units: number;
+  /** Plafond suggéré (stock ∩ demande, via `tighterVolume`). PEUT VALOIR Infinity — ni achat ni
+   *  demande connus (logic.test.mjs:3357) — d'où le garde `isFinite(l.cap)` d'app.js:2188. */
+  cap: number;
+  /** Chargée ici, vendue AILLEURS : rien à décharger à l'arrivée, donc seul le chargement est
+   *  facturé (`lineHaulFee`:515) et la colonne profit affiche « — ». */
+  carry?: boolean;
+  /** Rien n'a été chargé ici — butin, minage, salvage, ou fret embarqué ailleurs : l'autoload du
+   *  terminal de départ ne l'a jamais manipulée (`lineHaulFee`:514). */
+  acquired?: boolean;
+  /** Déjà en soute ET coût connu (`paid`, ADR-002). Sous-cas d'`acquired` : ce qui les sépare est
+   *  le COÛT, pas la manutention. `loadHold` (:1768) ne recharge pas un lot `aBord`.
+   *  PIÈGE : sur le TRAJET, `aBord` est un NOMBRE de SCU (app.js:989, :1250). Même nom, autre
+   *  champ, autre type — ne pas réutiliser ce booléen pour typer `Trajet`. */
+  aBord?: boolean;
+};
+
+// Les lecteurs qui n'en prennent qu'une part n'élargissent PAS ce type — ils annoncent leur propre
+// besoin, et c'est ce qui gardera les fixtures à cinq champs valides le jour où les tests seront
+// typés : `loadHold` (:1766) veut `{ name; units; buyPrice?; aBord? }[]`, `manifestIntent`
+// `{ name; units }[]`, `lineHaulFee`/`lineNet` `{ margin?; carry?; acquired? }`.
+
+export type TotauxManifeste = { profit: number; invest: number; scu: number; fees: number };
+
+export type Caisse = { size: number; count: number };
+
+export type GrilleAutoload = { base: number; perBox: number; perScu: number };
+
+export type BornesK = { min: number; max: number };
+
+
+// ==============================================================================================
+// Chaîne multi-sauts, corrections locales, état partageable
+// ==============================================================================================
+
+
+export type CoteMarche = "buy" | "sell";
+
+export type ChargementDuSaut = { units: number; profit: number; lines: LigneManifeste[]; cargo: number };
+
+/** Une JAMBE du compagnon de voyage : un saut d'un terminal à un autre dans un parcours ORDONNÉ
+ *  (`{ legs, current }`, contrat écrit en toutes lettres logic.ts:1369-1374).
+ *
+ *  HUIT champs, tous OBLIGATOIRES — et cette rigidité est un contrat, pas une préférence. La jambe
+ *  est PERSISTÉE telle quelle dans le permalien `j=` sous forme de tuple POSITIONNEL de huit cases
+ *  (encodeJourney:2413), que decodeJourney:2432-2436 relit case par case en forçant `String()` et
+ *  `Number()`. Un `?` ici, et une case du tuple peut valoir `undefined` -> `JSON.stringify` l'écrit
+ *  `null` -> le lien partagé rend une jambe que le rendu ne sait pas peindre. C'est exactement le
+ *  TypeError qu'a corrigé le durcissement de `jambeValide` (logic.ts:2430) : le hash vient
+ *  potentiellement d'un tiers, la forme est donc une frontière, pas une commodité d'écriture.
+ *
+ *  `from`/`to` sont des NOMS de terminal, jamais des index ni des libellés « Nom — Système » :
+ *  legKey (app.js:2044), journeyConnects:1462 et manifestJourneyState:1489-1494 comparent des noms
+ *  seuls. Une seconde règle d'identité (nom + système) ferait diverger deux définitions du même mot.
+ *
+ *  La jambe « à VIDE » n'est PAS une jambe amputée : app.js:2261 (emptyLeg) et le pont de
+ *  removeJourneyStop (app.js:2324) écrivent `commodity: ""` et trois zéros. Le vide se dit par la
+ *  valeur neutre — d'où l'absence de `?` ET de `| null` sur les huit champs.
+ *
+ *  DEUX HOMONYMES, que seul le typage rend visibles :
+ *   - l'arc du graphe de chaîne (`ArcChaine`, buildChainAdjacency:1129) : son `to` est un INDEX de
+ *     terminal, il n'a pas de `from`, et il porte stock/demande/frais. legsFromChain:1429-1434 le
+ *     CONVERTIT en `Jambe` — cette conversion est la preuve que ce sont deux types ;
+ *   - le segment de boucle (`SegmentBoucle` de data/loops.json, corrigé par app.js:614-618) : ni
+ *     `from` ni `to`, deux extrémités tour à tour achat et vente.
+ *
+ *  PIÈGE DE SIGNATURE, à ne PAS résoudre en assouplissant ce type : manifestJourneyState:1492
+ *  appelle `journeyConnects(journey, [{ from: origin.name }])` avec une jambe réduite à son départ.
+ *  Le paramètre de journeyConnects se type donc `readonly Pick<Jambe, "from">[]`, et le `bridge` de
+ *  removeJourneyStop:1567 `Jambe | null` (les tests l'omettent : logic.test.mjs:3046, 3061, 3067). */
+export type Jambe = {
+  /** Nom du terminal de départ. C'est LUI qui porte l'identité de la jambe (legKey, journeyConnects). */
+  from: string;
+  /** Système du départ : sert à retrouver l'index via stationLabel (app.js:2006) et à écrire le
+   *  libellé — jamais à comparer deux jambes. */
+  fromSystem: string;
+  to: string;
+  toSystem: string;
+  /** Commodité de TÊTE seulement. Un saut transporte un MANIFESTE (#56) qui n'entre pas dans huit
+   *  cases : la vue Voyage recompose le chargement complet au rendu (legManifest, app.js:2004), et
+   *  legsFromChain:1432 prend la tête du manifeste — pas le repli mono de l'arc — pour que les deux
+   *  vues nomment la même commodité. `""` sur une jambe à vide (logic.test.mjs:3372). */
+  commodity: string;
+  buyPrice: number;
+  sellPrice: number;
+  /** Marge de MARCHÉ, toujours BRUTE, jamais nette des frais d'autoload (legFromTrip:1023-1027) :
+   *  elle survit dans le permalien à l'extinction de l'interrupteur, et journeyMargin:1749 la cumule
+   *  avec des marges brutes venues des trois autres fabriques. Moyenne du chargement quand la jambe
+   *  vient d'un manifeste (legFromManifest:1045 injecte `marginGross`). */
+  margin: number;
+};
+
+/** Une jambe de CHAÎNE une fois chiffrée par `bestChain` : l'arc du graphe, plus ce que ce saut
+ *  transporte réellement (logic.ts, `legs: [...p.legs, { ...leg, units, profit, lines }]`).
+ *
+ *  Elle s'appuie sur `JambeChaine` et NON sur `Jambe` : ce sont deux choses distinctes que deux
+ *  zones d'analyse ont nommées pareil. `Jambe` est la jambe du COMPAGNON DE VOYAGE — elle part
+ *  d'un terminal nommé (`from: string`) et vit dans un parcours persisté. `JambeChaine` est un ARC
+ *  du graphe de la recherche multi-sauts — elle pointe un INDEX de terminal (`to: number`) et
+ *  n'existe que le temps d'un calcul. */
+export type JambeChiffree = JambeChaine & { units: number; profit: number; lines: LigneManifeste[] };
+
+export type OptionsChaine = { cargo?: number; beam?: number };
+
+/** Le résultat de `bestChain`. `path` porte des INDEX de terminaux, comme tout le graphe de la
+ *  chaîne — le premier est le `start` reçu, les suivants sont des `leg.to`. */
+export type Chaine = { path: number[]; legs: JambeChiffree[]; profit: number };
+
+export type CommoditeChargeable = { buyPrice: number; stock: number; demand?: number | null; demandKnown?: boolean; margin?: number };
+
+export type RestantManifeste = { cargoLeft: number; budgetLeft: number };
+
+export type StoreCorrections = Record<string, Correction>;
+
+/** Le VERDICT DE FRAÎCHEUR d'une correction locale : ce que rendent `effValue` (logic.ts:242-259) et
+ *  `effFromStore` (logic.ts:629-638), et eux seuls. À ne pas confondre avec `ValeurResolue`, qui est
+ *  ce que logic.ts EXIGE d'un résolveur : celui-ci est plus riche, l'autre est le minimum.
+ *
+ *  Les six champs sont TOUJOURS là — les trois points de retour d'effValue les posent tous les six,
+ *  et deux tests le verrouillent au champ près par `assert.deepEqual` (logic.test.mjs:265 et :745).
+ *  Rien n'est optionnel ici, et c'est le cœur de l'affaire : mis en optionnels, `stale` et `staleVol`
+ *  deviendraient `boolean | undefined`, et un lecteur qui écrit `if (v.stale)` lirait `undefined` —
+ *  donc « pas périmé » — sur un objet incapable de répondre. C'est précisément le contresens
+ *  silencieux contre lequel logic.ts:240-241 impose DEUX drapeaux plutôt qu'un objet.
+ *
+ *  Les deux péremptions ne sont pas interchangeables :
+ *    `stale`    — UEX a republié le point : toute la correction est morte, la clé part du store ;
+ *    `staleVol` — le volume a dépassé DUREE_VOL : lui seul meurt, le prix corrigé survit.
+ *
+ *  `vol: number | null` est MESURÉ, pas prudentiel : 1 572 des 1 879 points de vente de
+ *  data/market.json ne publient aucun volume (0 sur 494 côté achat). null = capacité INCONNUE chez
+ *  UEX — ni zéro, ni l'infini ; c'est ce que `ovol` sert à démentir quand l'utilisateur a vu le
+ *  comptoir de ses yeux.
+ *
+ *  Limite connue : `relireCorrections` (logic.ts:2544) est le SEUL appelant à passer `price = null,
+ *  vol = null` — et il ne lit que `stale`/`staleVol`, jamais le prix. `price: number` reste donc le
+ *  contrat du chemin marché ; c'est ce site-là qui prendra une annotation quand `strictNullChecks`
+ *  montera d'une marche (l'escalier est décrit dans tsconfig.json). */
+export type ValeurEffective = {
+  price: number;
+  vol: number | null;
+  oprice: boolean;    // le prix affiché vient d'une correction locale (pastille ✎, app.js:379)
+  ovol: boolean;      // le volume affiché vient d'une correction locale — donc FIABLE : un 0 plafonne
+  stale: boolean;
+  staleVol: boolean;
+};
+
+export type ChampCorrection = "price" | "vol";
+
+export type GroupeCorrections = { terminal: string; corrections: number; actif: boolean };
+
+export type EtatDecode = Record<string, string>;
+
+
+// ==============================================================================================
+// Marché interactif : deals, suggestions, manifestes
+// ==============================================================================================
+
+/** Ce qu'un `Resolveur` PROMET à logic.ts, et rien de plus. Le contrat est écrit en toutes lettres
+ *  en logic.ts:754-755 : « renvoie au moins { price, vol, ovol } (identité si aucune correction) ».
+ *
+ *  « Au moins » n'a pas besoin d'optionnels pour se dire en TypeScript — le sous-typage structurel le
+ *  dit déjà : `effVals` (app.js:192) rend un `ValeurEffective` à six champs et reste assignable ici
+ *  sans qu'on ait à l'annoncer. Trois champs, donc, et pas six :
+ *    - c'est ce que rendent les cinq résolveurs RÉELS des tests (logic.test.mjs:917, :2302, :2842,
+ *      :3328, :3415) ;
+ *    - c'est exactement ce que logic.ts lit sur une valeur résolue — `.price`, `.vol`, `.ovol`, et
+ *      jamais rien d'autre (338-341, 372, 382, 849-851, 879-882, 1124-1129, 1201, 1242, 1912,
+ *      1986, 2008-2033) ;
+ *    - et `manifestLine` reçoit directement des littéraux de cette forme (logic.test.mjs:1563-1564,
+ *      :1604-1605, :1947), ce qu'un champ obligatoire de plus ferait échouer.
+ *  Y ajouter `stale?`/`staleVol?`/`oprice?` en optionnels serait pire qu'inutile : ça autoriserait
+ *  `if (e.stale)` sur une valeur qu'aucun résolveur léger ne renseigne — toujours `undefined`, donc
+ *  toujours « frais ». Qui a besoin des drapeaux de péremption tient un `ValeurEffective`, pas ceci.
+ *
+ *  `vol: number | null` : null = capacité INCONNUE chez UEX (1 572 des 1 879 points de vente de
+ *  data/market.json), et surtout pas zéro.
+ *  `ovol` n'est pas décoratif : `manifestLine` en fait `demandKnown` (logic.ts:341), et c'est lui
+ *  qui autorise un 0 à plafonner le remplissage (computeUnits, logic.ts:139) — une demande corrigée
+ *  à la main est CONNUE, là où un `vol` null d'UEX ne l'est pas. */
+export type ValeurResolue = { price: number; vol: number | null; ovol: boolean };
+
+/** Le PORT par lequel les corrections locales entrent dans des fonctions pures. logic.ts ne connaît
+ *  ni localStorage ni l'objet OVERRIDES : il reçoit cette fonction. L'unique implémentation réelle
+ *  est `effVals` (app.js:192), qui délègue à `effFromStore` (logic.ts:629) puis y ajoute ses effets
+ *  de bord d'application (persistance, notifications). C'est ce port, et lui seul, qui rend
+ *  `logic.ts` testable : les tests y injectent une identité.
+ *
+ *  `terminal` est le NOM du terminal, jamais son index : tous les sites d'appel passent `t.name`
+ *  (logic.ts:362-363, 847-848, 871, 878, 1114, 1123, 1201, 1239, 1911, 1985, 2007), parce que la clé
+ *  du store est textuelle (`ovKey`, logic.ts:623) et doit survivre à un réordonnancement des
+ *  terminaux au prochain export UEX — un index corrigerait alors le mauvais comptoir.
+ *
+ *  `vol: number | null` À L'ENTRÉE aussi, pas seulement en sortie : c'est le 3ᵉ élément du tuple de
+ *  marché, null sur 1 572 des 1 879 points de vente de data/market.json.
+ *  `updated` est la date UEX du point (4ᵉ élément) : c'est l'ANCRE de fraîcheur — c'est en la
+ *  comparant à `base` qu'effValue décide qu'une correction est périmée, pas en regardant l'heure.
+ *
+ *  Le type ne porte PAS `| null`. `resolve` est facultatif à presque tous les appels (`resolve = null`
+ *  en logic.ts:1198, 1232, 1971, 2096 ; les tests passent `null`, p. ex. logic.test.mjs:2184), mais
+ *  c'est le PARAMÈTRE qui s'annote `Resolveur | null` : rendre le type lui-même nullable
+ *  contaminerait jusqu'aux sites qui en exigent un (manifestsFrom, buildChainAdjacency).
+ *
+ *  Rend un `ValeurResolue` — le minimum — et non un `ValeurEffective` : un résolveur de test rend
+ *  trois champs, et exiger les six l'exclurait. Un résolveur plus riche reste assignable.
+ *  Les fixtures qui ne déclarent que 5 paramètres (le 6ᵉ leur est inutile) restent assignables aussi.
+ *  `side` est écrit ici en clair : si le dépôt adopte un alias `Cote = "buy" | "sell"`, il se
+ *  substitue sans rien changer d'autre. */
+export type Resolveur = (
+  commodity: string,
+  terminal: string,
+  side: "buy" | "sell",
+  price: number,
+  vol: number | null,
+  updated: number,
+) => ValeurResolue;
+
+export type ResolveurFrais = (terminal: Terminal) => PointFrais | null;
+
+/** Une entrée de CATALOGUE côté vente : où l'on peut vendre, à quel prix, avec quelle capacité
+ *  restante, et depuis quand le relevé date. Deux producteurs, exactement la même forme :
+ *  l'extrémité `sell` d'une route (data/routes.json, et `dealFrom` l.766) et les points de vente
+ *  du panneau Commodités (`commodityPoints` l.1240-1243, dont la clé de volume est « demand »).
+ *  `demand: null` = capacité INCONNUE chez UEX. Ce n'est ni zéro — un comptoir saturé, lui,
+ *  publie 0 et porte le statut 7, la seule équivalence fiable du jeu de données (l.2009-2015) —
+ *  ni l'infini. 256 des 316 routes et 1 572 des 1 879 points de vente du marché sont dans ce cas :
+ *  c'est le cas MAJORITAIRE, et il commande `computeUnits` (l.137-139), la double colonne
+ *  absorbe/garanti d'`offloadPlan` et le « plancher » de la tournée d'écoulement. */
+export type PointVente = {
+  terminal: string; system: string; planet: string; outpost: boolean;
+  price: number; demand: number | null; updated: number; status: number;
+};
+
+/** Le DÉBOUCHÉ d'une commodité à un terminal donné : ce comptoir la reprend-il, à quel prix, et
+ *  jusqu'où. Rendu par `sellableAt` (l.1905-1913) ; `null` = aucun débouché ici. Le mot est celui
+ *  du dépôt, pas une invention : `sansDebouche` (l.2075, l.2104, app.js:2507-2509).
+ *  Ce n'est PAS un `PointVente` amputé, c'est une autre question. `PointVente` est une entrée de
+ *  catalogue — localisée, datée, triable, faite pour être listée. `Debouche` est la réponse LOCALE
+ *  à « puis-je écouler ça ici ? », posée quand on sait déjà où l'on est : d'où trois champs, et
+ *  d'où `terminal` conservé alors que l'appelant tient déjà l'index — c'est le NOM qui sert de clé
+ *  au refus de vente (`refuseHere`, app.js:1523). Les fondre en une union mentirait sur les deux. */
+export type Debouche = { price: number; demand: number | null; terminal: string };
+
+export type CandidatChargement = {
+  name: string; kind: string; illegal: boolean;
+  buyPrice: number; stock: number | null;
+  sellPrice: number | null; demand: number | null; demandKnown: boolean;
+  margin: number; buyUpdated: number; sellUpdated: number;
+};
+
+// ---------- Vue « Trajets » multi-commodité et vue « En route » : un CHARGEMENT ----------
+/** Un chargement multi-commodité d'un terminal vers un autre — ce que `manifestsFrom` construit
+ *  (l.967), le seul endroit du dépôt où ces neuf champs sont posés ensemble.
+ *  Le « manifeste » de la vue « En route » et le « trajet » de la vue « Trajets multi » sont le
+ *  MÊME objet : le commentaire l.1037-1038 le dit en toutes lettres, `legFromManifest` (l.1045) en
+ *  dépend, et `manifesteSansOptimal` (app.js:965-972) en fabrique le jumeau exact quand plus aucun
+ *  chargement n'est rentable. Deux types diraient qu'ils peuvent diverger : ils ne le peuvent pas.
+ *  À NE PAS confondre avec `Route`, la ligne à une commodité de data/routes.json : la vue s'appelle
+ *  « Trajets » et montre les deux, mais elles n'ont pas un champ en commun.
+ *  Un `Trajet` n'a pas de distance — elle n'existe pas hors routes.json — d'où le
+ *  `tripMinutes(0, trip.cross)` de `tripMetrics` (l.995).
+ *
+ *  Les trois derniers champs ne sont JAMAIS posés par `manifestsFrom` : l'appelant les greffe après
+ *  coup. Ils sont déclarés ici parce que logic.ts les LIT, et qu'une propriété non déclarée est une
+ *  erreur de compilation même sans `strict` :
+ *    `margin` / `marginGross` — versés par `tripMetrics` (app.js:506 fait `{ ...t, ...tripMetrics(t) }`,
+ *      `legFromManifest` fait `{ ...man, marginGross }` l.1046), lus par `legFromTrip` l.1033.
+ *      La jambe retient la marge BRUTE : elle part dans le permalien `j=`, où une marge nette des
+ *      frais d'autoload n'aurait plus de sens l'interrupteur éteint.
+ *    `f` — les filtres qui ont produit le chargement, greffés par app.js:1249 et lus par
+ *      `suggestionsFrom` l.846 : sans eux la boîte de suggestions proposerait ce que le manifeste
+ *      optimal vient d'écarter, exactement le défaut que `pairEligible` a corrigé.
+ *  Qui préfère un type distinct pour le trajet greffé (`TrajetAffiche = Trajet & { … }`) peut les
+ *  sortir d'ici — mais pas les supprimer : l.846 et l.1033 les lisent. */
+export type Trajet = {
+  origin: Terminal; originIdx: number; dest: Terminal; destIdx: number;
+  cross: boolean;
+  lines: LigneManifeste[];
+  profit: number;
+  fee: PaireFrais | null;
+  cargo: number;
+  margin?: number; marginGross?: number;
+  f?: Filtres;
+};
+
+export type MetriquesTrajet = {
+  age: number | null; partVolume: number; units: number; investment: number; profit: number;
+  margin: number; marginGross: number; roi: number; minutes: number; profitHour: number | null;
+  fiabilite: number; fees: number; nLines: number; commodity: string; buyPrice: number; sellPrice: number;
+};
+
+export type ContexteManifeste = {
+  lines: Array<{ name: string }>; originIdx: number; destIdx: number;
+  origin: { name: string }; dest: { name: string }; f: Filtres;
+};
+
+export type ChiffrageSaut = { units: number; profit: number; lines: LigneManifeste[]; cargo: number };
+
+export type JambeChaine = {
+  to: number; commodity: string; kind: string; illegal: boolean;
+  margin: number; buyPrice: number; sellPrice: number;
+  stock: number | null; demand: number | null; demandKnown: boolean;
+  fee: PaireFrais | null; buyUpdated?: number; sellUpdated?: number;
+  lines?: LigneManifeste[]; net?: ChiffrageSaut;
+};
+
+
+// ==============================================================================================
+// Panneau Commodités, résolution, compagnon de voyage
+// ==============================================================================================
+
+export type Cote = "buy" | "sell";
+
+export type Station = { name: string; system: string };
+
+export type BoardCommodites = "market" | "loot";
+
+export type FiltresBoard = Filtres & { board?: BoardCommodites };
+
+export type ResumeCommodite = {
+  name: string; code: string; kind: string; illegal: boolean;
+  nBuy: number; nSell: number;
+  bestBuy: number | null; bestSell: number | null;
+  buyStatus: number; sellStatus: number;
+  margin: number | null; sellOnly: boolean;
+};
+
+type PointCommoditeBase = {
+  terminal: string; system: string; planet: string; outpost: boolean;
+  price: number; updated: number; status: number;
+};
+// `stock`/`demand` OPTIONNELS : ils sont posés par clé calculée (`[volKey]`, logic.ts:1242),
+// que TypeScript ne sait pas relier à un nom de propriété. Les rendre requis casse le typecheck.
+export type PointAchatCommodite = PointCommoditeBase & { stock?: number | null };
+export type PointVenteCommodite = PointCommoditeBase & { demand?: number | null };
+
+export type DetailCommodite = {
+  name: string; code: string; kind: string; illegal: boolean;
+  buys: PointAchatCommodite[]; sells: PointVenteCommodite[];
+};
+
+export type CleDeValeur = "bestSell" | "bestBuy" | "margin";
+export type ClassableParValeur = {
+  name: string; bestSell?: number | null; bestBuy?: number | null; margin?: number | null;
+};
+export type PalierValeur = "t-hot" | "t-warm" | "t-mid" | "t-low" | "t-none";
+
+export type StationArbre = {
+  i: number; name: string; system: string; zone: string;
+  code: string; shot: string; outpost: boolean; label: string;
+};
+export type ZoneArbre = { zone: string; stations: StationArbre[] };
+export type NoeudSysteme = { systeme: string; zones: ZoneArbre[] };
+
+export type ArcChaine = {
+  to: number; commodity: string; kind?: string; illegal?: boolean;
+  margin: number; buyPrice: number; sellPrice: number;
+  stock: number; demand: number | null; demandKnown: boolean;
+  fee?: unknown; lines?: LigneManifeste[]; net?: unknown; units?: number; profit?: number;
+};
+export type ChaineChiffree = { path: number[]; legs: ArcChaine[]; profit?: number };
+
+export type Parcours = { legs: Jambe[]; current: number; start?: Station };
+
+export type RetraitArret = Parcours & { removedFrom: number; removedCount: number; insertedCount: number };
+
+export type SuggestionArret = { label: string; terminal: string; system: string; commodity: string; margin: number };
+
+export type IntentionLigne = { name: string; units: number };
+
+export type CompositionManifeste = {
+  from: string; fromSystem: string; to: string; toSystem: string; lines?: IntentionLigne[];
+};
+export type VueManifeste = { from: Station; dest: Station | null; destSystem: string };
+
+export type EtatVoyageManifeste =
+  | { etat: "ajouter" }
+  | { etat: "deja"; leg: number }
+  | { etat: "conflit"; fin: string | null };
+
+
+// ==============================================================================================
+// Jambes, soute, tournée d'écoulement, carte du parcours
+// ==============================================================================================
+
+export type TarifTerminal = (terminal: Terminal) => PointFrais | null;
+
+export type IntentionManifeste = { name: string; units: number };
+
+export type Retrait = { removedFrom: number; removedCount: number; insertedCount?: number };
+
+export type Lot = {
+  name: string; units: number; paid: number; from: string;
+  at?: number;        // horodatage du chargement — ABSENT d'un lot repris d'entrepôt
+  leg?: string;       // "<rang>|<from>|<to>" — la CLÉ est supprimée, jamais mise à null
+  refuse?: string; refuseAt?: number;
+  deposeAt?: number;  // posé par storeFromHold
+  avant?: number;     // format ANTÉRIEUR au registre, retiré par migrerChargements
+};
+
+export type LotConsomme = { name: string; units: number; paid: number; from: string };
+
+export type Entrepots = Record<string, Lot[]>;
+
+export type GroupeSoute = { name: string; units: number; invest: number; lots: (Lot & { i: number })[]; paidMoyen: number };
+
+export type VenteSoute = { hold: Lot[]; vendu: number; recette: number; cout: number; profit: number; lots: LotConsomme[] };
+
+export type VenteLigne = { name: string; units: number; price: number; recette: number; cout: number; profit: number; lots: LotConsomme[] };
+
+export type VenteEtape = { hold: Lot[]; ventes: VenteLigne[]; recette: number; cout: number; profit: number };
+
+export type Prise = { name: string; terminal: string; ref: number | null; units: number };
+
+export type Chargements = Record<string, Prise[]>;
+
+export type PorteursDeRang = {
+  edits?: Record<string, IntentionManifeste[]>;
+  pins?: Record<string, boolean>;
+  lots?: Lot[];
+  chargements?: Chargements;
+};
+
+export type Certitude = "connue" | "inconnue" | "partielle";
+
+export type LigneEcoulement = {
+  name: string; absorbe: number; garanti: number; reste: number;
+  price: number; demand: number | null; connue: boolean;
+  profit: number; encaisse: number; sousLePrixPaye: boolean;
+};
+
+export type Destination = {
+  idx: number; terminal: string; system: string; planet?: string; outpost?: boolean;
+  cross: boolean; lignes: LigneEcoulement[];
+  scu: number; garanti: number; profit: number; encaisse: number;
+  scuReine: number; reine: string | null; aPerte: boolean;
+  certitude: Certitude; reste: number;
+};
+
+export type OptionsEcoulement = {
+  inclureOrigine?: boolean;
+  comparer?: (a: Destination, b: Destination) => number;
+};
+
+export type OptionsTournee = { maxArrets?: number; premierForce?: number; k?: number };
+
+export type SansDebouche = { name: string; units: number };
+
+export type Tournee = {
+  arrets: Destination[]; reste: Lot[]; sansDebouche: SansDebouche[];
+  resteScu: number; scu: number; garanti: number; encaisse: number; profit: number;
+  sauts: number; certitude: Certitude;
+  // Posés SEULEMENT sur l'alternative, après coup (logic.ts:2153-2154) :
+  ecart?: number; ecartPct?: number | null;
+};
+
+export type Ancre = { au: number; lon: number };
+
+export type Starmap = Record<string, { ancres: Record<string, Ancre> }>;
+
+export type InfoTerminal = (nom: string) => { planet?: string } | null;
+
+export type CorpsCarte = { nom: string; orbite: number; x: number; y: number; occupe?: boolean };
+
+export type SystemeCarte = { nom: string; cx: number; cy: number; r: number; auMax?: number; corps: CorpsCarte[] };
+
+export type ArretCarte = { nom: string; systeme: string; orphelin: boolean; parent?: string; x: number; y: number };
+
+export type JambeCarte = {
+  x1: number; y1: number; x2: number; y2: number; cx: number; cy: number;
+  saut: boolean; faite: boolean; fleche: { x: number; y: number; angle: number };
+};
+
+export type Carte = {
+  largeur: number; hauteur: number;
+  systemes: SystemeCarte[]; arrets: ArretCarte[]; jambes: JambeCarte[];
+  vaisseau: { x: number; y: number; angle: number; arret: number; enVol: boolean };
+};
+
+export type Releves = Record<string, number>;
+
+export type EnteteExport = { v: number; type: string; emis: string | null };
+
+export type CorrectionExportee = {
+  commodite: string; terminal: string; cote: "achat" | "vente";
+  champ: "prix" | "volume"; valeur: number; saisi: string | null; base: string | null;
+};
+
+export type ExportCorrections = EnteteExport & { corrections: CorrectionExportee[] };
+
+export type Verdict = "appliquer" | "périmée-uex" | "périmée-âge" | "date-inconnue";
+
+export type CorrectionRelue = CorrectionExportee & { verdict: Verdict };
+
+
+// ==============================================================================================
+// Types nés de la réconciliation (une zone en cachait deux)
+// ==============================================================================================
+
+// ==============================================================================================
+// Types nés du typecheck : là où une annotation d'agent promettait plus que la fonction ne rend
+// ==============================================================================================
+
+/** Ce que `sellableAt` rend vraiment : le prix et la capacité d'UN terminal pour UNE commodité,
+ *  vus APRÈS corrections locales. Volontairement plus petit qu'un `PointVente` — la fonction ne
+ *  connaît ni le système, ni la planète, ni le statut UEX, et promettre ces champs aurait fait
+ *  mentir la signature. `demand: null` garde ici son sens habituel : capacité inconnue, ni zéro
+ *  ni infinie. */
+export type VenteAuTerminal = { price: number | null; demand: number | null; terminal: string };
+
+/** Un disque de système sur la carte du parcours, pendant sa construction. `auMax` et `corps` se
+ *  remplissent en DEUX TEMPS : le disque est d'abord posé (position, rayon), puis les ancres de
+ *  starmap.json y ajoutent le rayon orbital maximal et les corps. D'où deux champs qui ne sont pas
+ *  optionnels par tolérance, mais parce que l'objet existe réellement sans eux un instant. */
+export type DisqueSysteme = {
+  nom: string;
+  cx: number; cy: number; r: number;
+  corps: CorpsCarte[];
+  auMax?: number;
+};


### PR DESCRIPTION
> **Base : `v2/main`, jamais `main`.** ADR-008 §3 — `main` sert la v1 jusqu'à la bascule finale.

## Ce que ça change

`logic.mjs` devient **`logic.ts`** — 2 584 lignes de fonctions pures, 127 exports — et le
vocabulaire du domaine est posé à côté dans **`types.ts`**. Rien pour l'utilisateur : aucune vue,
aucun React, aucun comportement.

## Pourquoi

Second livrable de la refonte ([ADR-008 §5](docs/superpowers/specs/2026-08-15-refonte-v2-vite-react-adr.md), #96).
`logic` passe en premier parce que **475 tests la couvrent en 400 ms**, là où une vue demande un
tour de Playwright complet.

### La preuve que rien n'a été réécrit

```
vite build →  dist/assets/index-CtJ4-dpO.js
              ↑ le MÊME hash qu'avant le renommage, et qu'avant l'annotation
```

Le JavaScript émis est **identique au bit près** : les annotations sont purement effacées. C'est
ce que l'ADR exige, et pour une raison précise — si une annotation et une réécriture voyageaient
ensemble, un échec de test deviendrait inexploitable : nouveau type, ou nouveau bug ?

### Les types ne sont pas inventés

Ils ont été relevés sur les usages réels (`logic.ts`, les 425 tests de `logic.test.mjs`, `app.js`)
et sur les **données réelles** de `data/*.json`. Deux règles en sont sorties, écrites en tête de
`types.ts` :

**`?` ne veut pas dire « rare »** mais « un instantané `data/` **déjà publié** a pu ne pas porter ce
champ ». Le critère est donc l'**histoire du dépôt**, pas le fichier du jour — le service worker
sert les données en « réseau d'abord, cache en repli », donc une coquille antérieure peut revenir à
tout moment. `autoload`/`maxBox` datent du 2026-08-11, `code`/`shot`/`shotBy` du 2026-08-13 : le cas
est tout sauf théorique.

**`| null` n'est pas `?`.** Ici `null` veut dire « UEX ne publie pas cette capacité », ce qui n'est
ni zéro ni l'infini — **1 572 des 1 879 points de vente** sont dans ce cas. Confondre les deux
inverse la lecture : un `0` **connu** dit « saturé, ne prend plus rien ».

### Ce que le typecheck a fait remonter

Ce sont de vraies confusions, pas du bruit de compilateur.

**Deux concepts portaient le même nom.** Une `Jambe` du compagnon de voyage part d'un terminal
**nommé** et vit dans un parcours persisté ; une jambe de **chaîne** pointe un **index** et n'existe
que le temps d'un calcul. Elles sont désormais `Jambe` et `JambeChaine`. Même histoire pour `Trajet`
(le trajet multi-commodités) contre la route que `legFromRoute` reçoit réellement.

**Deux signatures promettaient plus que la fonction ne rend.** `sellableAt` annonçait un `PointVente`
complet alors qu'elle ne connaît ni le système, ni la planète, ni le statut UEX : elle rend un
`VenteAuTerminal`, plus petit et honnête. Idem pour le disque de la carte, qui se remplit en deux
temps — d'où `auMax` optionnel, non par tolérance mais parce que l'objet existe vraiment sans lui
un instant.

### Outillage : la propriété qu'on garde

**Node 24 exécute le TypeScript en effaçant les annotations, sans flag et sans dépendance.** Le job
`unit` de la CI n'installe donc **toujours rien** — le commentaire qui l'explique reste vrai au lieu
de devenir un mensonge.

Mais **effacer n'est pas vérifier** : `node --test` passerait au vert sur des annotations fausses.
D'où `npm run typecheck` et son **propre job `types`**, pour que « les types ne collent pas » ne se
confonde pas avec « un test échoue ».

La sévérité est un **escalier, et chaque marche est mesurée** (`tsconfig.json` le documente) :

| réglage | erreurs | nature |
|---|---|---|
| `strictNullChecks: true` | 152 | dont **125** d'un seul artefact d'inférence (`never[]`) |
| `strictNullChecks: false` | 27 | presque toutes le même motif **utile** : un paramètre d'options `= {}` |

On prend cette marche-ci — ces 27 se règlent en annotant, c'est-à-dire en faisant le travail.
`strictNullChecks` puis `noImplicitAny` viendront chacun dans leur PR, sinon on ne saurait plus
laquelle a cassé quoi.

## Vérification

```
npx tsc --noEmit      0 erreur
node --test           ℹ tests 475 · ℹ pass 475 · ℹ fail 0
npx playwright test   190 collectés · 188 passés · 2 ignorés (1,2 min)  SUR LE BUILD
vite build            index-CtJ4-dpO.js — hash inchangé
```

Aucun test n'a été modifié : `logic.test.mjs` ne change que sa ligne d'import. C'est voulu — les
tests sont le harnais, pas la variable d'ajustement.

## Ce qui n'est pas couvert

- **`strictNullChecks` et `noImplicitAny` restent éteints.** Chacun est une PR, avec son compte
  d'erreurs mesuré d'avance.
- **`app.js` reste du JavaScript** et n'entre pas dans le typecheck (`include` ne porte que
  `logic.ts` et `types.ts`). Conséquence à connaître : une annotation qui casserait `app.js` — par
  exemple `bySort(dir: 1 | -1)` face aux `let sortDir = -1` inférés `number` — ne rougirait pas
  encore. Elle a donc été évitée.
- **Les tests ne sont pas typecheckés.** Si on les y fait entrer un jour, ~8 fixtures échoueront sur
  `planet`/`outpost` : la réparation sera dans la fixture (`planet: ""`, comme le fait déjà
  `logic.test.mjs`), pas dans l'élargissement du type.
- **25 des 117 types ne sont référencés par personne** pour l'instant. Ils sont gardés : ils
  documentent le domaine et serviront aux vues.
- **`update-data.yml` nomme encore `logic.mjs`** dans sa ligne d'assemblage. C'est sans effet — ce
  workflow s'exécute depuis `main`, où le fichier existe toujours — et ce sera réglé par la PR qui
  bascule le déploiement sur `dist/`.

Refs #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)
