### PR TITLE
feat(theme): le HUD devient un thème, et une régression de peinture devient visible

### DIFF
--- a/docs/superpowers/specs/2026-08-15-refonte-v2-vite-react-adr.md
+++ b/docs/superpowers/specs/2026-08-15-refonte-v2-vite-react-adr.md
@@ -59,9 +59,24 @@ distincts**. « Fini » est déjà écrit, exécutable, et indépendant de l'imp
 >
 > Les **108 sélecteurs `#id`** sont exacts, mais deux d'entre eux sont des fragments d'URL et non
 > des sélecteurs : **106 réels**, dont **31 ne sont PAS dans `index.html`** — ils sont émis à
-> l'exécution par `app.js`. Et le contrat n'est chiffré qu'à moitié : la suite s'appuie aussi sur
-> ~109 sélecteurs de **classe** et 9 attributs `data-*` (`rail.pw.mjs` lit `dataset.view` sur
-> `.rail-nav .vbtn`). La structure de classes est un contrat au même titre que les `id`.
+> l'exécution par `app.js`.
+>
+> **La moitié classes du contrat était sous-estimée** (mesuré le 2026-08-15, PR des jetons) :
+> **147 sélecteurs de classe** et **16 attributs `data-*`**, non « ~109 et 9 ». Un développeur qui
+> migre une vue en se fiant à l'ancien chiffre croit avoir couvert le contrat en en ignorant 38.
+>
+> Trois pièges de cette moitié-là, qu'aucun compteur ne montre :
+>
+> - **29 classes ne sont écrites que par interpolation** (`.k-*` ×21, `.s-blue|green|orange|red`,
+>   `.sys-stanton|pyro|nyx`) : invisibles à toute analyse statique de contenu, donc **élaguées** si
+>   elles passent un jour dans une couche Tailwind. Ce sont exactement celles qui portent la couleur
+>   par système et par famille de commodité. Elles restent en CSS ordinaire, jamais en couche
+>   élaguable.
+> - **4 classes n'existent dans aucune règle** (`.acquired`, `.chain-leg-scu`, `.jm-sys`, `.schema`)
+>   et ressemblent à du code mort : ce sont des crochets de STRUCTURE. `.schema` est même un
+>   contrat **négatif** hérité de #30 — il se casserait en *réintroduisant* du style.
+> - **67 % des classes de `style.css` ne sont nommées par aucun test.** Le contrat e2e n'est pas la
+>   frontière de ce qu'il faut préserver : c'est un échantillon d'un tiers.
 
 > **Les `id` et les classes ne changent pas.** C'est ce qui transforme la suite e2e en **harnais de
 > migration** et en contrat anti-régression. Renommer les sélecteurs parce que la nouvelle pile
@@ -91,6 +106,28 @@ il se paie à chaque vue ajoutée et à chaque saisie effacée, pas une fois.
 > **Ces jetons deviennent le thème Tailwind d'abord, la première vue ensuite.** Dans l'autre ordre,
 > le caractère du site ne se perd pas par décision mais **par accumulation de défauts shadcn** —
 > chaque composant posé « provisoirement » en gris neutre, et personne pour dire quand ça a basculé.
+
+> **Amendement du 2026-08-15 (PR des jetons).** « 19 variables » était un décompte trompeur, et
+> l'étape telle qu'elle est décrite ici aurait donné l'illusion d'être faite. Mesuré :
+> **245 couleurs écrites en dur hors de `:root`**, pour 127 valeurs distinctes — dont **77 % ne
+> sont que des voiles de teintes déjà jetonnées**. Une des 19 était morte (`--panel-2`, zéro usage).
+>
+> Le fait qui change la méthode : **l'identité de ce site n'est pas « l'ambre `#ffb020` », c'est
+> « l'ambre à dix-huit opacités »** (`--acc-2` en compte 16, `--good` et `--bad` 10). Un jeton
+> hexadécimal ne peut produire aucune de ces déclinaisons. Chaque teinte porte donc **deux formes** :
+> le hex — qui est une **API publique**, `app.js` l'écrivant dans des attributs SVG `fill=` — et ses
+> **canaux** (`--acc-rgb: 255 176 32`), qui autorisent `rgb(var(--acc-rgb) / .14)`.
+>
+> Deux familles absentes du décompte d'origine ont été jetonnées avec : les **encres sur fond
+> accentué** (recopiées 9 fois, et ce sont des noirs *teintés de leur fond*), et le **palier de
+> titre** au-dessus de `--text` — 34 usages de `#fff`, qui portent tous les noms propres du HUD.
+> shadcn ne propose que `foreground` et `muted-foreground` : sans ce jeton, trois paliers s'écrasent
+> en deux, et c'est très exactement ce qui fait qu'une interface « ressemble à du shadcn ».
+>
+> Enfin, le §2 énonçait une intention sans mécanisme. Il en a un : `scripts/jetons.test.mjs`
+> (la source), `e2e/jetons.pw.mjs` (ce que le navigateur calcule, SVG compris) et
+> `scripts/coquille.test.mjs` (le budget de la coquille précachée). Sans eux, le site pouvait virer
+> au gris avec 190 tests au vert — les quatre seules assertions de couleur étant *relationnelles*.
 
 C'est la contrepartie exacte de l'adoption large : shadcn donne le comportement, le thème garde
 l'identité.

--- a/e2e/jetons.pw.mjs
+++ b/e2e/jetons.pw.mjs
@@ -1,0 +1,105 @@
+import { test, expect } from "@playwright/test";
+
+// Le pendant à l'exécution de scripts/jetons.test.mjs. Celui-là lit la SOURCE ; celui-ci lit ce que
+// le NAVIGATEUR calcule, sur le site RÉELLEMENT PRODUIT (la suite sert dist/). Les deux sont
+// nécessaires et ne disent pas la même chose : une source juste peut rendre une valeur fausse si une
+// règle la surcharge, si une couche CSS l'emporte, ou si un outil de build réécrit la déclaration.
+//
+// C'est ce dernier cas qui motive ce fichier : la refonte v2 va poser Tailwind par-dessus. Une
+// déclaration hors @layer bat TOUTE déclaration layered, quelle que soit la spécificité — donc le
+// thème peut être parfaitement écrit et parfaitement ignoré, sans erreur ni test rouge.
+
+// Le contrat, en valeurs calculées. Le navigateur normalise les hex en rgb().
+const JETONS = {
+  "--acc": "#ffb020",
+  "--acc-2": "#a970ff",
+  "--good": "#46e5a0",
+  "--warn": "#f5a742",
+  "--bad": "#ff5d5d",
+  "--text": "#e8ecf5",
+  "--muted": "#8a93a8",
+  "--stanton": "#38bdf8",
+  "--pyro": "#ff6a3d",
+  "--nyx": "#a970ff",
+};
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/index.html");
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+});
+
+test("Jetons : le HUD rend EXACTEMENT ses couleurs d'identité (#96)", async ({ page }) => {
+  const lus = await page.evaluate((noms) => {
+    const cs = getComputedStyle(document.documentElement);
+    return Object.fromEntries(noms.map((n) => [n, cs.getPropertyValue(n).trim().toLowerCase()]));
+  }, Object.keys(JETONS));
+  expect(lus).toEqual(JETONS);
+});
+
+test("Jetons : les canaux décrivent la même couleur que les hex (#96)", async ({ page }) => {
+  // Les deux formes doivent rester en phase : c'est le hex que le JavaScript écrit dans les SVG,
+  // et les canaux que les déclinaisons alpha consomment. Si elles divergent, la moitié du site
+  // prend une teinte et l'autre moitié une autre — sans qu'aucune erreur ne soit levée.
+  // Même liste que scripts/jetons.test.mjs : les teintes réellement DÉCLINÉES. `--text` sert
+  // d'encre pleine et n'apparaît à aucune opacité — lui donner un jumeau créerait un jeton mort.
+  const DECLINABLES = Object.keys(JETONS).filter((n) => n !== "--text");
+  const ecarts = await page.evaluate((noms) => {
+    const cs = getComputedStyle(document.documentElement);
+    const out = [];
+    for (const n of noms) {
+      const hex = cs.getPropertyValue(n).trim();
+      const canaux = cs.getPropertyValue(n + "-rgb").trim();
+      if (!canaux) { out.push(`${n}-rgb absent`); continue; }
+      const [r, g, b] = canaux.split(/\s+/).map(Number);
+      const attendu = "#" + [r, g, b].map((v) => v.toString(16).padStart(2, "0")).join("");
+      if (attendu.toLowerCase() !== hex.toLowerCase()) out.push(`${n}: ${hex} vs ${n}-rgb ${canaux}`);
+    }
+    return out;
+  }, DECLINABLES);
+  expect(ecarts, "hex et canaux ont divergé").toEqual([]);
+});
+
+test("Jetons : les trois polices du HUD sont bien celles qui s'appliquent (#96)", async ({ page }) => {
+  // Pas la variable — la police RÉELLEMENT appliquée à un élément. Une @font-face qui ne charge
+  // plus (nom haché par le build, CSP font-src) laisse la variable intacte et le rendu en repli.
+  const applique = await page.evaluate(() => ({
+    corps: getComputedStyle(document.body).fontFamily,
+    titre: getComputedStyle(document.querySelector(".brand-name") || document.querySelector("h1")).fontFamily,
+    mono: getComputedStyle(document.querySelector(".rn")).fontFamily,
+  }));
+  expect(applique.corps).toContain("Chakra Petch");
+  expect(applique.titre).toContain("Orbitron");
+  expect(applique.mono).toContain("JetBrains Mono");
+
+  // Et les fichiers de police répondent vraiment : `font-src 'self'` les autorise, encore faut-il
+  // que le build les ait émis sous le nom que le CSS demande.
+  const polices = await page.evaluate(() =>
+    performance.getEntriesByType("resource").filter((r) => r.name.endsWith(".woff2")).length
+  );
+  expect(polices, "aucune woff2 chargée — le HUD est rendu avec les polices de repli").toBeGreaterThan(0);
+});
+
+test("Jetons : la couleur par SYSTÈME arrive jusqu'au SVG de la carte (#96)", async ({ page }) => {
+  // app.js écrit littéralement « var(--stanton) » dans des attributs fill= et stroke= (SYS_TEINTE).
+  // Renommer ce jeton ne casse rien de visible en test : le fill devient simplement invalide et les
+  // planètes retombent en noir sur fond sombre — elles DISPARAISSENT. Aucun des 190 autres tests ne
+  // regarde une couleur de SVG.
+  await page.locator("#rows tr").first().locator(".journey-pick").click();
+  await page.click("#viewPlan");
+  await expect(page.locator("#journeyMap")).toBeVisible({ timeout: 8000 });
+
+  // On vise `.jm-sysnom`, le nom du système : app.js lui pose `fill="${teinte(sys.nom)}"`. Les
+  // premiers <circle> du groupe portent volontairement `fill="none"` — ce sont les anneaux
+  // orbitaux en pointillés, dont seule la couleur de TRAIT compte.
+  const teintes = await page.locator("#journeyMap .jm-sysnom").evaluateAll((els) =>
+    els.map((e) => getComputedStyle(e).fill)
+  );
+  expect(teintes.length, "aucun nom de système sur la carte").toBeGreaterThan(0);
+  for (const t of teintes) {
+    expect(t, "un nom de système est rendu sans teinte — le jeton n'arrive pas au SVG").not.toBe("none");
+    expect(t, "teinte retombée au noir : le jeton nommé dans le fill= n'existe plus").not.toBe("rgb(0, 0, 0)");
+  }
+  // Et ce sont bien LES teintes du thème, pas une couleur quelconque.
+  const attendues = ["rgb(56, 189, 248)", "rgb(255, 106, 61)", "rgb(169, 112, 255)", "rgb(255, 176, 32)"];
+  for (const t of teintes) expect(attendues).toContain(t);
+});

--- a/scripts/coquille.test.mjs
+++ b/scripts/coquille.test.mjs
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readdirSync, statSync, existsSync, readFileSync } from "node:fs";
+import { join, sep } from "node:path";
+
+// Le budget de la COQUILLE (refonte v2). Ce test ne juge pas la performance : il rend VISIBLE une
+// dérive que rien d'autre ne montre.
+//
+// Le service worker précache la coquille de façon ATOMIQUE, et le plugin de build ramasse
+// automatiquement tout nouveau fragment émis (vite.config.mjs). Autrement dit : chaque dépendance
+// ajoutée à la v2 — React, Radix, les composants shadcn copiés — grossit ce que chaque visiteur
+// télécharge d'un bloc à l'installation, sans qu'aucun test ne bronche et sans que personne n'ait
+// eu à décider.
+//
+// Un plafond qu'on relève sciemment dans une PR est une décision. Une coquille qui grossit sans que
+// personne ne le voie n'en est pas une. Ce test transforme la seconde en la première.
+
+const PLAFOND_OCTETS = 420_000;  // mesuré à 392 707 le 2026-08-15 (thème posé, avant Tailwind)
+const PLAFOND_ENTREES = 24;      // mesuré à 20
+
+const dist = join(process.cwd(), "dist");
+
+const fichiersDe = (d) =>
+  readdirSync(d, { withFileTypes: true }).flatMap((e) =>
+    e.isDirectory() ? fichiersDe(join(d, e.name)) : [join(d, e.name)]
+  );
+
+test("coquille : le poids précaché reste sous son plafond", { skip: !existsSync(dist) && "pas de build" }, () => {
+  // `data/` est exclu : ces fichiers ne sont PAS précachés (sw.js leur applique « réseau d'abord »),
+  // et leur taille suit UEX, pas nos décisions.
+  const fichiers = fichiersDe(dist).filter((f) => !f.includes("data" + sep));
+  const octets = fichiers.reduce((s, f) => s + statSync(f).size, 0);
+
+  assert.ok(
+    octets <= PLAFOND_OCTETS,
+    `la coquille pèse ${octets} o pour un plafond de ${PLAFOND_OCTETS}. Ce n'est pas forcément une ` +
+      `erreur — mais c'est une DÉCISION : relever le plafond dans la même PR, en disant ce qui l'a ` +
+      `fait grossir. Rappel des postes mesurés : polices 38 %, JS 35 %, CSS 17 %.`
+  );
+});
+
+test("coquille : le nombre d'entrées précachées reste sous son plafond", { skip: !existsSync(dist) && "pas de build" }, () => {
+  const sw = readFileSync(join(dist, "sw.js"), "utf8");
+  const m = sw.match(/const SHELL = (\[[^\]]*\]);/);
+  assert.ok(m, "ancre : dist/sw.js porte toujours sa liste de précache écrite par le build");
+  const n = JSON.parse(m[1]).length;
+  assert.ok(
+    n <= PLAFOND_ENTREES,
+    `${n} entrées précachées pour un plafond de ${PLAFOND_ENTREES}. Le découpage de code multiplie ` +
+      "les fragments, et addAll est ATOMIQUE : plus il y a d'entrées, plus une seule 404 coûte cher."
+  );
+});

--- a/scripts/jetons.test.mjs
+++ b/scripts/jetons.test.mjs
@@ -1,0 +1,158 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+// Le filet visuel de la refonte v2 (ADR-008 §2). Il répare un trou mesuré : sur 190 tests e2e, il
+// existe QUATRE assertions de couleur, et toutes sont RELATIONNELLES — « le fond du ▶ diffère de
+// celui du 📦 », « le bord d'achat diffère du bord de vente ». Aucune n'affirme qu'une couleur EST
+// quelque chose. Conséquence : le site pouvait virer entièrement au gris avec 190 tests au vert.
+//
+// Ces tests-ci lisent la SOURCE, comme scripts/csp.test.mjs et scripts/version.test.mjs : ils
+// tournent dans le job `unit` de la CI, qui n'installe rien, et échouent en nommant ce qui a bougé.
+// Le pendant à l'exécution (le jeton tel que le NAVIGATEUR le calcule) est dans e2e/jetons.pw.mjs.
+//
+// Pourquoi épingler des valeurs plutôt que de vérifier « il y a bien un thème » : parce que la
+// panne qu'on redoute n'est pas l'absence de thème, c'est sa DÉRIVE — un ambre recopié de travers,
+// un palier de gris écrasé, une teinte de système remplacée par un neutre shadcn.
+
+const lire = (f) => readFileSync(join(process.cwd(), f), "utf8");
+
+// ---------- Les jetons d'identité, à la valeur près ----------
+// Cette table EST le contrat. La modifier est une décision de design ; la modifier sans le vouloir
+// est le bug que ce fichier existe pour attraper.
+const IDENTITE = {
+  "--acc": "#ffb020",       // l'ambre du HUD, 94 usages — la couleur du site
+  "--acc-2": "#a970ff",     // le violet (chaîne, secondaire)
+  "--good": "#46e5a0",
+  "--warn": "#f5a742",
+  "--bad": "#ff5d5d",
+  "--bg": "#05060d",
+  "--text": "#e8ecf5",
+  "--muted": "#8a93a8",
+  "--panel-solid": "#0b0f1c",
+  // La couleur PAR SYSTÈME. Ces trois-là sont aussi une API publique consommée par le JavaScript :
+  // app.js écrit littéralement « var(--stanton) » dans des attributs SVG fill=/stroke=. Les
+  // renommer rendrait le fill invalide et les planètes disparaîtraient sur le fond sombre de la
+  // carte — sans qu'aucun test de rendu ne le voie.
+  "--stanton": "#38bdf8",
+  "--pyro": "#ff6a3d",
+  "--nyx": "#a970ff",
+};
+
+// Les trois familles typographiques : le caractère du HUD tient autant à elles qu'aux couleurs.
+const POLICES = {
+  "--font": "Chakra Petch",
+  "--display": "Orbitron",
+  "--mono": "JetBrains Mono",
+};
+
+const racine = () => {
+  const css = lire("style.css");
+  const bloc = css.match(/^:root\s*\{([\s\S]*?)^\}/m);
+  assert.ok(bloc, "ancre : style.css déclare toujours son bloc :root");
+  return bloc[1];
+};
+
+test("jetons : les couleurs d'identité sont exactement celles du HUD", () => {
+  const r = racine();
+  for (const [nom, valeur] of Object.entries(IDENTITE)) {
+    const m = r.match(new RegExp("^\\s*" + nom + ":\\s*([^;]+);", "m"));
+    assert.ok(m, `${nom} a disparu de :root — c'est un jeton d'identité, pas un détail`);
+    assert.equal(
+      m[1].trim().toLowerCase(),
+      valeur,
+      `${nom} a changé de valeur. Si c'est voulu, la table de scripts/jetons.test.mjs se met à jour ` +
+        `DANS LA MÊME PR — sinon c'est une dérive, et c'est précisément ce que ce test attrape.`
+    );
+  }
+});
+
+test("jetons : les trois familles typographiques tiennent", () => {
+  const r = racine();
+  for (const [nom, famille] of Object.entries(POLICES)) {
+    const m = r.match(new RegExp("^\\s*" + nom + ":\\s*([^;]+);", "m"));
+    assert.ok(m, `${nom} a disparu de :root`);
+    assert.ok(
+      m[1].includes(famille),
+      `${nom} ne commence plus par « ${famille} » — la police de repli a pris sa place`
+    );
+  }
+});
+
+test("jetons : chaque teinte déclinable a son jumeau en CANAUX", () => {
+  // Le fait central relevé sur style.css : l'identité n'est pas « l'ambre #ffb020 », c'est « l'ambre
+  // à dix-huit opacités ». --acc vit à 18 alphas distincts, --acc-2 à 16, --good et --bad à 10.
+  // Un jeton hexadécimal ne peut produire AUCUNE de ces déclinaisons : chacune redevient un rgba()
+  // recopié à la main, et le site se dépeuple par accumulation — le scénario exact que l'ADR §2
+  // dit vouloir empêcher.
+  //
+  // D'où le jumeau en canaux : `--acc-rgb: 255 176 32` autorise `rgb(var(--acc-rgb) / .14)`.
+  // Le hex, lui, RESTE — c'est app.js qui l'exige (voir plus haut, les attributs SVG).
+  const r = racine();
+  // La liste est celle des teintes RÉELLEMENT déclinées dans style.css, pas celle qu'on imagine :
+  // --text (#e8ecf5) n'apparaît à aucune opacité — il sert d'encre pleine et rien d'autre. Lui
+  // donner un jumeau en canaux créerait un jeton mort, que le test suivant rejetterait à raison.
+  const DECLINABLES = ["--acc", "--acc-2", "--good", "--warn", "--bad", "--muted", "--stanton", "--pyro", "--nyx"];
+  for (const nom of DECLINABLES) {
+    const hex = r.match(new RegExp("^\\s*" + nom + ":\\s*#([0-9a-fA-F]{6});", "m"));
+    assert.ok(hex, `${nom} doit rester un hex lisible`);
+    const canaux = r.match(new RegExp("^\\s*" + nom + "-rgb:\\s*([\\d\\s]+);", "m"));
+    assert.ok(canaux, `${nom}-rgb manque : sans lui, toute déclinaison alpha redevient un littéral`);
+
+    const [rr, gg, bb] = canaux[1].trim().split(/\s+/).map(Number);
+    const h = hex[1];
+    assert.deepEqual(
+      [rr, gg, bb],
+      [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)],
+      `${nom}-rgb ne décrit pas la même couleur que ${nom} — les deux formes doivent rester en phase`
+    );
+  }
+});
+
+test("jetons : les encres sur fond accentué existent, et sont teintées de leur fond", () => {
+  // Elles n'existaient nulle part comme jetons et étaient écrites en dur 10 fois. Un bouton qui
+  // perd son encre affiche du texte sombre par défaut, ou hérite d'un --text clair sur fond vert
+  // vif : illisible dans les deux cas. Et ce sont des noirs TEINTÉS de leur fond, pas un noir
+  // générique — c'est ce qui les rend propres.
+  const r = racine();
+  for (const nom of ["--acc-fg", "--acc-2-fg", "--good-fg"]) {
+    assert.ok(
+      new RegExp("^\\s*" + nom + ":\\s*#[0-9a-fA-F]{6};", "m").test(r),
+      `${nom} manque : l'encre sur fond accentué doit être un jeton, pas un littéral recopié`
+    );
+  }
+});
+
+test("jetons : aucun jeton mort dans :root", () => {
+  // --panel-2 était déclaré et utilisé ZÉRO fois, dans style.css comme dans app.js. Un jeton que
+  // personne ne lit est une fausse piste pour qui reprend le thème.
+  const css = lire("style.css");
+  const app = lire("app.js");
+  const r = racine();
+  const declares = [...r.matchAll(/^\s*(--[a-z0-9-]+):/gm)].map((m) => m[1]);
+  const morts = declares.filter((n) => {
+    const usages = (css.match(new RegExp("var\\(" + n + "[,)]", "g")) || []).length;
+    return usages === 0 && !app.includes(n);
+  });
+  assert.deepEqual(morts, [], `jeton(s) déclaré(s) et jamais lu(s) : ${morts.join(", ")}`);
+});
+
+test("jetons : le CSS produit n'embarque aucune URI data:", () => {
+  // Garde-fou permanent, et il vise une classe entière de régressions invisibles : la CSP du site
+  // n'a PAS `data:` dans img-src. Tout plugin qui fabrique une image en CSS — @tailwindcss/forms
+  // et ses chevrons de <select>, par exemple — verrait ses images bloquées EN PRODUCTION comme EN
+  // TEST, sans qu'aucune assertion ne tombe. 6 <select> et 8 cases à cocher sont concernés.
+  const dist = join(process.cwd(), "dist", "assets");
+  if (!existsSync(dist)) return; // pas de build sous la main : rien à vérifier, pas d'échec factice
+  for (const f of readdirSync(dist).filter((x) => x.endsWith(".css"))) {
+    const css = readFileSync(join(dist, f), "utf8");
+    const m = css.match(/url\(\s*["']?data:/);
+    assert.equal(
+      m,
+      null,
+      `${f} embarque une URI data: — la CSP du site (img-src sans data:) la bloquera en production, ` +
+        `et aucun test de rendu ne le verra. Retirer le plugin qui la produit.`
+    );
+  }
+});

--- a/style.css
+++ b/style.css
@@ -2,24 +2,62 @@
    Best Hauling — refonte « HUD / cockpit » (amber · violet)
    Feuille de style ciblant le markup émis par app.js.
    ============================================================ */
+/* Le THÈME du HUD (refonte v2, ADR-008 §2). Il est verrouillé par scripts/jetons.test.mjs et par
+   e2e/jetons.pw.mjs — le premier lit cette source, le second lit ce que le navigateur calcule.
+   Ce double verrou répare un trou mesuré : sur 190 tests e2e, les seules assertions de couleur
+   étaient RELATIONNELLES (« ce fond diffère de celui-là »). Aucune n'affirmait qu'une couleur EST
+   quelque chose, et le site pouvait donc virer entièrement au gris sans faire rougir personne.
+
+   CHAQUE TEINTE EXISTE SOUS DEUX FORMES, et ce n'est pas une redondance :
+
+     --acc: #ffb020        le hex, pour l'usage direct — et c'est une API PUBLIQUE : app.js écrit
+                           littéralement « var(--acc) » et « var(--stanton) » dans des attributs
+                           SVG fill= et stroke=. Renommer ces jetons rendrait le fill invalide et
+                           ferait DISPARAÎTRE les planètes de la carte, sur fond sombre, sans
+                           qu'aucun test ne le voie.
+     --acc-rgb: 255 176 32 les canaux, pour les déclinaisons : rgb(var(--acc-rgb) / .14).
+
+   Pourquoi les canaux : parce que l'identité de ce site n'est pas « l'ambre #ffb020 », c'est
+   « l'ambre à DIX-HUIT opacités ». Mesuré sur cette feuille : --acc vit à 18 alphas distincts,
+   --acc-2 à 16, --good et --bad à 10 — 245 couleurs étaient écrites en dur hors de ce bloc, dont
+   77 % n'étaient que des voiles de teintes déjà jetonnées. Un jeton hexadécimal ne peut produire
+   aucune d'elles : chacune redevient un littéral recopié, et le caractère du site se dissout par
+   accumulation. C'est très exactement ce que l'ADR §2 dit vouloir empêcher. */
 :root {
   --acc: #ffb020;          /* ambre HUD (accent principal) */
+  --acc-rgb: 255 176 32;
   --acc-2: #a970ff;        /* violet (chaîne / secondaire) */
+  --acc-2-rgb: 169 112 255;
   --good: #46e5a0;
+  --good-rgb: 70 229 160;
   --warn: #f5a742;
+  --warn-rgb: 245 167 66;
   --bad: #ff5d5d;
+  --bad-rgb: 255 93 93;
   --bg: #05060d;
   --text: #e8ecf5;
   --muted: #8a93a8;
+  --muted-rgb: 138 147 168;
   --line: rgba(130, 150, 210, 0.16);
   --line2: rgba(255, 176, 32, 0.30);
   --panel: linear-gradient(160deg, rgba(22, 28, 48, 0.72), rgba(11, 15, 28, 0.72));
-  --panel-2: #101a26;
   --panel-solid: #0b0f1c;
 
+  /* Les ENCRES sur fond accentué — ce que shadcn appellerait *-foreground. Elles étaient écrites en
+     dur dix fois et n'apparaissaient dans aucun inventaire des « 19 variables » : un bouton qui
+     perd son encre rend du texte sombre par défaut, ou hérite d'un --text clair sur fond vert vif.
+     Illisible dans les deux cas. Ce sont des noirs TEINTÉS de leur fond, jamais un noir générique :
+     c'est ce qui les rend propres. */
+  --acc-fg: #1a1000;       /* sur l'ambre */
+  --acc-2-fg: #0a0410;     /* sur le violet */
+  --good-fg: #04120a;      /* sur le vert — 7 usages, le plus fréquent */
+
   --stanton: #38bdf8;      /* Stanton en bleu */
+  --stanton-rgb: 56 189 248;
   --pyro: #ff6a3d;
+  --pyro-rgb: 255 106 61;
   --nyx: #a970ff;
+  --nyx-rgb: 169 112 255;
 
   --font: "Chakra Petch", "Segoe UI", system-ui, -apple-system, sans-serif;
   --display: "Orbitron", "Chakra Petch", sans-serif;
@@ -35,9 +73,9 @@ body {
   line-height: 1.42;
   font-family: var(--font);
   background:
-    radial-gradient(1100px 720px at 86% -12%, rgba(255, 176, 32, 0.10), transparent 60%),
-    radial-gradient(920px 620px at 2% 8%, rgba(169, 112, 255, 0.11), transparent 55%),
-    radial-gradient(760px 520px at 50% 122%, rgba(70, 229, 160, 0.06), transparent 60%),
+    radial-gradient(1100px 720px at 86% -12%, rgb(var(--acc-rgb) / 0.10), transparent 60%),
+    radial-gradient(920px 620px at 2% 8%, rgb(var(--acc-2-rgb) / 0.11), transparent 55%),
+    radial-gradient(760px 520px at 50% 122%, rgb(var(--good-rgb) / 0.06), transparent 60%),
     linear-gradient(180deg, #080a15, var(--bg));
   background-attachment: fixed;
   min-height: 100vh;
@@ -47,8 +85,8 @@ a:hover { color: #ffcf6b; text-decoration: underline; }
 
 ::-webkit-scrollbar { width: 10px; height: 10px; }
 ::-webkit-scrollbar-track { background: rgba(255, 255, 255, 0.02); }
-::-webkit-scrollbar-thumb { background: rgba(255, 176, 32, 0.25); border-radius: 2px; }
-::-webkit-scrollbar-thumb:hover { background: rgba(255, 176, 32, 0.45); }
+::-webkit-scrollbar-thumb { background: rgb(var(--acc-rgb) / 0.25); border-radius: 2px; }
+::-webkit-scrollbar-thumb:hover { background: rgb(var(--acc-rgb) / 0.45); }
 
 /* ---------- Décor : grille + scanlines ---------- */
 .grid-overlay {
@@ -70,7 +108,7 @@ a:hover { color: #ffcf6b; text-decoration: underline; }
 }
 .scanbar {
   position: fixed; left: 0; right: 0; height: 34vh; z-index: 59; pointer-events: none;
-  background: linear-gradient(to bottom, transparent, rgba(255, 176, 32, 0.05), transparent);
+  background: linear-gradient(to bottom, transparent, rgb(var(--acc-rgb) / 0.05), transparent);
   animation: hb-scan 7.5s linear infinite;
 }
 @keyframes hb-grid { 0% { background-position: 0 0; } 100% { background-position: 0 -46px; } }
@@ -103,7 +141,7 @@ a:hover { color: #ffcf6b; text-decoration: underline; }
 .logo { position: relative; width: 40px; height: 40px; flex-shrink: 0; display: grid; place-items: center; }
 .logo::before {
   content: ""; position: absolute; inset: 0; border: 1.5px solid var(--acc);
-  transform: rotate(45deg); box-shadow: 0 0 16px rgba(255, 176, 32, 0.45);
+  transform: rotate(45deg); box-shadow: 0 0 16px rgb(var(--acc-rgb) / 0.45);
 }
 .logo-diamond { width: 12px; height: 12px; background: var(--acc); transform: rotate(45deg); box-shadow: 0 0 10px var(--acc); }
 .brand-text { line-height: 1.05; }
@@ -124,10 +162,10 @@ a:hover { color: #ffcf6b; text-decoration: underline; }
 .rail-toggle {
   align-self: flex-end; width: 28px; height: 28px; margin: -6px 0 8px;
   display: grid; place-items: center; cursor: pointer;
-  color: var(--acc); background: rgba(255, 176, 32, 0.06);
+  color: var(--acc); background: rgb(var(--acc-rgb) / 0.06);
   border: 1px solid var(--line2); font-size: 13px; line-height: 1;
 }
-.rail-toggle:hover { background: rgba(255, 176, 32, 0.14); }
+.rail-toggle:hover { background: rgb(var(--acc-rgb) / 0.14); }
 
 .rail-nav { display: flex; flex-direction: column; gap: 6px; }
 .vbtn {
@@ -142,8 +180,8 @@ a:hover { color: #ffcf6b; text-decoration: underline; }
 .vbtn.active {
   color: #fff; font-weight: 700;
   border: 1px solid var(--line2); border-left: 2px solid var(--acc);
-  background: linear-gradient(90deg, rgba(255, 176, 32, 0.14), rgba(255, 176, 32, 0.02));
-  box-shadow: inset 0 0 22px rgba(255, 176, 32, 0.08);
+  background: linear-gradient(90deg, rgb(var(--acc-rgb) / 0.14), rgb(var(--acc-rgb) / 0.02));
+  box-shadow: inset 0 0 22px rgb(var(--acc-rgb) / 0.08);
 }
 .vbtn .rn { font-family: var(--mono); font-size: 10px; opacity: 0.7; }
 
@@ -170,11 +208,11 @@ a:hover { color: #ffcf6b; text-decoration: underline; }
   display: flex; align-items: center; justify-content: center; gap: 8px;
   margin-top: 6px; padding: 11px 14px;
   font-family: var(--font); font-size: 11.5px; font-weight: 700; letter-spacing: 1.5px;
-  color: var(--acc); background: rgba(255, 176, 32, 0.06);
+  color: var(--acc); background: rgb(var(--acc-rgb) / 0.06);
   border: 1px solid var(--line2); cursor: pointer;
 }
 .share-btn:hover { color: #fff; }
-.share-btn.copied { color: #04120a; background: var(--good); border-color: var(--good); }
+.share-btn.copied { color: var(--good-fg); background: var(--good); border-color: var(--good); }
 
 .rail-status { margin-top: auto; padding: 10px 12px; border: 1px solid var(--line); background: rgba(0, 0, 0, 0.25); }
 .rail-status-head { display: flex; align-items: center; gap: 7px; font-size: 9px; letter-spacing: 1.5px; color: var(--muted); text-transform: uppercase; }
@@ -201,7 +239,7 @@ header::after {
   background: linear-gradient(90deg, var(--acc), transparent); box-shadow: 0 0 12px var(--acc);
 }
 .kicker { font-size: 10px; letter-spacing: 4px; color: var(--acc); text-transform: uppercase; margin-bottom: 4px; animation: hb-flick 6s infinite; }
-h1 { margin: 0; font-family: var(--display); font-weight: 700; font-size: 26px; letter-spacing: 3px; color: #fff; text-shadow: 0 0 22px rgba(255, 176, 32, 0.28); }
+h1 { margin: 0; font-family: var(--display); font-weight: 700; font-size: 26px; letter-spacing: 3px; color: #fff; text-shadow: 0 0 22px rgb(var(--acc-rgb) / 0.28); }
 .sub { margin: 5px 0 0; font-size: 12.5px; letter-spacing: 0.5px; color: var(--muted); }
 
 /* Haut-droite : indicateur de fraîcheur des données (compact, couleur par âge). */
@@ -213,9 +251,9 @@ h1 { margin: 0; font-family: var(--display); font-weight: 700; font-size: 26px; 
   background: rgba(0, 0, 0, 0.25); color: var(--text); white-space: nowrap;
 }
 .freshness-ind .fi-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; background: currentColor; box-shadow: 0 0 8px currentColor; }
-.freshness-ind.f-good { color: var(--good); border-color: rgba(70, 229, 160, 0.35); }
+.freshness-ind.f-good { color: var(--good); border-color: rgb(var(--good-rgb) / 0.35); }
 .freshness-ind.f-ok   { color: var(--warn); border-color: #5a4a1c; }
-.freshness-ind.f-old  { color: var(--bad);  border-color: rgba(255, 93, 93, 0.4); }
+.freshness-ind.f-old  { color: var(--bad);  border-color: rgb(var(--bad-rgb) / 0.4); }
 
 /* Bas du rail : dernière mise à jour + compteurs (sous « Flux UEX »). */
 .rail-status-body { margin-top: 9px; display: flex; flex-direction: column; gap: 8px; font-family: var(--mono); }
@@ -267,7 +305,7 @@ input[type="number"], input[type="text"], select {
   padding: 10px 12px; border-radius: 2px; font-size: 14px; font-family: var(--font);
   min-width: 168px; transition: border-color 0.15s, box-shadow 0.15s;
 }
-input:focus, select:focus { outline: none; border-color: var(--acc); box-shadow: 0 0 0 1px var(--acc), 0 0 14px rgba(255, 176, 32, 0.22); }
+input:focus, select:focus { outline: none; border-color: var(--acc); box-shadow: 0 0 0 1px var(--acc), 0 0 14px rgb(var(--acc-rgb) / 0.22); }
 input:disabled, select:disabled { opacity: 0.4; cursor: not-allowed; }
 /* --muted plutôt qu'un gris plus sombre : ~6,3:1 sur le fond du champ, au-dessus du 4,5:1 exigé (AA). */
 input::placeholder { color: var(--muted); }
@@ -283,7 +321,7 @@ input::placeholder { color: var(--muted); }
 }
 .autocomplete li { display: flex; justify-content: space-between; gap: 12px; padding: 8px 13px; font-size: 14px; cursor: pointer; }
 .autocomplete li .scu { color: var(--muted); font-size: 12px; white-space: nowrap; font-family: var(--mono); }
-.autocomplete li.active { background: rgba(255, 176, 32, 0.14); color: #fff; }
+.autocomplete li.active { background: rgb(var(--acc-rgb) / 0.14); color: #fff; }
 .autocomplete li.active .scu { color: var(--acc); }
 
 /* ---------- Sélecteur de station groupé (ADR-003) ---------- */
@@ -319,9 +357,9 @@ input::placeholder { color: var(--muted); }
   border: 1px solid var(--line); overflow: hidden;
   background: linear-gradient(140deg, rgba(130, 150, 210, 0.16), rgba(11, 15, 28, 0.9));
 }
-.stn-vign.sys-stanton { background: linear-gradient(140deg, rgba(56, 189, 248, 0.28), rgba(11, 15, 28, 0.9)); }
-.stn-vign.sys-pyro { background: linear-gradient(140deg, rgba(255, 106, 61, 0.28), rgba(11, 15, 28, 0.9)); }
-.stn-vign.sys-nyx { background: linear-gradient(140deg, rgba(169, 112, 255, 0.28), rgba(11, 15, 28, 0.9)); }
+.stn-vign.sys-stanton { background: linear-gradient(140deg, rgb(var(--stanton-rgb) / 0.28), rgba(11, 15, 28, 0.9)); }
+.stn-vign.sys-pyro { background: linear-gradient(140deg, rgb(var(--pyro-rgb) / 0.28), rgba(11, 15, 28, 0.9)); }
+.stn-vign.sys-nyx { background: linear-gradient(140deg, rgb(var(--nyx-rgb) / 0.28), rgba(11, 15, 28, 0.9)); }
 .stn-shot-gen {
   position: absolute; inset: 0; display: grid; place-items: center; overflow: hidden;
   font-family: var(--mono); font-size: 8px; letter-spacing: 0.5px; color: var(--muted);
@@ -337,7 +375,7 @@ input::placeholder { color: var(--muted); }
 /* ---------- Carte vaisseau ---------- */
 .ship-card {
   position: relative; display: flex; align-items: stretch; margin: 16px 0 0; max-width: 520px; overflow: hidden;
-  border: 1px solid var(--line2); background: linear-gradient(90deg, rgba(255, 176, 32, 0.07), rgba(11, 15, 28, 0.75));
+  border: 1px solid var(--line2); background: linear-gradient(90deg, rgb(var(--acc-rgb) / 0.07), rgba(11, 15, 28, 0.75));
 }
 .ship-card::before, .ship-card::after { content: ""; position: absolute; width: 14px; height: 14px; border-color: var(--acc); }
 .ship-card::before { top: 0; left: 0; border-top: 2px solid; border-left: 2px solid; }
@@ -361,7 +399,7 @@ input::placeholder { color: var(--muted); }
    restait au bouton secondaire. */
 .journey-pick {
   display: inline-grid; place-items: center; flex-shrink: 0; width: 30px; height: 30px; padding: 0;
-  color: #1a1000; background: var(--acc); border: 1px solid var(--acc); border-radius: 3px;
+  color: var(--acc-fg); background: var(--acc); border: 1px solid var(--acc); border-radius: 3px;
   cursor: pointer; font-size: 14px; line-height: 1;
   transition: background 0.12s, border-color 0.12s;
 }
@@ -380,15 +418,15 @@ input::placeholder { color: var(--muted); }
 .journey-card {
   position: relative; margin: 0; flex: 1 1 320px; min-width: 0; max-width: 640px; padding: 12px 16px;
   border: 1px solid var(--acc-2); border-left: 2px solid var(--acc-2);
-  background: linear-gradient(90deg, rgba(169, 112, 255, 0.08), rgba(11, 15, 28, 0.75));
+  background: linear-gradient(90deg, rgb(var(--acc-2-rgb) / 0.08), rgba(11, 15, 28, 0.75));
 }
 /* Récap voyage : remplit l'espace sous le vaisseau avec des KPIs utiles. */
 .journey-recap {
   position: relative; padding: 12px 16px; border: 1px solid var(--line2); border-left: 2px solid var(--good);
-  background: linear-gradient(90deg, rgba(70, 229, 160, 0.06), rgba(11, 15, 28, 0.72));
+  background: linear-gradient(90deg, rgb(var(--good-rgb) / 0.06), rgba(11, 15, 28, 0.72));
 }
 .recap-head { font-size: 10px; letter-spacing: 2px; text-transform: uppercase; color: var(--good); font-weight: 700; margin-bottom: 8px; }
-.recap-profit { font-family: var(--mono); font-size: 22px; font-weight: 700; color: var(--good); text-shadow: 0 0 10px rgba(70, 229, 160, 0.22); line-height: 1; }
+.recap-profit { font-family: var(--mono); font-size: 22px; font-weight: 700; color: var(--good); text-shadow: 0 0 10px rgb(var(--good-rgb) / 0.22); line-height: 1; }
 .recap-profit span { font-size: 11px; color: var(--muted); font-weight: 400; letter-spacing: 1px; }
 .recap-kpis { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px 12px; margin-top: 12px; }
 .recap-kpi { display: flex; flex-direction: column; gap: 1px; }
@@ -406,7 +444,7 @@ input::placeholder { color: var(--muted); }
 .journey-path { display: flex; flex-wrap: wrap; align-items: center; gap: 6px 4px; }
 .jstep { background: rgba(255, 255, 255, 0.03); border: 1px solid var(--line); cursor: pointer; padding: 3px 4px; border-radius: 3px; }
 .jstep:hover { border-color: var(--acc); }
-.jstep.here { border-color: var(--acc); box-shadow: 0 0 0 1px var(--acc), 0 0 10px rgba(255, 176, 32, 0.25); }
+.jstep.here { border-color: var(--acc); box-shadow: 0 0 0 1px var(--acc), 0 0 10px rgb(var(--acc-rgb) / 0.25); }
 .jstep.here::after { content: " ⦿"; color: var(--acc); font-size: 10px; }
 .jsep { color: var(--acc-2); font-size: 13px; }
 .jstep-wrap { display: inline-flex; align-items: center; gap: 2px; }
@@ -416,7 +454,7 @@ input::placeholder { color: var(--muted); }
 /* Manifeste optimal par jambe (cargaison entre 2 arrêts). */
 .journey-legs { display: flex; flex-direction: column; gap: 6px; margin-top: 10px; }
 .jleg { border: 1px solid var(--line); border-left: 2px solid transparent; padding: 7px 10px; background: rgba(255, 255, 255, 0.015); }
-.jleg.current { border-left-color: var(--acc); background: rgba(255, 176, 32, 0.06); }
+.jleg.current { border-left-color: var(--acc); background: rgb(var(--acc-rgb) / 0.06); }
 .jleg-head { display: flex; align-items: center; gap: 8px; font-size: 11.5px; }
 .jleg-n { display: inline-grid; place-items: center; flex-shrink: 0; width: 16px; height: 16px; font-family: var(--mono); font-size: 9px; color: var(--acc-2); border: 1px solid var(--acc-2); border-radius: 50%; }
 .jleg-route { font-weight: 600; color: #fff; }
@@ -432,8 +470,8 @@ input::placeholder { color: var(--muted); }
 .journey-suggest { display: flex; flex-wrap: wrap; align-items: center; gap: 5px; margin-top: 7px; }
 .suggest-lbl { font-size: 10px; color: var(--muted); }
 .journey-suggest-empty { margin-top: 7px; font-size: 10.5px; line-height: 1.4; }
-.jstop-suggest { font-family: var(--font); font-size: 10.5px; color: var(--acc-2); background: rgba(169, 112, 255, 0.08); border: 1px solid rgba(169, 112, 255, 0.35); border-radius: 3px; padding: 4px 9px; cursor: pointer; }
-.jstop-suggest:hover { color: #fff; background: rgba(169, 112, 255, 0.22); }
+.jstop-suggest { font-family: var(--font); font-size: 10.5px; color: var(--acc-2); background: rgb(var(--acc-2-rgb) / 0.08); border: 1px solid rgb(var(--acc-2-rgb) / 0.35); border-radius: 3px; padding: 4px 9px; cursor: pointer; }
+.jstop-suggest:hover { color: #fff; background: rgb(var(--acc-2-rgb) / 0.22); }
 .jstop-suggest .muted { color: var(--muted); }
 /* Jambe dépliable + éditeur de manifeste inline. */
 .jleg-head { cursor: pointer; }
@@ -455,18 +493,18 @@ input.jman-qty { width: 56px; min-width: 0; padding: 3px 5px; text-align: right;
 .jman-empty { padding: 4px 0; }
 .jman-add { display: flex; gap: 6px; margin-top: 3px; align-items: center; }
 .jman-add-input { flex: 1; min-width: 0; padding: 5px 8px; background: rgba(8, 11, 20, 0.9); border: 1px solid var(--line2); color: var(--text); border-radius: 3px; font-family: var(--font); font-size: 11px; }
-.jman-add-btn { padding: 4px 12px; color: var(--acc-2); background: rgba(169, 112, 255, 0.1); border: 1px solid rgba(169, 112, 255, 0.4); border-radius: 3px; cursor: pointer; font-weight: 700; }
-.jman-add-btn:hover { color: #fff; background: rgba(169, 112, 255, 0.25); }
+.jman-add-btn { padding: 4px 12px; color: var(--acc-2); background: rgb(var(--acc-2-rgb) / 0.1); border: 1px solid rgb(var(--acc-2-rgb) / 0.4); border-radius: 3px; cursor: pointer; font-weight: 700; }
+.jman-add-btn:hover { color: #fff; background: rgb(var(--acc-2-rgb) / 0.25); }
 .jman-reset { font-size: 10px; color: var(--muted); background: transparent; border: 1px solid var(--line); border-radius: 3px; cursor: pointer; padding: 4px 8px; }
 .jman-reset:hover { color: var(--acc); border-color: var(--acc); }
 /* Boucles pertinentes pour le parcours (partent de l'arrivée courante) : remontées + surlignées. */
-#loops tr.from-here td { background: rgba(169, 112, 255, 0.07); }
+#loops tr.from-here td { background: rgb(var(--acc-2-rgb) / 0.07); }
 #loops tr.from-here td.loop-cell { box-shadow: inset 2px 0 0 var(--acc-2); }
 /* `align-self` parce que ce bouton vit dans deux en-têtes flex (.chain-head, .manifest-head) dont
    aucune ne pose align-items : sans lui il s'étire sur toute la hauteur de la ligne. Règle commune
    aux deux, volontairement : le bouton du manifeste est le MÊME que celui de la chaîne. */
-.chain-pick { align-self: center; font-family: var(--font); font-size: 11px; font-weight: 700; white-space: nowrap; color: var(--acc-2); background: rgba(169, 112, 255, 0.1); border: 1px solid rgba(169, 112, 255, 0.4); border-radius: 3px; padding: 5px 11px; cursor: pointer; }
-.chain-pick:hover { color: #fff; background: rgba(169, 112, 255, 0.25); }
+.chain-pick { align-self: center; font-family: var(--font); font-size: 11px; font-weight: 700; white-space: nowrap; color: var(--acc-2); background: rgb(var(--acc-2-rgb) / 0.1); border: 1px solid rgb(var(--acc-2-rgb) / 0.4); border-radius: 3px; padding: 5px 11px; cursor: pointer; }
+.chain-pick:hover { color: #fff; background: rgb(var(--acc-2-rgb) / 0.25); }
 
 /* ---------- La soute (ADR-002) ---------- */
 /* Bordure verte : ce panneau ne décrit pas un plan mais du fret RÉEL, déjà payé. La distinguer des
@@ -512,16 +550,16 @@ input.jman-qty { width: 56px; min-width: 0; padding: 3px 5px; text-align: right;
 .ec-profit.perte { color: var(--bad); }
 .hold-store {
   font-family: var(--mono); font-size: 10px; color: var(--acc-2);
-  background: none; border: 1px solid rgba(169, 112, 255, 0.4); border-radius: 2px;
+  background: none; border: 1px solid rgb(var(--acc-2-rgb) / 0.4); border-radius: 2px;
   padding: 2px 6px; cursor: pointer;
 }
-.hold-store:hover { color: #fff; background: rgba(169, 112, 255, 0.25); }
+.hold-store:hover { color: #fff; background: rgb(var(--acc-2-rgb) / 0.25); }
 .hold-sell-btn, .hold-sell-ok, .hold-sell-no {
   font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.5px; text-transform: uppercase;
-  color: var(--good); background: none; border: 1px solid rgba(70, 229, 160, 0.4);
+  color: var(--good); background: none; border: 1px solid rgb(var(--good-rgb) / 0.4);
   border-radius: 2px; padding: 2px 6px; cursor: pointer; white-space: nowrap;
 }
-.hold-sell-btn:hover, .hold-sell-ok:hover { color: #04120a; background: var(--good); }
+.hold-sell-btn:hover, .hold-sell-ok:hover { color: var(--good-fg); background: var(--good); }
 .hold-sell-no { color: var(--muted); border-color: var(--line); }
 .hold-sell.open { display: inline-flex; align-items: center; gap: 4px; }
 .hold-sell-qty {
@@ -539,10 +577,10 @@ input.jman-qty { width: 56px; min-width: 0; padding: 3px 5px; text-align: right;
 .hold-declare { display: flex; flex-direction: column; gap: 9px; }
 .hold-add-open {
   font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.4px; text-align: left;
-  color: var(--good); background: none; border: 1px dashed rgba(70, 229, 160, 0.4);
+  color: var(--good); background: none; border: 1px dashed rgb(var(--good-rgb) / 0.4);
   border-radius: 3px; padding: 6px 9px; cursor: pointer;
 }
-.hold-add-open:hover { color: #04120a; background: var(--good); border-style: solid; }
+.hold-add-open:hover { color: var(--good-fg); background: var(--good); border-style: solid; }
 .hold-add { display: flex; flex-wrap: wrap; align-items: center; gap: 5px; }
 .hold-add input { min-width: 0; padding: 3px 7px; font-size: 11.5px; }
 #holdAddName { flex: 1 1 130px; }
@@ -554,7 +592,7 @@ input.jman-qty { width: 56px; min-width: 0; padding: 3px 5px; text-align: right;
    profit affiché juste au-dessus. Teinte ambre, celle de tout ce qui demande une lecture avertie. */
 .hold-butin {
   font-family: var(--mono); font-size: 9px; letter-spacing: 0.6px; text-transform: uppercase;
-  color: var(--warn); border: 1px solid rgba(255, 176, 32, 0.35); border-radius: 2px;
+  color: var(--warn); border: 1px solid rgb(var(--acc-rgb) / 0.35); border-radius: 2px;
   padding: 0 4px; cursor: help;
 }
 /* « Je suis à » : sans voyage, c'est la seule façon de dire d'où l'on part — donc de vendre et de
@@ -575,18 +613,18 @@ input.jman-qty { width: 56px; min-width: 0; padding: 3px 5px; text-align: right;
    liste. Le retour « ✓ Copié » reste vert : c'est le même signal partout dans l'app. */
 .depots-card .hold-head .copy-btn {
   font-size: 11px; padding: 5px 11px;
-  color: var(--acc-2); background: rgba(169, 112, 255, 0.08); border-color: rgba(169, 112, 255, 0.4);
+  color: var(--acc-2); background: rgb(var(--acc-2-rgb) / 0.08); border-color: rgb(var(--acc-2-rgb) / 0.4);
 }
-.depots-card .hold-head .copy-btn:hover { color: #fff; background: rgba(169, 112, 255, 0.18); }
-.depots-card .hold-head .copy-btn.copied { color: #04120a; background: var(--good); border-color: var(--good); }
+.depots-card .hold-head .copy-btn:hover { color: #fff; background: rgb(var(--acc-2-rgb) / 0.18); }
+.depots-card .hold-head .copy-btn.copied { color: var(--good-fg); background: var(--good); border-color: var(--good); }
 .depot-stations { display: flex; flex-direction: column; gap: 11px; }
 .depot-lieu { display: flex; align-items: center; gap: 6px; font-size: 11.5px; margin-bottom: 5px; }
 .depot-take {
   margin-left: auto; font-family: var(--font); font-size: 10.5px; white-space: nowrap;
-  color: var(--acc-2); background: rgba(169, 112, 255, 0.1);
-  border: 1px solid rgba(169, 112, 255, 0.4); border-radius: 3px; padding: 2px 7px; cursor: pointer;
+  color: var(--acc-2); background: rgb(var(--acc-2-rgb) / 0.1);
+  border: 1px solid rgb(var(--acc-2-rgb) / 0.4); border-radius: 3px; padding: 2px 7px; cursor: pointer;
 }
-.depot-take:hover { background: rgba(169, 112, 255, 0.2); }
+.depot-take:hover { background: rgb(var(--acc-2-rgb) / 0.2); }
 .depot-take:focus-visible { outline: 2px solid var(--acc-2); outline-offset: 1px; }
 
 /* « ✓ chargé » sur la jambe : le moment où l'intention devient un fait. Vert quand c'est à bord. */
@@ -596,7 +634,7 @@ input.jman-qty { width: 56px; min-width: 0; padding: 3px 5px; text-align: right;
   border: 1px solid var(--line); border-radius: 2px; padding: 2px 6px; margin-left: 6px; cursor: pointer;
 }
 .jleg-load:hover { color: var(--good); border-color: var(--good); }
-.jleg-load.charge { color: #04120a; background: var(--good); border-color: var(--good); font-weight: 700; }
+.jleg-load.charge { color: var(--good-fg); background: var(--good); border-color: var(--good); font-weight: 700; }
 
 /* ---------- Carte 2D du parcours (ADR-001) ---------- */
 /* Bandeau pleine largeur sous le compagnon. Tout est dessiné par app.js : aucun asset, aucune
@@ -671,7 +709,7 @@ input.jman-qty { width: 56px; min-width: 0; padding: 3px 5px; text-align: right;
   background: var(--panel); border: 1px solid var(--line); border-left: 2px solid var(--acc-2);
 }
 .enroute-controls .field > label { color: var(--acc-2); }
-.enroute-controls input, .enroute-controls select { border-color: rgba(169, 112, 255, 0.35); }
+.enroute-controls input, .enroute-controls select { border-color: rgb(var(--acc-2-rgb) / 0.35); }
 .enroute-hint { flex-basis: 100%; margin: 2px 0 0; color: var(--muted); font-size: 12px; }
 .enroute-hint b { color: var(--acc-2); }
 
@@ -748,7 +786,7 @@ th.sorted-asc::after { content: " ▴"; color: var(--acc); }
 td { padding: 12px 14px; border-bottom: 1px solid var(--line); vertical-align: top; overflow-wrap: anywhere; }
 td.num { text-align: right; font-family: var(--mono); font-variant-numeric: tabular-nums; white-space: nowrap; }
 tbody tr { transition: background 0.1s; }
-tbody tr:hover { background: rgba(255, 176, 32, 0.05); }
+tbody tr:hover { background: rgb(var(--acc-rgb) / 0.05); }
 tbody tr:hover td { border-bottom-color: var(--line2); }
 /* Score centré verticalement + horizontalement */
 #routes td:nth-child(4), #enroute td:nth-child(4), #loops td:nth-child(4) { vertical-align: middle; }
@@ -786,22 +824,22 @@ tbody tr:hover td { border-bottom-color: var(--line2); }
   background: rgba(255, 255, 255, 0.04); border: 1px solid var(--line2); color: var(--muted);
   letter-spacing: 0.5px; text-transform: uppercase; vertical-align: middle; white-space: nowrap;
 }
-.sys.pyro { color: var(--pyro); border-color: rgba(255, 106, 61, 0.4); background: rgba(255, 106, 61, 0.09); }
-.sys.stanton { color: var(--stanton); border-color: rgba(56, 189, 248, 0.4); background: rgba(56, 189, 248, 0.09); }
-.sys.nyx { color: var(--nyx); border-color: rgba(169, 112, 255, 0.4); background: rgba(169, 112, 255, 0.09); }
+.sys.pyro { color: var(--pyro); border-color: rgb(var(--pyro-rgb) / 0.4); background: rgb(var(--pyro-rgb) / 0.09); }
+.sys.stanton { color: var(--stanton); border-color: rgb(var(--stanton-rgb) / 0.4); background: rgb(var(--stanton-rgb) / 0.09); }
+.sys.nyx { color: var(--nyx); border-color: rgb(var(--nyx-rgb) / 0.4); background: rgb(var(--nyx-rgb) / 0.09); }
 
-.outpost { display: inline-block; font-size: 9px; padding: 1px 6px; border-radius: 3px; background: rgba(245, 167, 66, 0.10); border: 1px solid #5a4a1c; color: var(--warn); white-space: nowrap; letter-spacing: 0.5px; text-transform: uppercase; vertical-align: middle; }
-.illegal { display: inline-block; font-size: 9px; padding: 1px 6px; border-radius: 3px; background: rgba(255, 93, 93, 0.10); border: 1px solid rgba(255,93,93,.4); color: var(--bad); white-space: nowrap; letter-spacing: 0.5px; text-transform: uppercase; vertical-align: middle; }
-.suspect { display: inline-block; font-size: 9px; padding: 1px 6px; border-radius: 3px; background: rgba(245, 167, 66, 0.10); border: 1px solid #5a4a1c; color: var(--warn); letter-spacing: 0.5px; text-transform: uppercase; vertical-align: middle; }
-.cross { display: inline-block; font-size: 9px; padding: 1px 6px; border-radius: 3px; color: var(--stanton); border: 1px solid rgba(56, 189, 248, 0.4); background: rgba(56, 189, 248, 0.1); letter-spacing: 0.5px; text-transform: uppercase; }
+.outpost { display: inline-block; font-size: 9px; padding: 1px 6px; border-radius: 3px; background: rgb(var(--warn-rgb) / 0.10); border: 1px solid #5a4a1c; color: var(--warn); white-space: nowrap; letter-spacing: 0.5px; text-transform: uppercase; vertical-align: middle; }
+.illegal { display: inline-block; font-size: 9px; padding: 1px 6px; border-radius: 3px; background: rgb(var(--bad-rgb) / 0.10); border: 1px solid rgb(var(--bad-rgb) / .4); color: var(--bad); white-space: nowrap; letter-spacing: 0.5px; text-transform: uppercase; vertical-align: middle; }
+.suspect { display: inline-block; font-size: 9px; padding: 1px 6px; border-radius: 3px; background: rgb(var(--warn-rgb) / 0.10); border: 1px solid #5a4a1c; color: var(--warn); letter-spacing: 0.5px; text-transform: uppercase; vertical-align: middle; }
+.cross { display: inline-block; font-size: 9px; padding: 1px 6px; border-radius: 3px; color: var(--stanton); border: 1px solid rgb(var(--stanton-rgb) / 0.4); background: rgb(var(--stanton-rgb) / 0.1); letter-spacing: 0.5px; text-transform: uppercase; }
 .stock { color: #5f7891; }
 
 /* Pastille de fraîcheur */
 .fresh { display: inline-block; font-size: 9.5px; padding: 1px 7px; border-radius: 3px; font-family: var(--mono); white-space: nowrap; vertical-align: middle; }
 .fresh::before { content: "⟳ "; }
-.fresh.f-good { color: var(--good); background: rgba(70, 229, 160, 0.10); border: 1px solid rgba(70, 229, 160, 0.4); }
-.fresh.f-ok { color: var(--warn); background: rgba(245, 167, 66, 0.10); border: 1px solid #5a4a1c; }
-.fresh.f-old { color: var(--bad); background: rgba(255, 93, 93, 0.10); border: 1px solid rgba(255, 93, 93, 0.4); }
+.fresh.f-good { color: var(--good); background: rgb(var(--good-rgb) / 0.10); border: 1px solid rgb(var(--good-rgb) / 0.4); }
+.fresh.f-ok { color: var(--warn); background: rgb(var(--warn-rgb) / 0.10); border: 1px solid #5a4a1c; }
+.fresh.f-old { color: var(--bad); background: rgb(var(--bad-rgb) / 0.10); border: 1px solid rgb(var(--bad-rgb) / 0.4); }
 /* Pastille de fraîcheur compacte (compagnon de voyage) : couleur = âge du relevé UEX. */
 .fresh-dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; vertical-align: middle; margin-right: 5px; background: currentColor; box-shadow: 0 0 5px currentColor; }
 .fresh-dot.f-good { color: var(--good); }
@@ -810,10 +848,10 @@ tbody tr:hover td { border-bottom-color: var(--line2); }
 
 /* Point de statut d'inventaire */
 .sdot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 4px; vertical-align: middle; }
-.sdot.s-red { background: var(--bad); box-shadow: 0 0 5px rgba(255, 93, 93, 0.6); }
-.sdot.s-orange { background: var(--warn); box-shadow: 0 0 5px rgba(245, 167, 66, 0.5); }
+.sdot.s-red { background: var(--bad); box-shadow: 0 0 5px rgb(var(--bad-rgb) / 0.6); }
+.sdot.s-orange { background: var(--warn); box-shadow: 0 0 5px rgb(var(--warn-rgb) / 0.5); }
 .sdot.s-blue { background: var(--stanton); }
-.sdot.s-green { background: var(--good); box-shadow: 0 0 5px rgba(70, 229, 160, 0.5); }
+.sdot.s-green { background: var(--good); box-shadow: 0 0 5px rgb(var(--good-rgb) / 0.5); }
 
 /* Valeur éditable (correction locale) */
 .editv { cursor: pointer; border-bottom: 1px dashed var(--line2); padding: 0 1px; transition: color 0.1s, border-color 0.1s; }
@@ -837,12 +875,12 @@ input.editv-input { width: 80px; min-width: 0; padding: 2px 5px; font-size: 12px
    (#29), et deux carrés pleins côte à côte annulent la hiérarchie. L'état actif se dit donc ici en
    CONTOUR — d'autant que le glyphe est un emoji, que `color` ne repeint pas : sur fond ambre plein,
    📦 devenait illisible. */
-.route-toggle.open { color: var(--acc); background: rgba(255, 176, 32, 0.14); border-color: var(--acc); }
+.route-toggle.open { color: var(--acc); background: rgb(var(--acc-rgb) / 0.14); border-color: var(--acc); }
 
 /* La rangée dépliée reste : elle porte désormais le seul chargement. Les règles du schéma
    géographique (.schema, .schema-leg, .schema-label, .schema-path, .schema-arrow) sont parties
    avec lui (#30). .snode survit : la vue Chaîne s'en sert encore pour ses terminaux. */
-.schema-row > td { background: rgba(255, 176, 32, 0.03); padding: 0; }
+.schema-row > td { background: rgb(var(--acc-rgb) / 0.03); padding: 0; }
 .snode { padding: 4px 10px; border-radius: 3px; font-size: 13px; background: rgba(255, 255, 255, 0.03); border: 1px solid var(--line); color: var(--muted); }
 .snode.term { color: #fff; border-color: var(--line2); font-weight: 600; }
 
@@ -854,25 +892,25 @@ input.editv-input { width: 80px; min-width: 0; padding: 2px 5px; font-size: 12px
    retombe en `width: auto`, qui REMPLIT le parent — une barre hors bornes se lisait « meilleure du
    tableau ». La borne vit dans scoreBarWidth ; ceci est la ceinture qui la double. */
 .scorebar i { display: block; height: 100%; width: 0; }
-.scorebar.s-good i { background: linear-gradient(90deg, rgba(70,229,160,.5), var(--good)); }
+.scorebar.s-good i { background: linear-gradient(90deg, rgb(var(--good-rgb) / .5), var(--good)); }
 .score-cell.has b, .scorebar.s-good + b { color: var(--good); }
 .scorebar.s-good ~ b { color: var(--good); }
-.scorebar.s-ok i { background: linear-gradient(90deg, rgba(255,176,32,.5), var(--acc)); }
+.scorebar.s-ok i { background: linear-gradient(90deg, rgb(var(--acc-rgb) / .5), var(--acc)); }
 .scorebar.s-ok ~ b { color: var(--acc); }
-.scorebar.s-low i { background: linear-gradient(90deg, rgba(255,93,93,.5), var(--bad)); }
+.scorebar.s-low i { background: linear-gradient(90deg, rgb(var(--bad-rgb) / .5), var(--bad)); }
 .scorebar.s-low ~ b { color: var(--bad); }
 
 .roi-badge { color: var(--acc); }
-.profit { color: var(--good); font-weight: 700; text-shadow: 0 0 10px rgba(70, 229, 160, 0.22); }
+.profit { color: var(--good); font-weight: 700; text-shadow: 0 0 10px rgb(var(--good-rgb) / 0.22); }
 /* Le pendant de `.profit` quand le chiffre est négatif : les frais d'autoload peuvent dépasser la
    marge, et c'est précisément le cas qu'il faut voir. Même graisse, couleur opposée — sans quoi une
    perte s'affichait dans le vert réservé aux gains. */
-.perte { color: var(--bad); font-weight: 700; text-shadow: 0 0 10px rgba(255, 93, 93, 0.22); }
-.recap-profit.perte { color: var(--bad); text-shadow: 0 0 10px rgba(255, 93, 93, 0.22); }
+.perte { color: var(--bad); font-weight: 700; text-shadow: 0 0 10px rgb(var(--bad-rgb) / 0.22); }
+.recap-profit.perte { color: var(--bad); text-shadow: 0 0 10px rgb(var(--bad-rgb) / 0.22); }
 .empty { color: var(--muted); padding: 44px; text-align: center; font-size: 14px; }
 
 /* ---------- Manifeste ---------- */
-.manifest { margin: 0 0 20px; border: 1px solid var(--line2); background: linear-gradient(90deg, rgba(255, 176, 32, 0.06), rgba(11, 15, 28, 0.7)); }
+.manifest { margin: 0 0 20px; border: 1px solid var(--line2); background: linear-gradient(90deg, rgb(var(--acc-rgb) / 0.06), rgba(11, 15, 28, 0.7)); }
 .manifest-hint { padding: 16px 20px; color: var(--muted); font-size: 13px; }
 .manifest-hint b { color: var(--acc); }
 .manifest-head { display: flex; flex-wrap: wrap; justify-content: space-between; gap: 10px 18px; padding: 14px 20px; border-bottom: 1px solid var(--line); }
@@ -886,18 +924,18 @@ input.editv-input { width: 80px; min-width: 0; padding: 2px 5px; font-size: 12px
 .manifest-tot b.profit { color: var(--good); }
 .copy-btn {
   align-self: center; font-family: var(--font); font-size: 12px; font-weight: 600; white-space: nowrap;
-  color: var(--acc); background: rgba(255, 176, 32, 0.06); border: 1px solid var(--line2); border-radius: 3px; padding: 7px 13px; cursor: pointer;
+  color: var(--acc); background: rgb(var(--acc-rgb) / 0.06); border: 1px solid var(--line2); border-radius: 3px; padding: 7px 13px; cursor: pointer;
   transition: color 0.12s, background 0.12s, border-color 0.12s;
 }
 .copy-btn:hover { color: #fff; }
-.copy-btn.copied { color: #04120a; background: var(--good); border-color: var(--good); }
+.copy-btn.copied { color: var(--good-fg); background: var(--good); border-color: var(--good); }
 .manifest-lines { display: flex; flex-direction: column; }
 .mline { display: grid; grid-template-columns: auto auto 1fr auto auto auto; align-items: center; gap: 4px 14px; padding: 10px 20px; border-bottom: 1px solid var(--line); }
 .mline:last-child { border-bottom: none; }
 .mqtywrap { display: flex; align-items: center; gap: 5px; }
 input.mqty-input { width: 66px; min-width: 0; padding: 4px 6px; text-align: right; background: rgba(8, 11, 20, 0.9); border: 1px solid var(--line2); color: var(--acc); border-radius: 3px; font-family: var(--mono); font-weight: 700; font-size: 13px; }
 /* SCU saisis au-delà du stock UEX dispo : autorisé mais signalé (vol de fret, relevé périmé…). */
-input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box-shadow: 0 0 0 1px rgba(245, 167, 66, 0.35); }
+input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box-shadow: 0 0 0 1px rgb(var(--warn-rgb) / 0.35); }
 .munit { font-family: var(--mono); font-size: 10px; color: var(--muted); }
 .mname { font-weight: 600; color: #fff; }
 .mstock { font-family: var(--mono); font-size: 11px; color: #5f7891; white-space: nowrap; }
@@ -907,8 +945,8 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 .manifest-suggest:not(:empty) { border-top: 1px dashed var(--line2); }
 .suggest-head { padding: 10px 20px 4px; color: var(--acc); font-size: 10px; text-transform: uppercase; letter-spacing: 1.5px; }
 .sline { display: grid; grid-template-columns: auto 1fr auto auto auto; align-items: center; gap: 12px; padding: 8px 20px; border-top: 1px solid var(--line); }
-.suggest-add { font-family: var(--font); font-size: 11px; font-weight: 600; white-space: nowrap; color: var(--good); background: rgba(70, 229, 160, 0.08); border: 1px solid rgba(70, 229, 160, 0.35); border-radius: 3px; padding: 5px 11px; cursor: pointer; transition: background 0.12s, color 0.12s; }
-.suggest-add:hover { color: #04120a; background: var(--good); border-color: var(--good); }
+.suggest-add { font-family: var(--font); font-size: 11px; font-weight: 600; white-space: nowrap; color: var(--good); background: rgb(var(--good-rgb) / 0.08); border: 1px solid rgb(var(--good-rgb) / 0.35); border-radius: 3px; padding: 5px 11px; cursor: pointer; transition: background 0.12s, color 0.12s; }
+.suggest-add:hover { color: var(--good-fg); background: var(--good); border-color: var(--good); }
 
 /* Mêmes suggestions de remplissage dans l'éditeur de jambe du compagnon qu'« En route ».
    Seul le padding de carte (20px) saute : l'éditeur `.jman` n'a pas de retrait horizontal. */
@@ -931,7 +969,7 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 .mname .mline-del:hover { color: var(--bad); border-color: var(--bad); }
 /* Ligne « carry-only » : chargée mais non vendable à cette destination (à écouler ailleurs). */
 .carry-tag { color: var(--warn); font-style: italic; }
-.mline.carry { background: rgba(245, 167, 66, 0.04); }
+.mline.carry { background: rgb(var(--warn-rgb) / 0.04); }
 .mprofit.muted { color: var(--muted); }
 /* Ajout libre d'une commodité au manifeste, et retour au chargement calculé. */
 .manifest-add { display: flex; gap: 8px; padding: 10px 20px; border-top: 1px solid var(--line); }
@@ -946,10 +984,10 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 
 /* ---------- Chaîne ---------- */
 .chain-wrap { margin: 0 0 20px; }
-.chain { border: 1px solid rgba(169, 112, 255, 0.35); background: linear-gradient(90deg, rgba(169, 112, 255, 0.06), rgba(11, 15, 28, 0.7)); }
+.chain { border: 1px solid rgb(var(--acc-2-rgb) / 0.35); background: linear-gradient(90deg, rgb(var(--acc-2-rgb) / 0.06), rgba(11, 15, 28, 0.7)); }
 .chain-head { display: flex; flex-wrap: wrap; justify-content: space-between; gap: 10px 18px; padding: 16px 20px; border-bottom: 1px solid var(--line); }
 .chain-path { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; }
-.chain-path .sys { border-color: rgba(169,112,255,.4); }
+.chain-path .sys { border-color: rgb(var(--acc-2-rgb) / .4); }
 .chain-arrow { color: var(--acc-2); font-size: 16px; margin: 0 2px; }
 .chain-tot { font-family: var(--mono); font-size: 12px; color: var(--muted); align-self: center; }
 .chain-tot b { color: var(--text); }
@@ -958,7 +996,7 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 .chain-leg { display: grid; grid-template-columns: auto 1fr auto; align-items: start; gap: 14px; padding: 12px 20px; border-bottom: 1px solid var(--line); }
 .chain-leg:last-child { border-bottom: none; }
 .chain-leg-main { min-width: 0; }
-.chain-step { width: 26px; height: 26px; flex-shrink: 0; display: grid; place-items: center; font-family: var(--mono); font-weight: 700; font-size: 12px; border-radius: 50%; color: #0a0410; background: var(--acc-2); }
+.chain-step { width: 26px; height: 26px; flex-shrink: 0; display: grid; place-items: center; font-family: var(--mono); font-weight: 700; font-size: 12px; border-radius: 50%; color: var(--acc-2-fg); background: var(--acc-2); }
 .chain-leg-profit { font-family: var(--mono); white-space: nowrap; color: var(--good); }
 /* Le chargement d'un saut, ligne par ligne (#56) : un saut transporte un manifeste, pas une
    commodité. Mêmes colonnes que le manifeste d'« En route » — commodité, volume, prix, ce que la
@@ -1002,8 +1040,8 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 .stn-tile.active {
   color: #fff; font-weight: 700;
   border: 1px solid var(--line2); border-left: 2px solid var(--acc);
-  background: linear-gradient(180deg, rgba(255, 176, 32, 0.14), rgba(255, 176, 32, 0.02));
-  box-shadow: inset 0 0 22px rgba(255, 176, 32, 0.08);
+  background: linear-gradient(180deg, rgb(var(--acc-rgb) / 0.14), rgb(var(--acc-rgb) / 0.02));
+  box-shadow: inset 0 0 22px rgb(var(--acc-rgb) / 0.08);
 }
 /* Le focus clavier ne doit PAS se confondre avec la sélection. */
 .stn-tile:focus-visible { outline: 2px solid var(--acc-2); outline-offset: 1px; }
@@ -1086,17 +1124,17 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 .station-count { font-family: var(--mono); font-size: 10px; letter-spacing: 1px; text-transform: uppercase; color: var(--muted); margin-left: 8px; }
 
 .corr-list-head { display: flex; align-items: center; gap: 12px; margin: 8px 0 10px; font-size: 11px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--acc); }
-.corr-item { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 9px 14px; border: 1px solid var(--line); border-left: 2px solid var(--acc); border-radius: 3px; margin-bottom: 6px; background: rgba(255, 176, 32, 0.03); }
+.corr-item { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 9px 14px; border: 1px solid var(--line); border-left: 2px solid var(--acc); border-radius: 3px; margin-bottom: 6px; background: rgb(var(--acc-rgb) / 0.03); }
 .corr-side { font-size: 10px; text-transform: uppercase; letter-spacing: 1px; color: var(--muted); border: 1px solid var(--line2); border-radius: 3px; padding: 1px 6px; margin-left: 4px; }
-.corr-del { flex-shrink: 0; width: 26px; height: 26px; border-radius: 4px; cursor: pointer; color: var(--bad); background: rgba(255, 93, 93, 0.08); border: 1px solid rgba(255, 93, 93, 0.35); font-size: 13px; line-height: 1; transition: color 0.12s, background 0.12s; }
+.corr-del { flex-shrink: 0; width: 26px; height: 26px; border-radius: 4px; cursor: pointer; color: var(--bad); background: rgb(var(--bad-rgb) / 0.08); border: 1px solid rgb(var(--bad-rgb) / 0.35); font-size: 13px; line-height: 1; transition: color 0.12s, background 0.12s; }
 .corr-del:hover { color: #fff; background: #6b1c1c; }
 /* Les deux boutons de fin de bandeau restent COLLÉS à droite : c'est le `margin-left: auto` du
    premier qui pousse la paire, jamais celui des deux — deux marges automatiques se partageraient
    l'espace libre et les écarteraient l'un de l'autre au milieu du bandeau. */
 .corr-list-head .copy-btn { margin-left: auto; font-size: 11px; padding: 5px 11px; }
 .corr-list-head .copy-btn + .reset-ov { margin-left: 0; }
-.reset-ov { margin-left: auto; color: var(--warn); border-color: #5a4a1c; background: rgba(245,167,66,.08); border-radius: 3px; padding: 5px 11px; cursor: pointer; font-family: var(--font); font-size: 11px; font-weight: 600; }
-.reset-ov:hover { color: #fff; border-color: var(--warn); background: rgba(245, 167, 66, 0.16); }
+.reset-ov { margin-left: auto; color: var(--warn); border-color: #5a4a1c; background: rgb(var(--warn-rgb) / .08); border-radius: 3px; padding: 5px 11px; cursor: pointer; font-family: var(--font); font-size: 11px; font-weight: 600; }
+.reset-ov:hover { color: #fff; border-color: var(--warn); background: rgb(var(--warn-rgb) / 0.16); }
 
 /* ---------- Frais d'autoload ---------- */
 /* Marqueur des lignes où l'interrupteur est actif mais où aucune des deux stations ne facture :
@@ -1106,14 +1144,14 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 .fee-chip { color: var(--muted); cursor: help; }
 /* Panneau de relevé du tarif d'une station (vue Corrections). Violet comme la chaîne : ce n'est
    pas une correction de prix UEX, c'est une mesure de manutention faite par le joueur. */
-.fee-panel { border: 1px solid var(--line); border-left: 2px solid var(--acc-2); border-radius: 3px; padding: 12px 14px; margin: 12px 0 18px; background: rgba(169, 112, 255, 0.04); }
+.fee-panel { border: 1px solid var(--line); border-left: 2px solid var(--acc-2); border-radius: 3px; padding: 12px 14px; margin: 12px 0 18px; background: rgb(var(--acc-2-rgb) / 0.04); }
 .fee-head { font-family: var(--display); font-size: 12px; letter-spacing: 1px; color: var(--acc-2); margin-bottom: 9px; }
 .fee-row { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; font-size: 13px; }
 .fee-row input[type="number"] { min-width: 108px; padding: 7px 9px; font-size: 13px; }
 .fee-note { margin-top: 9px; font-family: var(--mono); font-size: 12px; color: var(--muted); }
 .fee-note b { color: var(--text); }
 .fee-off { font-size: 13px; color: var(--muted); }
-.corr-item.autoload { border-left-color: var(--acc-2); background: rgba(169, 112, 255, 0.04); }
+.corr-item.autoload { border-left-color: var(--acc-2); background: rgb(var(--acc-2-rgb) / 0.04); }
 
 /* ---------- Toast ---------- */
 .toast {
@@ -1127,16 +1165,16 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 
 /* ---------- Couleurs par catégorie (fond de l'icône) ---------- */
 .k-metal, .k-alloy, .k-manmade { --k-bg: rgba(148,163,184,.14); --k-line: #47566b; }
-.k-mineral, .k-raw, .k-nonmetal { --k-bg: rgba(56,189,248,.13); --k-line: #1a5566; }
-.k-gas, .k-halogen { --k-bg: rgba(70,229,160,.13); --k-line: #1d5a52; }
-.k-fuel { --k-bg: rgba(255,176,32,.14); --k-line: #5a4a1c; }
-.k-agricultural, .k-food, .k-natural { --k-bg: rgba(70,229,160,.13); --k-line: #235a37; }
+.k-mineral, .k-raw, .k-nonmetal { --k-bg: rgb(var(--stanton-rgb) / .13); --k-line: #1a5566; }
+.k-gas, .k-halogen { --k-bg: rgb(var(--good-rgb) / .13); --k-line: #1d5a52; }
+.k-fuel { --k-bg: rgb(var(--acc-rgb) / .14); --k-line: #5a4a1c; }
+.k-agricultural, .k-food, .k-natural { --k-bg: rgb(var(--good-rgb) / .13); --k-line: #235a37; }
 .k-organic { --k-bg: rgba(163,230,53,.13); --k-line: #3f5a1c; }
-.k-drug { --k-bg: rgba(169,112,250,.14); --k-line: #43356b; }
+.k-drug { --k-bg: rgb(var(--acc-2-rgb) / .14); --k-line: #43356b; }
 .k-vice { --k-bg: rgba(244,114,182,.13); --k-line: #6b2a4d; }
-.k-medical { --k-bg: rgba(56,189,248,.14); --k-line: #1c3d6b; }
+.k-medical { --k-bg: rgb(var(--stanton-rgb) / .14); --k-line: #1c3d6b; }
 .k-scrap, .k-waste { --k-bg: rgba(120,113,108,.16); --k-line: #4a453f; }
-.k-explosive { --k-bg: rgba(255,93,93,.14); --k-line: #6b1c1c; }
+.k-explosive { --k-bg: rgb(var(--bad-rgb) / .14); --k-line: #6b1c1c; }
 .k-temporary, .k-other { --k-bg: rgba(125,148,171,.10); --k-line: var(--line2); }
 
 /* ===================== Vue « Commodités » ===================== */
@@ -1148,7 +1186,7 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
   border: 1px solid var(--line); border-left: 2px solid transparent; cursor: pointer;
 }
 .sort-modes button:hover { color: var(--text); }
-.sort-modes button.active { color: #fff; border: 1px solid var(--line2); border-left: 2px solid var(--acc); background: rgba(255, 176, 32, 0.10); }
+.sort-modes button.active { color: #fff; border: 1px solid var(--line2); border-left: 2px solid var(--acc); background: rgb(var(--acc-rgb) / 0.10); }
 
 /* Méga-board : grille dense de tuiles « code · marge », colorées en heatmap + tiroir détail dessous. */
 .commodities-wrap { margin: 18px 0 0; display: flex; flex-direction: column; gap: 14px; }
@@ -1164,10 +1202,10 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
   color: var(--text); background: rgba(255, 255, 255, 0.015);
   border: 1px solid var(--line); border-left: 2px solid transparent;
 }
-.comm-tile:hover { background: rgba(255, 176, 32, 0.08); border-color: var(--line2); }
-.comm-tile.selected { border: 1px solid var(--acc); border-left: 2px solid var(--acc); background: rgba(255, 176, 32, 0.14); box-shadow: inset 0 0 12px rgba(255, 176, 32, 0.12); }
+.comm-tile:hover { background: rgb(var(--acc-rgb) / 0.08); border-color: var(--line2); }
+.comm-tile.selected { border: 1px solid var(--acc); border-left: 2px solid var(--acc); background: rgb(var(--acc-rgb) / 0.14); box-shadow: inset 0 0 12px rgb(var(--acc-rgb) / 0.12); }
 .comm-tile.illegal { border-left: 2px solid var(--bad); } /* liseré rouge = commodité illégale */
-.comm-tile.carried { border-color: var(--acc-2); box-shadow: inset 0 0 0 1px var(--acc-2), 0 0 10px rgba(169, 112, 255, 0.15); } /* transportée dans le voyage */
+.comm-tile.carried { border-color: var(--acc-2); box-shadow: inset 0 0 0 1px var(--acc-2), 0 0 10px rgb(var(--acc-2-rgb) / 0.15); } /* transportée dans le voyage */
 /* Mode Butin : introuvable à l'achat (minage, salvage, wreck) -> contour pointillé. */
 .comm-tile.sell-only { border-style: dashed; }
 .tile-carried { color: var(--acc-2); font-size: 8px; margin-right: 3px; vertical-align: middle; }
@@ -1179,7 +1217,7 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 .t-warm .tile-val { color: var(--warn); }
 .t-mid .tile-val  { color: var(--stanton); }
 .t-low .tile-val  { color: #6d84a8; }
-.t-none .tile-val { color: rgba(138, 147, 168, 0.5); }
+.t-none .tile-val { color: rgb(var(--muted-rgb) / 0.5); }
 
 /* Tiroir de détail (points d'achat / vente) — sous le board, plein largeur. */
 .comm-detail { border: 1px solid var(--line2); border-top: 2px solid var(--acc); background: var(--panel); padding: 16px 20px; margin-top: 12px; }
@@ -1216,12 +1254,12 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
    nombre d'arrêts est presque toujours faux vers le bas. Un total ne s'affiche jamais sans dire
    s'il est garanti ou parié (ADR-007 §8). */
 .tour-plancher { padding: 8px 14px; font-size: 11.5px; line-height: 1.5; border-left: 2px solid; }
-.tour-plancher.parie { color: var(--warn); border-color: var(--warn); background: rgba(245, 167, 66, 0.06); }
-.tour-plancher.sur { color: var(--good); border-color: var(--good); background: rgba(70, 229, 160, 0.05); }
+.tour-plancher.parie { color: var(--warn); border-color: var(--warn); background: rgb(var(--warn-rgb) / 0.06); }
+.tour-plancher.sur { color: var(--good); border-color: var(--good); background: rgb(var(--good-rgb) / 0.05); }
 .tour-plancher b { color: inherit; }
 .tour-orphelines {
   padding: 8px 14px; font-size: 11.5px; line-height: 1.6; color: var(--text);
-  border-left: 2px solid var(--bad); background: rgba(255, 93, 93, 0.05);
+  border-left: 2px solid var(--bad); background: rgb(var(--bad-rgb) / 0.05);
 }
 .tour-orph { display: inline-block; margin: 0 8px 0 0; font-family: var(--mono); font-size: 11px; color: var(--bad); }
 .tour-arrets { display: flex; flex-direction: column; gap: 8px; }
@@ -1241,7 +1279,7 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 .tour-arret-meta { margin-top: 6px; font-size: 10.5px; color: var(--muted); }
 /* L'alternative « un arrêt de plus » : l'ordre reste lexicographique strict, c'est l'utilisateur
    qui arbitre — l'app ne sait pas s'il a le temps. */
-.tour-alt { padding: 10px 14px; border: 1px dashed var(--line2); background: rgba(255, 176, 32, 0.04); }
+.tour-alt { padding: 10px 14px; border: 1px dashed var(--line2); background: rgb(var(--acc-rgb) / 0.04); }
 .tour-alt-head { font-size: 12px; color: var(--text); }
 .tour-alt-head b { font-family: var(--mono); }
 .tour-alt-chemin { margin-top: 5px; font-size: 12px; }
@@ -1294,18 +1332,18 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 .plan-hold-name .cicon, .plan-cargo-item .cicon { width: 18px; height: 18px; font-size: 10px; }
 .plan-hold-name > span:not(.cicon) { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .plan-hold-bar { display: block; height: 6px; background: rgba(130, 150, 210, 0.14); }
-.plan-hold-bar i { display: block; height: 100%; background: var(--acc); box-shadow: 0 0 8px rgba(255, 176, 32, 0.35); }
+.plan-hold-bar i { display: block; height: 100%; background: var(--acc); box-shadow: 0 0 8px rgb(var(--acc-rgb) / 0.35); }
 .plan-hold-scu { font-family: var(--mono); font-size: 11px; color: var(--muted); }
 .plan-hold-scu b { color: var(--text); font-size: 12px; }
 .plan-hold-paid { font-family: var(--mono); font-size: 11px; color: var(--muted); }
 /* Le parcours : les mêmes étapes que le bandeau, mais INERTES — aucun bouton, aucun ✕. */
 .plan-path { display: flex; flex-wrap: wrap; align-items: center; gap: 6px 4px; margin-bottom: 12px; }
 .plan-step { padding: 3px 5px; border: 1px solid var(--line); background: rgba(255, 255, 255, 0.03); font-size: 12px; }
-.plan-step.here { border-color: var(--acc); box-shadow: 0 0 0 1px var(--acc), 0 0 10px rgba(255, 176, 32, 0.25); }
+.plan-step.here { border-color: var(--acc); box-shadow: 0 0 0 1px var(--acc), 0 0 10px rgb(var(--acc-rgb) / 0.25); }
 .plan-sep { color: var(--muted); }
 .plan-legs { display: flex; flex-direction: column; gap: 8px; }
 .plan-leg { padding: 8px 10px; border: 1px solid var(--line); border-left: 2px solid var(--line); }
-.plan-leg.current { border-left-color: var(--acc); background: rgba(255, 176, 32, 0.04); }
+.plan-leg.current { border-left-color: var(--acc); background: rgb(var(--acc-rgb) / 0.04); }
 .plan-leg.done { opacity: 0.62; }
 .plan-leg-head { display: flex; align-items: center; gap: 9px; font-size: 12px; }
 .plan-leg-n { font-family: var(--mono); font-size: 10px; color: var(--muted); }

--- a/style.css
+++ b/style.css
@@ -35,13 +35,30 @@
   --bad: #ff5d5d;
   --bad-rgb: 255 93 93;
   --bg: #05060d;
+
+  /* La hiérarchie de TEXTE a trois paliers, pas deux. Seuls deux étaient jetonnés, et le plus haut
+     — le blanc pur — était écrit en dur 34 fois : c'est lui qui porte tous les noms propres du HUD
+     (stations, commodités, vaisseaux, titres). shadcn ne propose que `foreground` et
+     `muted-foreground` : la pente naturelle est d'écraser trois paliers en deux, et c'est
+     exactement ce qui fait qu'une interface « ressemble à du shadcn ». D'où ce jeton, posé avant
+     la première vue. Ses canaux servent aussi aux voiles blancs des surfaces (12 usages à 1,5-4 %). */
+  --text-fort: #fff;
+  --text-fort-rgb: 255 255 255;
   --text: #e8ecf5;
   --muted: #8a93a8;
+  /* Le palier SOUS --muted : chiffres secondaires (stock, caisses), là où la donnée est présente
+     mais ne doit pas appeler l'œil. */
+  --muted-2: #5f7891;
   --muted-rgb: 138 147 168;
   --line: rgba(130, 150, 210, 0.16);
   --line2: rgba(255, 176, 32, 0.30);
   --panel: linear-gradient(160deg, rgba(22, 28, 48, 0.72), rgba(11, 15, 28, 0.72));
   --panel-solid: #0b0f1c;
+  --panel-solid-rgb: 11 15 28;
+  /* Le fond de la carte du parcours — la seule surface plus sombre que les panneaux, pour que les
+     étoiles et les orbites s'y détachent. app.js l'écrit aussi en dur dans le <rect> du SVG. */
+  --fond-carte: #080b14;
+  --fond-carte-rgb: 8 11 20;
 
   /* Les ENCRES sur fond accentué — ce que shadcn appellerait *-foreground. Elles étaient écrites en
      dur dix fois et n'apparaissaient dans aucun inventaire des « 19 variables » : un bouton qui
@@ -84,7 +101,7 @@ a { color: var(--acc); text-decoration: none; }
 a:hover { color: #ffcf6b; text-decoration: underline; }
 
 ::-webkit-scrollbar { width: 10px; height: 10px; }
-::-webkit-scrollbar-track { background: rgba(255, 255, 255, 0.02); }
+::-webkit-scrollbar-track { background: rgb(var(--text-fort-rgb) / 0.02); }
 ::-webkit-scrollbar-thumb { background: rgb(var(--acc-rgb) / 0.25); border-radius: 2px; }
 ::-webkit-scrollbar-thumb:hover { background: rgb(var(--acc-rgb) / 0.45); }
 
@@ -102,7 +119,7 @@ a:hover { color: #ffcf6b; text-decoration: underline; }
 .scanlines {
   position: fixed; inset: 0; z-index: 60; pointer-events: none;
   background: repeating-linear-gradient(to bottom,
-    rgba(255, 255, 255, 0.016) 0px, rgba(255, 255, 255, 0.016) 1px,
+    rgb(var(--text-fort-rgb) / 0.016) 0px, rgb(var(--text-fort-rgb) / 0.016) 1px,
     transparent 1px, transparent 3px);
   mix-blend-mode: overlay;
 }
@@ -145,7 +162,7 @@ a:hover { color: #ffcf6b; text-decoration: underline; }
 }
 .logo-diamond { width: 12px; height: 12px; background: var(--acc); transform: rotate(45deg); box-shadow: 0 0 10px var(--acc); }
 .brand-text { line-height: 1.05; }
-.brand-name { font-family: var(--display); font-weight: 800; font-size: 14px; letter-spacing: 2px; color: #fff; }
+.brand-name { font-family: var(--display); font-weight: 800; font-size: 14px; letter-spacing: 2px; color: var(--text-fort); }
 .brand-sub { font-size: 8.5px; letter-spacing: 2.5px; color: var(--muted); text-transform: uppercase; }
 /* La marque est un BOUTON depuis l'ADR-004 (§5 : elle ramène aux Trajets). Style natif remis à
    zéro, et .brand-name / .brand-sub repassent en bloc : le contenu d'un <button> doit être du
@@ -178,7 +195,7 @@ a:hover { color: #ffcf6b; text-decoration: underline; }
 }
 .vbtn:hover { color: var(--text); border-color: var(--line); }
 .vbtn.active {
-  color: #fff; font-weight: 700;
+  color: var(--text-fort); font-weight: 700;
   border: 1px solid var(--line2); border-left: 2px solid var(--acc);
   background: linear-gradient(90deg, rgb(var(--acc-rgb) / 0.14), rgb(var(--acc-rgb) / 0.02));
   box-shadow: inset 0 0 22px rgb(var(--acc-rgb) / 0.08);
@@ -211,7 +228,7 @@ a:hover { color: #ffcf6b; text-decoration: underline; }
   color: var(--acc); background: rgb(var(--acc-rgb) / 0.06);
   border: 1px solid var(--line2); cursor: pointer;
 }
-.share-btn:hover { color: #fff; }
+.share-btn:hover { color: var(--text-fort); }
 .share-btn.copied { color: var(--good-fg); background: var(--good); border-color: var(--good); }
 
 .rail-status { margin-top: auto; padding: 10px 12px; border: 1px solid var(--line); background: rgba(0, 0, 0, 0.25); }
@@ -239,7 +256,7 @@ header::after {
   background: linear-gradient(90deg, var(--acc), transparent); box-shadow: 0 0 12px var(--acc);
 }
 .kicker { font-size: 10px; letter-spacing: 4px; color: var(--acc); text-transform: uppercase; margin-bottom: 4px; animation: hb-flick 6s infinite; }
-h1 { margin: 0; font-family: var(--display); font-weight: 700; font-size: 26px; letter-spacing: 3px; color: #fff; text-shadow: 0 0 22px rgb(var(--acc-rgb) / 0.28); }
+h1 { margin: 0; font-family: var(--display); font-weight: 700; font-size: 26px; letter-spacing: 3px; color: var(--text-fort); text-shadow: 0 0 22px rgb(var(--acc-rgb) / 0.28); }
 .sub { margin: 5px 0 0; font-size: 12.5px; letter-spacing: 0.5px; color: var(--muted); }
 
 /* Haut-droite : indicateur de fraîcheur des données (compact, couleur par âge). */
@@ -301,7 +318,7 @@ main { padding: 22px 30px 40px; }
 
 input[type="checkbox"] { accent-color: var(--acc); width: 15px; height: 15px; cursor: pointer; }
 input[type="number"], input[type="text"], select {
-  background: rgba(8, 11, 20, 0.9); border: 1px solid var(--line2); color: var(--text);
+  background: rgb(var(--fond-carte-rgb) / 0.9); border: 1px solid var(--line2); color: var(--text);
   padding: 10px 12px; border-radius: 2px; font-size: 14px; font-family: var(--font);
   min-width: 168px; transition: border-color 0.15s, box-shadow 0.15s;
 }
@@ -321,7 +338,7 @@ input::placeholder { color: var(--muted); }
 }
 .autocomplete li { display: flex; justify-content: space-between; gap: 12px; padding: 8px 13px; font-size: 14px; cursor: pointer; }
 .autocomplete li .scu { color: var(--muted); font-size: 12px; white-space: nowrap; font-family: var(--mono); }
-.autocomplete li.active { background: rgb(var(--acc-rgb) / 0.14); color: #fff; }
+.autocomplete li.active { background: rgb(var(--acc-rgb) / 0.14); color: var(--text-fort); }
 .autocomplete li.active .scu { color: var(--acc); }
 
 /* ---------- Sélecteur de station groupé (ADR-003) ---------- */
@@ -355,11 +372,11 @@ input::placeholder { color: var(--muted); }
 .stn-vign {
   position: relative; flex: 0 0 auto; width: 34px; height: 24px; border-radius: 2px;
   border: 1px solid var(--line); overflow: hidden;
-  background: linear-gradient(140deg, rgba(130, 150, 210, 0.16), rgba(11, 15, 28, 0.9));
+  background: linear-gradient(140deg, rgba(130, 150, 210, 0.16), rgb(var(--panel-solid-rgb) / 0.9));
 }
-.stn-vign.sys-stanton { background: linear-gradient(140deg, rgb(var(--stanton-rgb) / 0.28), rgba(11, 15, 28, 0.9)); }
-.stn-vign.sys-pyro { background: linear-gradient(140deg, rgb(var(--pyro-rgb) / 0.28), rgba(11, 15, 28, 0.9)); }
-.stn-vign.sys-nyx { background: linear-gradient(140deg, rgb(var(--nyx-rgb) / 0.28), rgba(11, 15, 28, 0.9)); }
+.stn-vign.sys-stanton { background: linear-gradient(140deg, rgb(var(--stanton-rgb) / 0.28), rgb(var(--panel-solid-rgb) / 0.9)); }
+.stn-vign.sys-pyro { background: linear-gradient(140deg, rgb(var(--pyro-rgb) / 0.28), rgb(var(--panel-solid-rgb) / 0.9)); }
+.stn-vign.sys-nyx { background: linear-gradient(140deg, rgb(var(--nyx-rgb) / 0.28), rgb(var(--panel-solid-rgb) / 0.9)); }
 .stn-shot-gen {
   position: absolute; inset: 0; display: grid; place-items: center; overflow: hidden;
   font-family: var(--mono); font-size: 8px; letter-spacing: 0.5px; color: var(--muted);
@@ -375,7 +392,7 @@ input::placeholder { color: var(--muted); }
 /* ---------- Carte vaisseau ---------- */
 .ship-card {
   position: relative; display: flex; align-items: stretch; margin: 16px 0 0; max-width: 520px; overflow: hidden;
-  border: 1px solid var(--line2); background: linear-gradient(90deg, rgb(var(--acc-rgb) / 0.07), rgba(11, 15, 28, 0.75));
+  border: 1px solid var(--line2); background: linear-gradient(90deg, rgb(var(--acc-rgb) / 0.07), rgb(var(--panel-solid-rgb) / 0.75));
 }
 .ship-card::before, .ship-card::after { content: ""; position: absolute; width: 14px; height: 14px; border-color: var(--acc); }
 .ship-card::before { top: 0; left: 0; border-top: 2px solid; border-left: 2px solid; }
@@ -387,7 +404,7 @@ input::placeholder { color: var(--muted); }
 .ship-img { width: 100%; height: 100%; object-fit: cover; display: block; filter: saturate(1.05) contrast(1.05); }
 .ship-card-info { display: flex; flex-direction: column; justify-content: center; gap: 5px; padding: 14px 20px; }
 .ship-card-label { font-size: 9.5px; letter-spacing: 2px; text-transform: uppercase; color: var(--acc); }
-.ship-card-name { font-family: var(--display); font-size: 18px; font-weight: 600; letter-spacing: 1px; color: #fff; }
+.ship-card-name { font-family: var(--display); font-size: 18px; font-weight: 600; letter-spacing: 1px; color: var(--text-fort); }
 .ship-card-scu { font-size: 13px; color: var(--muted); font-family: var(--mono); }
 .ship-card-scu b { color: var(--good); }
 
@@ -418,12 +435,12 @@ input::placeholder { color: var(--muted); }
 .journey-card {
   position: relative; margin: 0; flex: 1 1 320px; min-width: 0; max-width: 640px; padding: 12px 16px;
   border: 1px solid var(--acc-2); border-left: 2px solid var(--acc-2);
-  background: linear-gradient(90deg, rgb(var(--acc-2-rgb) / 0.08), rgba(11, 15, 28, 0.75));
+  background: linear-gradient(90deg, rgb(var(--acc-2-rgb) / 0.08), rgb(var(--panel-solid-rgb) / 0.75));
 }
 /* Récap voyage : remplit l'espace sous le vaisseau avec des KPIs utiles. */
 .journey-recap {
   position: relative; padding: 12px 16px; border: 1px solid var(--line2); border-left: 2px solid var(--good);
-  background: linear-gradient(90deg, rgb(var(--good-rgb) / 0.06), rgba(11, 15, 28, 0.72));
+  background: linear-gradient(90deg, rgb(var(--good-rgb) / 0.06), rgb(var(--panel-solid-rgb) / 0.72));
 }
 .recap-head { font-size: 10px; letter-spacing: 2px; text-transform: uppercase; color: var(--good); font-weight: 700; margin-bottom: 8px; }
 .recap-profit { font-family: var(--mono); font-size: 22px; font-weight: 700; color: var(--good); text-shadow: 0 0 10px rgb(var(--good-rgb) / 0.22); line-height: 1; }
@@ -442,7 +459,7 @@ input::placeholder { color: var(--muted); }
 .journey-clear { background: transparent; border: 1px solid var(--line); color: var(--muted); cursor: pointer; border-radius: 3px; padding: 0 6px; line-height: 1.5; }
 .journey-clear:hover { color: var(--bad); border-color: var(--bad); }
 .journey-path { display: flex; flex-wrap: wrap; align-items: center; gap: 6px 4px; }
-.jstep { background: rgba(255, 255, 255, 0.03); border: 1px solid var(--line); cursor: pointer; padding: 3px 4px; border-radius: 3px; }
+.jstep { background: rgb(var(--text-fort-rgb) / 0.03); border: 1px solid var(--line); cursor: pointer; padding: 3px 4px; border-radius: 3px; }
 .jstep:hover { border-color: var(--acc); }
 .jstep.here { border-color: var(--acc); box-shadow: 0 0 0 1px var(--acc), 0 0 10px rgb(var(--acc-rgb) / 0.25); }
 .jstep.here::after { content: " ⦿"; color: var(--acc); font-size: 10px; }
@@ -453,11 +470,11 @@ input::placeholder { color: var(--muted); }
 .journey-meta { margin-top: 9px; font-family: var(--mono); font-size: 11px; color: var(--muted); }
 /* Manifeste optimal par jambe (cargaison entre 2 arrêts). */
 .journey-legs { display: flex; flex-direction: column; gap: 6px; margin-top: 10px; }
-.jleg { border: 1px solid var(--line); border-left: 2px solid transparent; padding: 7px 10px; background: rgba(255, 255, 255, 0.015); }
+.jleg { border: 1px solid var(--line); border-left: 2px solid transparent; padding: 7px 10px; background: rgb(var(--text-fort-rgb) / 0.015); }
 .jleg.current { border-left-color: var(--acc); background: rgb(var(--acc-rgb) / 0.06); }
 .jleg-head { display: flex; align-items: center; gap: 8px; font-size: 11.5px; }
 .jleg-n { display: inline-grid; place-items: center; flex-shrink: 0; width: 16px; height: 16px; font-family: var(--mono); font-size: 9px; color: var(--acc-2); border: 1px solid var(--acc-2); border-radius: 50%; }
-.jleg-route { font-weight: 600; color: #fff; }
+.jleg-route { font-weight: 600; color: var(--text-fort); }
 .jleg-profit { margin-left: auto; font-family: var(--mono); }
 .jleg-cargo { margin-top: 5px; display: flex; flex-wrap: wrap; gap: 4px 12px; font-size: 10.5px; color: var(--muted); }
 .jcargo-item { display: inline-flex; align-items: center; gap: 5px; }
@@ -466,12 +483,12 @@ input::placeholder { color: var(--muted); }
 /* Ajout d'arrêt : champ libre + suggestions rentables. */
 .journey-add { display: flex; gap: 6px; margin-top: 10px; }
 .journey-hint { margin: 6px 0 0; font-size: 10.5px; line-height: 1.45; color: var(--muted); }
-#journeyAddStop, #journeyStart { flex: 1; min-width: 0; padding: 6px 9px; background: rgba(8, 11, 20, 0.9); border: 1px solid var(--line2); color: var(--text); border-radius: 3px; font-family: var(--font); font-size: 11px; }
+#journeyAddStop, #journeyStart { flex: 1; min-width: 0; padding: 6px 9px; background: rgb(var(--fond-carte-rgb) / 0.9); border: 1px solid var(--line2); color: var(--text); border-radius: 3px; font-family: var(--font); font-size: 11px; }
 .journey-suggest { display: flex; flex-wrap: wrap; align-items: center; gap: 5px; margin-top: 7px; }
 .suggest-lbl { font-size: 10px; color: var(--muted); }
 .journey-suggest-empty { margin-top: 7px; font-size: 10.5px; line-height: 1.4; }
 .jstop-suggest { font-family: var(--font); font-size: 10.5px; color: var(--acc-2); background: rgb(var(--acc-2-rgb) / 0.08); border: 1px solid rgb(var(--acc-2-rgb) / 0.35); border-radius: 3px; padding: 4px 9px; cursor: pointer; }
-.jstop-suggest:hover { color: #fff; background: rgb(var(--acc-2-rgb) / 0.22); }
+.jstop-suggest:hover { color: var(--text-fort); background: rgb(var(--acc-2-rgb) / 0.22); }
 .jstop-suggest .muted { color: var(--muted); }
 /* Jambe dépliable + éditeur de manifeste inline. */
 .jleg-head { cursor: pointer; }
@@ -485,16 +502,16 @@ input::placeholder { color: var(--muted); }
 .jleg.expanded { border-left-color: var(--acc-2); }
 .jman { margin-top: 8px; border-top: 1px dashed var(--line); padding-top: 8px; display: flex; flex-direction: column; gap: 5px; }
 .jman-line { display: grid; grid-template-columns: auto auto 1fr auto auto; align-items: center; gap: 6px 10px; font-size: 11px; }
-input.jman-qty { width: 56px; min-width: 0; padding: 3px 5px; text-align: right; background: rgba(8, 11, 20, 0.9); border: 1px solid var(--line2); color: var(--acc); border-radius: 3px; font-family: var(--mono); font-weight: 700; font-size: 12px; }
-.jman-name { color: #fff; }
+input.jman-qty { width: 56px; min-width: 0; padding: 3px 5px; text-align: right; background: rgb(var(--fond-carte-rgb) / 0.9); border: 1px solid var(--line2); color: var(--acc); border-radius: 3px; font-family: var(--mono); font-weight: 700; font-size: 12px; }
+.jman-name { color: var(--text-fort); }
 .jman-profit { font-family: var(--mono); text-align: right; color: var(--good); }
 .jman-del { background: transparent; border: 1px solid var(--line); color: var(--muted); border-radius: 3px; cursor: pointer; padding: 0 5px; font-size: 10px; }
 .jman-del:hover { color: var(--bad); border-color: var(--bad); }
 .jman-empty { padding: 4px 0; }
 .jman-add { display: flex; gap: 6px; margin-top: 3px; align-items: center; }
-.jman-add-input { flex: 1; min-width: 0; padding: 5px 8px; background: rgba(8, 11, 20, 0.9); border: 1px solid var(--line2); color: var(--text); border-radius: 3px; font-family: var(--font); font-size: 11px; }
+.jman-add-input { flex: 1; min-width: 0; padding: 5px 8px; background: rgb(var(--fond-carte-rgb) / 0.9); border: 1px solid var(--line2); color: var(--text); border-radius: 3px; font-family: var(--font); font-size: 11px; }
 .jman-add-btn { padding: 4px 12px; color: var(--acc-2); background: rgb(var(--acc-2-rgb) / 0.1); border: 1px solid rgb(var(--acc-2-rgb) / 0.4); border-radius: 3px; cursor: pointer; font-weight: 700; }
-.jman-add-btn:hover { color: #fff; background: rgb(var(--acc-2-rgb) / 0.25); }
+.jman-add-btn:hover { color: var(--text-fort); background: rgb(var(--acc-2-rgb) / 0.25); }
 .jman-reset { font-size: 10px; color: var(--muted); background: transparent; border: 1px solid var(--line); border-radius: 3px; cursor: pointer; padding: 4px 8px; }
 .jman-reset:hover { color: var(--acc); border-color: var(--acc); }
 /* Boucles pertinentes pour le parcours (partent de l'arrivée courante) : remontées + surlignées. */
@@ -504,7 +521,7 @@ input.jman-qty { width: 56px; min-width: 0; padding: 3px 5px; text-align: right;
    aucune ne pose align-items : sans lui il s'étire sur toute la hauteur de la ligne. Règle commune
    aux deux, volontairement : le bouton du manifeste est le MÊME que celui de la chaîne. */
 .chain-pick { align-self: center; font-family: var(--font); font-size: 11px; font-weight: 700; white-space: nowrap; color: var(--acc-2); background: rgb(var(--acc-2-rgb) / 0.1); border: 1px solid rgb(var(--acc-2-rgb) / 0.4); border-radius: 3px; padding: 5px 11px; cursor: pointer; }
-.chain-pick:hover { color: #fff; background: rgb(var(--acc-2-rgb) / 0.25); }
+.chain-pick:hover { color: var(--text-fort); background: rgb(var(--acc-2-rgb) / 0.25); }
 
 /* ---------- La soute (ADR-002) ---------- */
 /* Bordure verte : ce panneau ne décrit pas un plan mais du fret RÉEL, déjà payé. La distinguer des
@@ -535,7 +552,7 @@ input.jman-qty { width: 56px; min-width: 0; padding: 3px 5px; text-align: right;
   font-family: var(--mono); font-size: 10px; letter-spacing: 0.5px; color: var(--acc);
   background: none; border: none; padding: 0; margin-left: 8px; cursor: pointer;
 }
-.hold-offload:hover { color: #fff; }
+.hold-offload:hover { color: var(--text-fort); }
 .hold-ecouler { margin-top: 10px; padding-top: 9px; border-top: 1px solid var(--line); display: flex; flex-direction: column; gap: 8px; }
 .ec-head { font-family: var(--mono); font-size: 9.5px; letter-spacing: 1.4px; text-transform: uppercase; color: var(--muted); }
 .ec-dest { display: grid; grid-template-columns: 1fr auto; gap: 2px 8px; font-size: 12px; }
@@ -553,7 +570,7 @@ input.jman-qty { width: 56px; min-width: 0; padding: 3px 5px; text-align: right;
   background: none; border: 1px solid rgb(var(--acc-2-rgb) / 0.4); border-radius: 2px;
   padding: 2px 6px; cursor: pointer;
 }
-.hold-store:hover { color: #fff; background: rgb(var(--acc-2-rgb) / 0.25); }
+.hold-store:hover { color: var(--text-fort); background: rgb(var(--acc-2-rgb) / 0.25); }
 .hold-sell-btn, .hold-sell-ok, .hold-sell-no {
   font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.5px; text-transform: uppercase;
   color: var(--good); background: none; border: 1px solid rgb(var(--good-rgb) / 0.4);
@@ -615,7 +632,7 @@ input.jman-qty { width: 56px; min-width: 0; padding: 3px 5px; text-align: right;
   font-size: 11px; padding: 5px 11px;
   color: var(--acc-2); background: rgb(var(--acc-2-rgb) / 0.08); border-color: rgb(var(--acc-2-rgb) / 0.4);
 }
-.depots-card .hold-head .copy-btn:hover { color: #fff; background: rgb(var(--acc-2-rgb) / 0.18); }
+.depots-card .hold-head .copy-btn:hover { color: var(--text-fort); background: rgb(var(--acc-2-rgb) / 0.18); }
 .depots-card .hold-head .copy-btn.copied { color: var(--good-fg); background: var(--good); border-color: var(--good); }
 .depot-stations { display: flex; flex-direction: column; gap: 11px; }
 .depot-lieu { display: flex; align-items: center; gap: 6px; font-size: 11.5px; margin-bottom: 5px; }
@@ -670,7 +687,7 @@ input.jman-qty { width: 56px; min-width: 0; padding: 3px 5px; text-align: right;
 /* Un SAUT ne se dessine pas comme un vol intra-système : c'est le moment que le texte rend le
    plus mal (« ⚡ inter-système » dans une cellule) et que la carte rend le mieux. */
 .jm-saut { fill: none; stroke: var(--acc-2); stroke-opacity: 0.9; stroke-width: 1.6; stroke-dasharray: 1 4; stroke-linecap: round; }
-.jm-saut-noeud { fill: #080b14; stroke: var(--acc-2); stroke-opacity: 0.5; }
+.jm-saut-noeud { fill: var(--fond-carte); stroke: var(--acc-2); stroke-opacity: 0.5; }
 .jm-saut-glyphe { font-size: 8px; text-anchor: middle; fill: var(--acc-2); }
 
 /* Tout le décor est inerte au pointeur : sans ça, l'étiquette d'une planète posée sur une escale
@@ -680,19 +697,19 @@ input.jman-qty { width: 56px; min-width: 0; padding: 3px 5px; text-align: right;
 .jm-arret, .jm-arret > * { pointer-events: auto; }
 .jm-arret { cursor: pointer; }
 .jm-cible { fill: transparent; }            /* cible de clic confortable, invisible */
-.jm-point { fill: #080b14; stroke: var(--acc); stroke-width: 1.4; }
+.jm-point { fill: var(--fond-carte); stroke: var(--acc); stroke-width: 1.4; }
 /* Liseré sombre sous le texte : les corps d'un même secteur se serrent (à Pyro, six longitudes
    entre 42° et 152°), et un nom d'escale devait rester lisible par-dessus leurs libellés. Le
    décor passe donc dessous, ce qui est le bon ordre de priorité. */
 .jm-nom {
   fill: var(--text); font-size: 8.5px; font-family: var(--font); font-weight: 600;
-  paint-order: stroke; stroke: #080b14; stroke-width: 2.6px; stroke-linejoin: round;
+  paint-order: stroke; stroke: var(--fond-carte); stroke-width: 2.6px; stroke-linejoin: round;
 }
 .jm-arret.fait .jm-point { stroke-opacity: 0.4; }
 .jm-arret.fait .jm-nom { fill: var(--muted); }
 .jm-arret.ici .jm-point { fill: var(--acc); }
-.jm-arret:hover .jm-point { stroke: #fff; }
-.jm-arret:hover .jm-nom { fill: #fff; }
+.jm-arret:hover .jm-point { stroke: var(--text-fort); }
+.jm-arret:hover .jm-nom { fill: var(--text-fort); }
 .jm-arret:focus-visible { outline: none; }
 .jm-arret:focus-visible .jm-cible { stroke: var(--acc-2); stroke-width: 1.5; }
 
@@ -738,10 +755,10 @@ thead th {
   background: #0a0e18; border-bottom: 2px solid var(--line2);
   cursor: pointer; user-select: none; white-space: nowrap;
 }
-thead th:hover { color: #fff; background: #0d1420; }
+thead th:hover { color: var(--text-fort); background: #0d1420; }
 /* En-têtes triables : focusables au clavier, donc focus visible (même accent que les champs). */
 thead th[data-sort]:focus-visible, thead th[data-sort-loop]:focus-visible {
-  outline: none; color: #fff; background: #0d1420; box-shadow: inset 0 0 0 1px var(--acc);
+  outline: none; color: var(--text-fort); background: #0d1420; box-shadow: inset 0 0 0 1px var(--acc);
 }
 /* Les colonnes de chiffres se serrent la ceinture. Elles sont en `nowrap` (td.num plus bas) : un
    `6 315 398` ne se coupe pas, et c'est LUI qui forçait la table à rester plus large que son cadre
@@ -791,7 +808,7 @@ tbody tr:hover td { border-bottom-color: var(--line2); }
 /* Score centré verticalement + horizontalement */
 #routes td:nth-child(4), #enroute td:nth-child(4), #loops td:nth-child(4) { vertical-align: middle; }
 
-.loc > div:first-child { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; font-weight: 600; color: #fff; }
+.loc > div:first-child { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; font-weight: 600; color: var(--text-fort); }
 .loc-sub { color: var(--muted); font-size: 10.5px; margin-top: 5px; font-family: var(--mono); display: flex; flex-wrap: wrap; align-items: center; gap: 6px; }
 
 /* Icône de catégorie (emoji) */
@@ -801,8 +818,8 @@ tbody tr:hover td { border-bottom-color: var(--line2); }
 /* Badges alignés SOUS le titre (système, avant-poste, illégal, à vérifier, saut inter-système). */
 .loc-badges { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; margin-top: 5px; }
 .loc-badges:empty { display: none; }
-.cname { font-family: var(--font); font-weight: 600; color: #fff; }
-.term-name { font-weight: 600; color: #fff; }
+.cname { font-family: var(--font); font-weight: 600; color: var(--text-fort); }
+.term-name { font-weight: 600; color: var(--text-fort); }
 /* Pastille de fraîcheur : dernière ligne, en bas de la cellule. */
 .loc-fresh { margin-top: 6px; }
 /* Boucles : Départ / ⇄ inter-système / Arrivée empilés sur 3 lignes, mêmes styles pour les
@@ -815,13 +832,13 @@ tbody tr:hover td { border-bottom-color: var(--line2); }
 .loop-mid { display: flex; align-items: center; gap: 8px; }
 .cicon {
   flex-shrink: 0; width: 30px; height: 30px; display: grid; place-items: center; font-size: 15px;
-  border-radius: 4px; border: 1px solid var(--k-line, var(--line2)); background: var(--k-bg, rgba(255,255,255,.04));
+  border-radius: 4px; border: 1px solid var(--k-line, var(--line2)); background: var(--k-bg, rgb(var(--text-fort-rgb) / .04));
 }
 
 /* Badges système */
 .sys {
   display: inline-block; font-size: 9px; padding: 1px 6px; border-radius: 3px;
-  background: rgba(255, 255, 255, 0.04); border: 1px solid var(--line2); color: var(--muted);
+  background: rgb(var(--text-fort-rgb) / 0.04); border: 1px solid var(--line2); color: var(--muted);
   letter-spacing: 0.5px; text-transform: uppercase; vertical-align: middle; white-space: nowrap;
 }
 .sys.pyro { color: var(--pyro); border-color: rgb(var(--pyro-rgb) / 0.4); background: rgb(var(--pyro-rgb) / 0.09); }
@@ -832,7 +849,7 @@ tbody tr:hover td { border-bottom-color: var(--line2); }
 .illegal { display: inline-block; font-size: 9px; padding: 1px 6px; border-radius: 3px; background: rgb(var(--bad-rgb) / 0.10); border: 1px solid rgb(var(--bad-rgb) / .4); color: var(--bad); white-space: nowrap; letter-spacing: 0.5px; text-transform: uppercase; vertical-align: middle; }
 .suspect { display: inline-block; font-size: 9px; padding: 1px 6px; border-radius: 3px; background: rgb(var(--warn-rgb) / 0.10); border: 1px solid #5a4a1c; color: var(--warn); letter-spacing: 0.5px; text-transform: uppercase; vertical-align: middle; }
 .cross { display: inline-block; font-size: 9px; padding: 1px 6px; border-radius: 3px; color: var(--stanton); border: 1px solid rgb(var(--stanton-rgb) / 0.4); background: rgb(var(--stanton-rgb) / 0.1); letter-spacing: 0.5px; text-transform: uppercase; }
-.stock { color: #5f7891; }
+.stock { color: var(--muted-2); }
 
 /* Pastille de fraîcheur */
 .fresh { display: inline-block; font-size: 9.5px; padding: 1px 7px; border-radius: 3px; font-family: var(--mono); white-space: nowrap; vertical-align: middle; }
@@ -862,12 +879,12 @@ tbody tr:hover td { border-bottom-color: var(--line2); }
 .editv.nc { color: var(--muted); font-style: italic; }
 .editv.nc:hover, .editv.nc:focus { color: var(--acc); }
 .ovmark { font-size: 9px; margin-left: 2px; vertical-align: super; }
-input.editv-input { width: 80px; min-width: 0; padding: 2px 5px; font-size: 12px; font-family: var(--mono); text-align: right; background: rgba(8, 11, 20, 0.95); border: 1px solid var(--acc); color: var(--text); border-radius: 3px; }
+input.editv-input { width: 80px; min-width: 0; padding: 2px 5px; font-size: 12px; font-family: var(--mono); text-align: right; background: rgb(var(--fond-carte-rgb) / 0.95); border: 1px solid var(--acc); color: var(--text); border-radius: 3px; }
 
 /* Bouton « voir le chargement » — lignes multi-commodité uniquement (#30). */
 .route-toggle {
   flex-shrink: 0; width: 24px; height: 24px; padding: 0; display: grid; place-items: center; font-size: 12px; line-height: 1;
-  background: rgba(255, 255, 255, 0.04); border: 1px solid var(--line2); border-radius: 4px; cursor: pointer; color: var(--muted);
+  background: rgb(var(--text-fort-rgb) / 0.04); border: 1px solid var(--line2); border-radius: 4px; cursor: pointer; color: var(--muted);
   transition: color 0.12s, border-color 0.12s, background 0.12s;
 }
 .route-toggle:hover { color: var(--acc); border-color: var(--acc); }
@@ -881,13 +898,13 @@ input.editv-input { width: 80px; min-width: 0; padding: 2px 5px; font-size: 12px
    géographique (.schema, .schema-leg, .schema-label, .schema-path, .schema-arrow) sont parties
    avec lui (#30). .snode survit : la vue Chaîne s'en sert encore pour ses terminaux. */
 .schema-row > td { background: rgb(var(--acc-rgb) / 0.03); padding: 0; }
-.snode { padding: 4px 10px; border-radius: 3px; font-size: 13px; background: rgba(255, 255, 255, 0.03); border: 1px solid var(--line); color: var(--muted); }
-.snode.term { color: #fff; border-color: var(--line2); font-weight: 600; }
+.snode { padding: 4px 10px; border-radius: 3px; font-size: 13px; background: rgb(var(--text-fort-rgb) / 0.03); border: 1px solid var(--line); color: var(--muted); }
+.snode.term { color: var(--text-fort); border-color: var(--line2); font-weight: 600; }
 
 /* Score */
 .score-cell { display: flex; align-items: center; justify-content: center; gap: 8px; white-space: nowrap; }
 .score-cell b { font-family: var(--mono); font-variant-numeric: tabular-nums; min-width: 22px; text-align: right; }
-.scorebar { display: inline-block; width: 46px; height: 6px; flex-shrink: 0; background: rgba(255, 255, 255, 0.07); border: 1px solid var(--line); overflow: hidden; }
+.scorebar { display: inline-block; width: 46px; height: 6px; flex-shrink: 0; background: rgb(var(--text-fort-rgb) / 0.07); border: 1px solid var(--line); overflow: hidden; }
 /* `width: 0` par défaut : sans elle, une largeur invalide (négative, NaN) est ignorée et l'élément
    retombe en `width: auto`, qui REMPLIT le parent — une barre hors bornes se lisait « meilleure du
    tableau ». La borne vit dans scoreBarWidth ; ceci est la ceinture qui la double. */
@@ -910,11 +927,11 @@ input.editv-input { width: 80px; min-width: 0; padding: 2px 5px; font-size: 12px
 .empty { color: var(--muted); padding: 44px; text-align: center; font-size: 14px; }
 
 /* ---------- Manifeste ---------- */
-.manifest { margin: 0 0 20px; border: 1px solid var(--line2); background: linear-gradient(90deg, rgb(var(--acc-rgb) / 0.06), rgba(11, 15, 28, 0.7)); }
+.manifest { margin: 0 0 20px; border: 1px solid var(--line2); background: linear-gradient(90deg, rgb(var(--acc-rgb) / 0.06), rgb(var(--panel-solid-rgb) / 0.7)); }
 .manifest-hint { padding: 16px 20px; color: var(--muted); font-size: 13px; }
 .manifest-hint b { color: var(--acc); }
 .manifest-head { display: flex; flex-wrap: wrap; justify-content: space-between; gap: 10px 18px; padding: 14px 20px; border-bottom: 1px solid var(--line); }
-.manifest-title { font-family: var(--display); font-weight: 600; font-size: 15px; letter-spacing: 0.5px; color: #fff; }
+.manifest-title { font-family: var(--display); font-weight: 600; font-size: 15px; letter-spacing: 0.5px; color: var(--text-fort); }
 .manifest-tot { font-family: var(--mono); font-size: 12px; color: var(--muted); align-self: center; }
 /* Refus d'engager le chargement : la phrase remplace le bouton, à sa place et sur sa ligne.
    La marge haute de .journey-hint est faite pour un paragraphe de la carte Voyage, pas pour un
@@ -927,21 +944,21 @@ input.editv-input { width: 80px; min-width: 0; padding: 2px 5px; font-size: 12px
   color: var(--acc); background: rgb(var(--acc-rgb) / 0.06); border: 1px solid var(--line2); border-radius: 3px; padding: 7px 13px; cursor: pointer;
   transition: color 0.12s, background 0.12s, border-color 0.12s;
 }
-.copy-btn:hover { color: #fff; }
+.copy-btn:hover { color: var(--text-fort); }
 .copy-btn.copied { color: var(--good-fg); background: var(--good); border-color: var(--good); }
 .manifest-lines { display: flex; flex-direction: column; }
 .mline { display: grid; grid-template-columns: auto auto 1fr auto auto auto; align-items: center; gap: 4px 14px; padding: 10px 20px; border-bottom: 1px solid var(--line); }
 .mline:last-child { border-bottom: none; }
 .mqtywrap { display: flex; align-items: center; gap: 5px; }
-input.mqty-input { width: 66px; min-width: 0; padding: 4px 6px; text-align: right; background: rgba(8, 11, 20, 0.9); border: 1px solid var(--line2); color: var(--acc); border-radius: 3px; font-family: var(--mono); font-weight: 700; font-size: 13px; }
+input.mqty-input { width: 66px; min-width: 0; padding: 4px 6px; text-align: right; background: rgb(var(--fond-carte-rgb) / 0.9); border: 1px solid var(--line2); color: var(--acc); border-radius: 3px; font-family: var(--mono); font-weight: 700; font-size: 13px; }
 /* SCU saisis au-delà du stock UEX dispo : autorisé mais signalé (vol de fret, relevé périmé…). */
 input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box-shadow: 0 0 0 1px rgb(var(--warn-rgb) / 0.35); }
 .munit { font-family: var(--mono); font-size: 10px; color: var(--muted); }
-.mname { font-weight: 600; color: #fff; }
-.mstock { font-family: var(--mono); font-size: 11px; color: #5f7891; white-space: nowrap; }
+.mname { font-weight: 600; color: var(--text-fort); }
+.mstock { font-family: var(--mono); font-size: 11px; color: var(--muted-2); white-space: nowrap; }
 .mprice { font-family: var(--mono); font-size: 12px; color: var(--muted); white-space: nowrap; }
 .mprofit { font-family: var(--mono); white-space: nowrap; text-align: right; color: var(--good); }
-.mboxes { grid-column: 1 / -1; font-family: var(--mono); font-size: 10.5px; color: #5f7891; margin-top: 2px; }
+.mboxes { grid-column: 1 / -1; font-family: var(--mono); font-size: 10.5px; color: var(--muted-2); margin-top: 2px; }
 .manifest-suggest:not(:empty) { border-top: 1px dashed var(--line2); }
 .suggest-head { padding: 10px 20px 4px; color: var(--acc); font-size: 10px; text-transform: uppercase; letter-spacing: 1.5px; }
 .sline { display: grid; grid-template-columns: auto 1fr auto auto auto; align-items: center; gap: 12px; padding: 8px 20px; border-top: 1px solid var(--line); }
@@ -973,7 +990,7 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 .mprofit.muted { color: var(--muted); }
 /* Ajout libre d'une commodité au manifeste, et retour au chargement calculé. */
 .manifest-add { display: flex; gap: 8px; padding: 10px 20px; border-top: 1px solid var(--line); }
-#manifestAddInput { flex: 1; min-width: 0; padding: 7px 10px; background: rgba(8, 11, 20, 0.9); border: 1px solid var(--line2); color: var(--text); border-radius: 3px; font-family: var(--font); font-size: 12px; }
+#manifestAddInput { flex: 1; min-width: 0; padding: 7px 10px; background: rgb(var(--fond-carte-rgb) / 0.9); border: 1px solid var(--line2); color: var(--text); border-radius: 3px; font-family: var(--font); font-size: 12px; }
 #manifestAddBtn { white-space: nowrap; }
 /* Même contrôle que le « ↺ optimal » d'une jambe de voyage (.jman-reset), même sobriété : il
    annule un travail, il ne s'offre pas avant qu'on le cherche. */
@@ -984,7 +1001,7 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 
 /* ---------- Chaîne ---------- */
 .chain-wrap { margin: 0 0 20px; }
-.chain { border: 1px solid rgb(var(--acc-2-rgb) / 0.35); background: linear-gradient(90deg, rgb(var(--acc-2-rgb) / 0.06), rgba(11, 15, 28, 0.7)); }
+.chain { border: 1px solid rgb(var(--acc-2-rgb) / 0.35); background: linear-gradient(90deg, rgb(var(--acc-2-rgb) / 0.06), rgb(var(--panel-solid-rgb) / 0.7)); }
 .chain-head { display: flex; flex-wrap: wrap; justify-content: space-between; gap: 10px 18px; padding: 16px 20px; border-bottom: 1px solid var(--line); }
 .chain-path { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; }
 .chain-path .sys { border-color: rgb(var(--acc-2-rgb) / .4); }
@@ -1020,7 +1037,7 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 
 /* ---------- Vue Corrections ---------- */
 .corrections-wrap { margin: 20px 0 0; }
-.station-title { padding: 12px 2px; font-family: var(--display); font-weight: 600; color: #fff; }
+.station-title { padding: 12px 2px; font-family: var(--display); font-weight: 600; color: var(--text-fort); }
 
 /* ---------- Bande des stations corrigées (ADR-003) ---------- */
 /* Elle passe naturellement à la ligne plutôt que de défiler : le nombre de STATIONS est petit par
@@ -1038,7 +1055,7 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 /* Station affichée : même grammaire que .vbtn.active et .sort-modes button.active — c'est ainsi que
    ce dépôt dit « actif », et il n'y a pas de raison d'en inventer une deuxième. */
 .stn-tile.active {
-  color: #fff; font-weight: 700;
+  color: var(--text-fort); font-weight: 700;
   border: 1px solid var(--line2); border-left: 2px solid var(--acc);
   background: linear-gradient(180deg, rgb(var(--acc-rgb) / 0.14), rgb(var(--acc-rgb) / 0.02));
   box-shadow: inset 0 0 22px rgb(var(--acc-rgb) / 0.08);
@@ -1070,7 +1087,7 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 .stn-hero .stn-vign { width: 96px; height: 52px; }
 .stn-hero-txt { min-width: 0; flex: 1 1 auto; }
 .stn-hero-line { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; }
-.stn-hero-name { font-family: var(--display); font-size: 15px; font-weight: 600; color: #fff; }
+.stn-hero-name { font-family: var(--display); font-size: 15px; font-weight: 600; color: var(--text-fort); }
 .stn-hero-zone { font-size: 11px; color: var(--muted); }
 .stn-hero-code { font-family: var(--mono); font-size: 10px; color: var(--muted); }
 .stn-hero-sub { display: flex; gap: 10px; margin-top: 2px; font-size: 11px; color: var(--muted); }
@@ -1083,7 +1100,7 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 .scomm-undo {
   padding: 1px 6px; border-radius: 3px; cursor: pointer;
   font-family: var(--mono); font-size: 10px; line-height: 1.5;
-  color: var(--muted); background: rgba(255, 255, 255, 0.04); border: 1px solid var(--line);
+  color: var(--muted); background: rgb(var(--text-fort-rgb) / 0.04); border: 1px solid var(--line);
   transition: color 0.12s, border-color 0.12s;
 }
 .scomm-undo:hover { color: var(--acc); border-color: var(--acc); }
@@ -1127,14 +1144,14 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 .corr-item { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 9px 14px; border: 1px solid var(--line); border-left: 2px solid var(--acc); border-radius: 3px; margin-bottom: 6px; background: rgb(var(--acc-rgb) / 0.03); }
 .corr-side { font-size: 10px; text-transform: uppercase; letter-spacing: 1px; color: var(--muted); border: 1px solid var(--line2); border-radius: 3px; padding: 1px 6px; margin-left: 4px; }
 .corr-del { flex-shrink: 0; width: 26px; height: 26px; border-radius: 4px; cursor: pointer; color: var(--bad); background: rgb(var(--bad-rgb) / 0.08); border: 1px solid rgb(var(--bad-rgb) / 0.35); font-size: 13px; line-height: 1; transition: color 0.12s, background 0.12s; }
-.corr-del:hover { color: #fff; background: #6b1c1c; }
+.corr-del:hover { color: var(--text-fort); background: #6b1c1c; }
 /* Les deux boutons de fin de bandeau restent COLLÉS à droite : c'est le `margin-left: auto` du
    premier qui pousse la paire, jamais celui des deux — deux marges automatiques se partageraient
    l'espace libre et les écarteraient l'un de l'autre au milieu du bandeau. */
 .corr-list-head .copy-btn { margin-left: auto; font-size: 11px; padding: 5px 11px; }
 .corr-list-head .copy-btn + .reset-ov { margin-left: 0; }
 .reset-ov { margin-left: auto; color: var(--warn); border-color: #5a4a1c; background: rgb(var(--warn-rgb) / .08); border-radius: 3px; padding: 5px 11px; cursor: pointer; font-family: var(--font); font-size: 11px; font-weight: 600; }
-.reset-ov:hover { color: #fff; border-color: var(--warn); background: rgb(var(--warn-rgb) / 0.16); }
+.reset-ov:hover { color: var(--text-fort); border-color: var(--warn); background: rgb(var(--warn-rgb) / 0.16); }
 
 /* ---------- Frais d'autoload ---------- */
 /* Marqueur des lignes où l'interrupteur est actif mais où aucune des deux stations ne facture :
@@ -1182,11 +1199,11 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 .sort-modes { display: flex; gap: 6px; flex-wrap: wrap; }
 .sort-modes button {
   font-family: var(--font); font-size: 11px; font-weight: 600; letter-spacing: 0.5px;
-  padding: 7px 12px; color: var(--muted); background: rgba(255, 255, 255, 0.02);
+  padding: 7px 12px; color: var(--muted); background: rgb(var(--text-fort-rgb) / 0.02);
   border: 1px solid var(--line); border-left: 2px solid transparent; cursor: pointer;
 }
 .sort-modes button:hover { color: var(--text); }
-.sort-modes button.active { color: #fff; border: 1px solid var(--line2); border-left: 2px solid var(--acc); background: rgb(var(--acc-rgb) / 0.10); }
+.sort-modes button.active { color: var(--text-fort); border: 1px solid var(--line2); border-left: 2px solid var(--acc); background: rgb(var(--acc-rgb) / 0.10); }
 
 /* Méga-board : grille dense de tuiles « code · marge », colorées en heatmap + tiroir détail dessous. */
 .commodities-wrap { margin: 18px 0 0; display: flex; flex-direction: column; gap: 14px; }
@@ -1199,7 +1216,7 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
   display: flex; align-items: center; justify-content: space-between; gap: 6px;
   padding: 5px 9px; min-width: 0; cursor: pointer;
   font-family: var(--mono); font-size: 11px; text-align: left;
-  color: var(--text); background: rgba(255, 255, 255, 0.015);
+  color: var(--text); background: rgb(var(--text-fort-rgb) / 0.015);
   border: 1px solid var(--line); border-left: 2px solid transparent;
 }
 .comm-tile:hover { background: rgb(var(--acc-rgb) / 0.08); border-color: var(--line2); }
@@ -1210,7 +1227,7 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 .comm-tile.sell-only { border-style: dashed; }
 .tile-carried { color: var(--acc-2); font-size: 8px; margin-right: 3px; vertical-align: middle; }
 .tile-code { color: var(--muted); font-weight: 700; letter-spacing: 0.5px; overflow: hidden; text-overflow: ellipsis; }
-.comm-tile.selected .tile-code { color: #fff; }
+.comm-tile.selected .tile-code { color: var(--text-fort); }
 .tile-val { flex-shrink: 0; font-weight: 700; }
 /* Heatmap de la marge (valeur) : rouge très lucratif → bleu correct → gris atone → sans marge. */
 .t-hot .tile-val  { color: var(--bad); }
@@ -1222,13 +1239,13 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 /* Tiroir de détail (points d'achat / vente) — sous le board, plein largeur. */
 .comm-detail { border: 1px solid var(--line2); border-top: 2px solid var(--acc); background: var(--panel); padding: 16px 20px; margin-top: 12px; }
 .comm-detail-head { display: flex; align-items: center; gap: 10px; padding-bottom: 12px; margin-bottom: 14px; border-bottom: 1px solid var(--line); }
-.comm-detail-title { font-family: var(--display); font-size: 15px; font-weight: 700; color: #fff; }
+.comm-detail-title { font-family: var(--display); font-size: 15px; font-weight: 700; color: var(--text-fort); }
 .comm-detail-title .comm-code { font-family: var(--mono); font-size: 13px; }
 .comm-cols { display: grid; grid-template-columns: 1fr 1fr; gap: 22px; }
 .comm-cols.one { grid-template-columns: 1fr; } /* mode Butin : pas de colonne « où acheter » */
 /* Mode Butin : la réponse directe — combien vaut 1 SCU, et au meilleur endroit. */
 .loot-value { margin-left: auto; text-align: right; font-family: var(--mono); font-size: 12px; color: var(--acc); }
-.loot-value b { font-size: 16px; color: #fff; }
+.loot-value b { font-size: 16px; color: var(--text-fort); }
 .loot-where { display: block; font-family: var(--font); font-size: 10.5px; color: var(--muted); letter-spacing: 0.3px; }
 .comm-col h4 { margin: 0 0 8px; font-size: 11px; letter-spacing: 1px; text-transform: uppercase; color: var(--acc); font-weight: 600; }
 .comm-col h4 .muted { color: var(--muted); font-weight: 400; text-transform: none; letter-spacing: 0; }
@@ -1338,7 +1355,7 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 .plan-hold-paid { font-family: var(--mono); font-size: 11px; color: var(--muted); }
 /* Le parcours : les mêmes étapes que le bandeau, mais INERTES — aucun bouton, aucun ✕. */
 .plan-path { display: flex; flex-wrap: wrap; align-items: center; gap: 6px 4px; margin-bottom: 12px; }
-.plan-step { padding: 3px 5px; border: 1px solid var(--line); background: rgba(255, 255, 255, 0.03); font-size: 12px; }
+.plan-step { padding: 3px 5px; border: 1px solid var(--line); background: rgb(var(--text-fort-rgb) / 0.03); font-size: 12px; }
 .plan-step.here { border-color: var(--acc); box-shadow: 0 0 0 1px var(--acc), 0 0 10px rgb(var(--acc-rgb) / 0.25); }
 .plan-sep { color: var(--muted); }
 .plan-legs { display: flex; flex-direction: column; gap: 8px; }


### PR DESCRIPTION
> **Base : `v2/main`, jamais `main`.** ADR-008 §3.

## Ce que ça change

Le HUD devient un **thème**, et — c'est le vrai livrable — une régression de peinture devient
**visible**. Aucune vue migrée, aucun Tailwind, aucun React. L'apparence est inchangée, et c'est
mesuré, pas espéré.

## Pourquoi : ce que « les tests passent » ne prouvait pas

Sur les 190 tests e2e, il existait **quatre** assertions de couleur, et toutes étaient
**relationnelles** — « le fond du ▶ diffère de celui du 📦 », « le bord d'achat diffère du bord de
vente ». **Aucune n'affirmait qu'une couleur EST quelque chose.**

Le site pouvait donc virer entièrement au gris shadcn avec 190 tests au vert. C'est l'étape où le
critère de fusion de l'ADR §4 ne veut plus rien dire, et il n'existait aucun instrument pour le
mesurer.

### « 19 variables » était un décompte trompeur

```
19    variables dans :root, dont UNE MORTE (--panel-2, zéro usage)
245   couleurs écrites en dur HORS de :root, pour 127 valeurs distinctes
189   d'entre elles (77 %) n'étaient que des voiles de teintes déjà jetonnées
```

Le fait qui change la méthode :

> **L'identité de ce site n'est pas « l'ambre `#ffb020 »`, c'est « l'ambre à DIX-HUIT opacités ».**

`--acc` vit à 18 alphas distincts, `--acc-2` à 16, `--good` et `--bad` à 10. Un jeton hexadécimal ne
peut produire aucune de ces déclinaisons : chacune redevient un littéral recopié — ou un
`bg-amber-500/10` générique — et le caractère se dissout par accumulation. Très exactement ce que
le §2 dit vouloir empêcher.

**D'où deux formes par teinte**, et ce n'est pas une redondance :

- **le hex reste**, parce que c'est une **API publique** : `app.js:1856` écrit littéralement
  `var(--stanton)` dans des attributs SVG `fill=` et `stroke=`. Renommer ces jetons rendrait le
  `fill` invalide et ferait **disparaître les planètes** de la carte, sur fond sombre — sans qu'un
  seul des 190 tests ne le voie ;
- **les canaux** (`--acc-rgb: 255 176 32`) autorisent `rgb(var(--acc-rgb) / .14)`.

**187 littéraux sont devenus des dérivations.** Deux familles absentes du décompte d'origine entrent
avec : les **encres sur fond accentué** (recopiées 9 fois — ce sont des noirs *teintés de leur
fond*, `#1a1000` sur l'ambre, `#04120a` sur le vert, jamais un noir générique), et le **palier de
titre** au-dessus de `--text` — 34 usages de `#fff`, qui portent tous les noms propres du HUD.
shadcn ne propose que `foreground` et `muted-foreground` : sans ce jeton, trois paliers s'écrasent
en deux, et c'est ce qui fait qu'une interface « ressemble à du shadcn ».

## Vérification

La preuve ne peut pas venir des tests existants. Elle vient du relevé des **styles calculés** de
840 formes, sur les 8 vues, animations figées, comparé à l'état de `v2/main` :

```
840 formes comparées
838 RIGOUREUSEMENT IDENTIQUES
  2 différences — la même, déclarée ci-dessous
```

La voici, en clair : `.k-drug` passait par `rgba(169, 112, 250, .14)` là où le violet du site est
`#a970ff` = `169 112 255`. Coquille du CSS d'origine, alignée par la dérivation — **5/255 sur un
canal, à 14 % d'opacité**. Invisible à l'œil, mais réelle : je la déclare plutôt que de la taire.

```
node --test           ℹ tests 483 · ℹ pass 483 · ℹ fail 0   (475 avant : 8 neufs)
npx playwright test   194 collectés · 192 passés · 2 ignorés  (190 avant : 4 neufs)
coquille              392 707 o · 20 entrées, sous plafond
```

Le rendu a aussi été **regardé**, pas seulement mesuré : ambre, violet, teintes par système, les
trois paliers de texte, le rail et son filet de sous-entrée — tout est en place.

## L'instrument, en trois pièces

**`scripts/jetons.test.mjs`** lit la **source** : chaque couleur d'identité épinglée à sa valeur,
les trois polices, la cohérence hex ↔ canaux, les encres, et l'absence de jeton mort. C'est lui qui
a imposé de *câbler* les encres au lieu de seulement les déclarer, et qui a débusqué `--panel-2`.

**`e2e/jetons.pw.mjs`** lit ce que le **navigateur calcule**, sur le site produit — y compris la
teinte qui arrive jusqu'au SVG de la carte. Nécessaire à part : une source juste peut rendre une
valeur fausse si une couche CSS l'emporte, ce qui est **précisément** le risque que Tailwind
apportera (une règle hors `@layer` bat toute règle layered, sans erreur ni test rouge).

**`scripts/coquille.test.mjs`** pose un budget — 420 ko et 24 entrées, mesuré à 392 707 o et 20. Le
service worker précache la coquille **atomiquement** et le build ramasse tout nouveau fragment :
sans plafond, chaque dépendance ajoutée grossit ce que le visiteur télécharge d'un bloc, sans que
personne n'ait eu à décider. Un plafond qu'on relève sciemment est une décision ; une coquille qui
grossit en silence n'en est pas une.

Un garde-fou en plus vise une classe entière de pannes invisibles : **aucune URI `data:` dans le CSS
produit**. La CSP n'a pas `data:` dans `img-src` — un plugin qui fabrique ses chevrons de `<select>`
en `data:` les ferait disparaître en production **et** en test, sans faire échouer une assertion.
C'est le cas concret d'`@tailwindcss/forms`, écarté d'avance.

## L'ADR est amendé sur deux points mesurés

**§2** — le décompte des jetons, et le mécanisme qui manquait à l'intention.

**§4** — la moitié « classes » du contrat était sous-estimée : **147 sélecteurs et 16 `data-*`**, non
« ~109 et 9 ». Avec trois pièges, dont le plus coûteux : **29 classes ne sont écrites que par
interpolation** (`.k-*`, `.sys-*`, `.s-*`) et seraient **élaguées** par une couche Tailwind — ce
sont exactement celles qui portent la couleur par système et par famille de commodité.

## Ce qui n'est pas couvert

- **Tailwind et shadcn ne sont pas installés.** Décidé : ils arrivent dans leur PR, sur un thème
  fini et déjà surveillé. L'ordre des couches (`@layer`) sera la première chose à trancher, et le
  relevé des 840 formes servira de filet.
- **49 littéraux restent en dur**, et c'est assumé : les ombres portées (un noir d'ombre n'a pas de
  teinte à défendre), les bordures des 12 familles de commodités, quelques ambres ponctuels. La
  palette catégorielle est une échelle à part entière et mérite sa propre décision.
- **Les effets HUD ne sont pas encore des primitives** — 24 `box-shadow`, 23 dégradés, le tramage
  animé, les scanlines en `mix-blend-mode`. Ils font autant le caractère que les couleurs, et
  Tailwind n'a d'équivalent pour aucun. À poser en couche de composants, avec Tailwind.
- **Le relevé des 840 formes est un outil de PR, pas un test permanent.** L'inscrire dans la suite
  demanderait de figer 840 valeurs, qui bougeraient à chaque retouche légitime.

Refs #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)
