### PR TITLE
feat(theme): Tailwind branché sur nos jetons, et pas un pixel n'a bougé

### DIFF
--- a/e2e/tailwind.pw.mjs
+++ b/e2e/tailwind.pw.mjs
@@ -1,0 +1,101 @@
+import { test, expect } from "@playwright/test";
+
+// Tailwind est installé mais utilisé par AUCUN élément de l'app. Ces tests ne vérifient donc pas
+// une apparence : ils vérifient que la CONFIGURATION produit ce qu'on croit, et surtout que la
+// cascade est dans le sens décidé.
+//
+// Pourquoi ça mérite des tests alors que rien ne l'utilise : les deux pannes possibles ici sont
+// silencieuses. Un ordre de couches inversé fait que la feuille maison perd sans erreur ni test
+// rouge ; une configuration de couleur mal branchée produit la bonne teinte sous une autre FORME
+// (color-mix au lieu de rgb), ce qui casse toute assertion qui compare des rgba(…) le jour où une
+// vue s'en sert. Les deux se découvriraient au pire moment : pendant la migration d'une vue.
+
+// Pose un élément témoin dans la page et rend ses styles calculés.
+const temoin = (page, html, sel = null) =>
+  page.evaluate(([h, s]) => {
+    const hote = document.createElement("div");
+    hote.id = "__temoin";
+    hote.innerHTML = h;
+    document.body.appendChild(hote);
+    // `sel` quand l'élément qui porte les classes n'est pas la racine du fragment — c'est le cas
+    // du SVG, où le <circle> est ce qui nous intéresse et non le <svg> qui l'enveloppe.
+    const el = s ? hote.querySelector(s) : hote.firstElementChild;
+    const cs = getComputedStyle(el);
+    const out = {
+      color: cs.color,
+      background: cs.backgroundColor,
+      borderColor: cs.borderTopColor,
+      fontFamily: cs.fontFamily,
+      padding: cs.paddingTop,
+      display: cs.display,
+      fill: cs.fill,
+      stroke: cs.stroke,
+    };
+    hote.remove();
+    return out;
+  }, [html, sel]);
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/index.html");
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+});
+
+test("Tailwind : les utilitaires de teinte passent par NOS canaux (#96)", async ({ page }) => {
+  // Le piège que cette configuration existe pour éviter : la voie normale de Tailwind 4 produit
+  // `color-mix(in oklab, …)`, que Chromium calcule en `oklab(0.813 …)`. Même couleur à l'œil, mais
+  // une chaîne différente — et toute assertion de couleur du dépôt compare des `rgba(…)`.
+  const t = await temoin(page, `<div class="bg-acc/14 text-muted border-good">x</div>`);
+  expect(t.background, "bg-acc/14 ne rend pas un rgba() — la config est repassée par color-mix")
+    .toBe("rgba(255, 176, 32, 0.14)");
+  expect(t.color).toBe("rgb(138, 147, 168)");
+  expect(t.borderColor).toBe("rgb(70, 229, 160)");
+});
+
+test("Tailwind : la teinte des systèmes s'applique aussi au SVG (#96)", async ({ page }) => {
+  const t = await temoin(page, `<svg><circle class="fill-stanton stroke-pyro/50" r="3"/></svg>`, "circle");
+  expect(t.fill).toBe("rgb(56, 189, 248)");
+  expect(t.stroke).toBe("rgba(255, 106, 61, 0.5)");
+});
+
+test("Tailwind : les trois familles du HUD sont exposées en utilitaires (#96)", async ({ page }) => {
+  expect((await temoin(page, `<div class="font-display">x</div>`)).fontFamily).toContain("Orbitron");
+  expect((await temoin(page, `<div class="font-mono">x</div>`)).fontFamily).toContain("JetBrains Mono");
+});
+
+test("Tailwind : les utilitaires NATIFS survivent à la surcharge de bg-/text-/border- (#96)", async ({ page }) => {
+  // On redéfinit `bg-*`, `text-*`, `border-*` : il fallait vérifier que Tailwind retombe bien sur
+  // ses propres utilitaires quand notre valeur ne résout pas. Sinon la moitié du vocabulaire
+  // standard disparaîtrait, et on ne s'en apercevrait qu'en écrivant la première vue.
+  const t = await temoin(page, `<div class="flex p-4">x</div>`);
+  expect(t.display).toBe("flex");
+  expect(t.padding).not.toBe("0px");
+});
+
+test("Tailwind : la feuille MAISON bat les utilitaires — l'ordre des couches (#96)", async ({ page }) => {
+  // LE test de cette PR. style.css est hors couche, et une déclaration hors couche bat TOUTE
+  // déclaration layered, quelle que soit la spécificité. C'est ce qui garantit qu'installer
+  // Tailwind ne déplace pas un pixel tant que personne n'écrit une classe.
+  //
+  // Si cet ordre s'inversait un jour, rien ne le signalerait : pas d'erreur, pas de test rouge,
+  // juste des règles maison qui cessent de s'appliquer là où un utilitaire passe par là.
+  const t = await temoin(page, `<div class="kicker text-acc-2/50">x</div>`);
+  const kicker = await page.evaluate(() => {
+    const e = document.createElement("div");
+    e.className = "kicker";
+    document.body.appendChild(e);
+    const c = getComputedStyle(e).color;
+    e.remove();
+    return c;
+  });
+  expect(t.color, "un utilitaire Tailwind a battu style.css : l'ordre des couches s'est inversé")
+    .toBe(kicker);
+});
+
+test("Tailwind : aucune palette étrangère n'entre dans le thème (#96)", async ({ page }) => {
+  // `--color-*: initial` retire la palette de Tailwind. Deux palettes côte à côte, c'est la dérive
+  // que le thème existe pour empêcher : le jour où quelqu'un écrit `bg-amber-500` parce que ça
+  // ressemble à notre ambre, l'identité commence à se dissoudre.
+  const t = await temoin(page, `<div class="bg-red-500 text-blue-300">x</div>`);
+  expect(t.background, "la palette Tailwind est revenue").toBe("rgba(0, 0, 0, 0)");
+  expect(t.color).not.toBe("rgb(147, 197, 253)");
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,63 @@
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.48.0",
+        "@tailwindcss/vite": "^4.3.3",
+        "tailwindcss": "^4.3.3",
         "typescript": "^7.0.2",
         "vite": "^8.2.1"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=24"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -305,6 +357,563 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.24.1",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+      "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "tailwindcss": "4.3.3"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
     },
     "node_modules/@typescript/typescript-aix-ppc64": {
       "version": "7.0.2",
@@ -656,6 +1265,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -687,6 +1310,23 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/lightningcss": {
@@ -962,6 +1602,16 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.18",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
@@ -1103,6 +1753,27 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/tinyglobby": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.48.0",
+    "@tailwindcss/vite": "^4.3.3",
+    "tailwindcss": "^4.3.3",
     "typescript": "^7.0.2",
     "vite": "^8.2.1"
   },

--- a/style.css
+++ b/style.css
@@ -2,6 +2,109 @@
    Best Hauling — refonte « HUD / cockpit » (amber · violet)
    Feuille de style ciblant le markup émis par app.js.
    ============================================================ */
+
+/* ── Tailwind 4.3.3 ────────────────────────────────────────────────────────────────────────────
+   Cette entête est TOUT ce que Tailwind ajoute à cette feuille. Les 1 400 lignes qui suivent
+   restent HORS COUCHE, et une déclaration hors couche bat toute déclaration layered quelle que
+   soit sa spécificité : c'est ce qui garantit qu'aucun pixel ne bouge tant que personne n'écrit
+   une classe utilitaire.
+
+   L'ordre est tranché MAINTENANT pour n'être plus à trancher plus tard. `heritage` est la couche
+   où cette feuille ira le jour où une vue React devra pouvoir la surcharger — déclarée AVANT
+   `utilities`, donc perdante face à un utilitaire, à dessein. */
+@layer theme, base, heritage, composants, utilities;
+@import "tailwindcss/theme.css" layer(theme);
+@import "tailwindcss/utilities.css" layer(utilities) source(none);
+
+/* PAS DE PREFLIGHT, et c'est mesuré, pas frileux. Il remet à zéro marges, titres, listes et
+   bordures — soit très exactement des pixels qui bougent. Les couches nous protègent partout où
+   cette feuille parle, mais elle est SILENCIEUSE à des endroits précis : `.empty`, `.fee-off`,
+   `.manifest-hint` et le <p> du pied de page ne déclarent aucune marge (les deux <p class="fee-off">
+   consécutifs se colleraient), et 20 des 37 classes de <button> ne déclarent pas de font-family —
+   `button { font: inherit }` les ferait basculer sur Chakra Petch, changeant glyphes et largeurs.
+
+   `source(none)` : aucun scan automatique. Sans lui, Tailwind fabrique 12 utilitaires (2,8 ko) à
+   partir de MOTS trouvés dans le code — « flex », « hidden », « table » lus dans des valeurs CSS
+   ou des noms de balises, jamais dans un attribut class. Du CSS mort, payé par le visiteur. Ce que
+   la refonte utilisera vraiment s'ajoutera par `@source` au fur et à mesure des vues migrées. */
+
+/* La palette et les familles de Tailwind sont RETIRÉES : deux palettes côte à côte, c'est
+   exactement la dérive que scripts/jetons.test.mjs existe pour attraper. */
+@theme {
+  --color-*: initial;
+  --font-*: initial;
+}
+
+/* `inline` fait que l'utilitaire prend la VALEUR au lieu de référencer un second jeton :
+   Tailwind n'émet ici AUCUNE variable, et surtout aucune couleur écrite une deuxième fois. La
+   source unique reste le :root ci-dessous. */
+@theme inline {
+  --canaux-acc:        var(--acc-rgb);
+  --canaux-acc-2:      var(--acc-2-rgb);
+  --canaux-good:       var(--good-rgb);
+  --canaux-warn:       var(--warn-rgb);
+  --canaux-bad:        var(--bad-rgb);
+  --canaux-muted:      var(--muted-rgb);
+  --canaux-text-fort:  var(--text-fort-rgb);
+  --canaux-panel:      var(--panel-solid-rgb);
+  --canaux-fond-carte: var(--fond-carte-rgb);
+  --canaux-stanton:    var(--stanton-rgb);
+  --canaux-pyro:       var(--pyro-rgb);
+  --canaux-nyx:        var(--nyx-rgb);
+
+  /* `--font-sans` et `--font-mono` reprennent les noms de Tailwind à dessein : c'est ce qu'un
+     composant tiers écrira. Ils ne dupliquent aucune valeur, ils pointent le même jeton. */
+  --font-sans:    var(--font);
+  --font-hud:     var(--font);
+  --font-display: var(--display);
+  --font-mono:    var(--mono);
+}
+
+/* Le cœur, et il ne s'improvise pas : `bg-acc/14` doit rendre `rgb(255 176 32 / .14)`, pas un
+   `color-mix()`. La voie normale de la v4 (`@theme { --color-acc }`) produit
+   `color-mix(in oklab, …)`, que Chromium calcule en `oklab(0.813 …)` — même couleur à l'œil, mais
+   une CHAÎNE différente, donc toute assertion comparant des `rgba(…)` tombe. Et
+   `@theme inline { --color-acc: rgb(var(--acc-rgb)) }` produit un repli silencieusement OPAQUE.
+
+   Ici, l'ORDRE des trois déclarations EST le mécanisme : Tailwind supprime toute déclaration dont
+   une fonction ne rend rien. Sans modificateur seule la 1re survit ; avec `/14` la 2e ; avec
+   `/[.14]` la 3e. `calc(--modifier(number) * 1%)` et non `--modifier(number)` : `rgb(… / 14)` est
+   un alpha supérieur à 1, donc écrêté — mesuré opaque. Et `--modifier()` n'existe QUE dans un
+   utilitaire fonctionnel `nom-*` : dans un `@utility bg-acc` statique il est recopié tel quel dans
+   le CSS produit, ce qui donne du CSS invalide sans que rien ne proteste.
+
+   Surcharger ces noms ne casse pas les utilitaires natifs : quand `--value(--canaux-*)` ne résout
+   pas, Tailwind retombe sur les siens (bg-cover, text-center, border-2… restent intacts). */
+@utility bg-* {
+  background-color: rgb(--value(--canaux-*));
+  background-color: rgb(--value(--canaux-*) / calc(--modifier(number) * 1%));
+  background-color: rgb(--value(--canaux-*) / --modifier([*]));
+}
+@utility text-* {
+  color: rgb(--value(--canaux-*));
+  color: rgb(--value(--canaux-*) / calc(--modifier(number) * 1%));
+  color: rgb(--value(--canaux-*) / --modifier([*]));
+}
+@utility border-* {
+  border-color: rgb(--value(--canaux-*));
+  border-color: rgb(--value(--canaux-*) / calc(--modifier(number) * 1%));
+  border-color: rgb(--value(--canaux-*) / --modifier([*]));
+}
+/* La carte du parcours est du SVG : sans ces deux-là, teinter une planète depuis un composant
+   obligerait à réécrire la couleur à la main — ce que tout ce thème existe pour éviter. */
+@utility fill-* {
+  fill: rgb(--value(--canaux-*));
+  fill: rgb(--value(--canaux-*) / calc(--modifier(number) * 1%));
+}
+@utility stroke-* {
+  stroke: rgb(--value(--canaux-*));
+  stroke: rgb(--value(--canaux-*) / calc(--modifier(number) * 1%));
+}
+
+/* Les témoins du test de couches et de teinte (e2e/tailwind.pw.mjs). `source(none)` coupant tout
+   scan, ces classes doivent être nommées explicitement pour exister. Elles ne sont portées par
+   aucun élément de l'app : elles servent à PROUVER que la configuration produit ce qu'on croit. */
+@source inline("bg-acc bg-acc/14 text-muted text-acc-2/50 border-good fill-stanton stroke-pyro/50 font-display font-mono p-4 flex");
 /* Le THÈME du HUD (refonte v2, ADR-008 §2). Il est verrouillé par scripts/jetons.test.mjs et par
    e2e/jetons.pw.mjs — le premier lit cette source, le second lit ce que le navigateur calcule.
    Ce double verrou répare un trou mesuré : sur 190 tests e2e, les seules assertions de couleur

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,4 +1,5 @@
 import { defineConfig } from "vite";
+import tailwindcss from "@tailwindcss/vite";
 import { readFileSync, writeFileSync, readdirSync, statSync, mkdirSync, copyFileSync, existsSync } from "node:fs";
 import { join, relative, sep } from "node:path";
 
@@ -232,5 +233,11 @@ export default defineConfig({
   // L'ordre compte : `horsBundle` retire les assets à nom contractuel et rétablit leurs href, et
   // `precache` liste ensuite dist/ tel qu'il est réellement. Inverser produirait un manifeste qui
   // précache des fichiers hachés que plus personne ne référence.
-  plugins: [cspDev(), horsBundle(), precache()],
+  //
+  // Tailwind est écrit en tête pour que la lecture corresponde à l'exécution, mais sa position est
+  // COSMÉTIQUE : ses trois sous-plugins portent tous `enforce: "pre"`, donc Vite les trie devant les
+  // nôtres quoi qu'on écrive. Nos trois-là n'en souffrent pas — ils n'agissent qu'en
+  // generateBundle/closeBundle, soit après toute transformation, et `precache` liste dist/ tel
+  // qu'il est : le CSS retravaillé par Tailwind y entre seul, sous son nom haché.
+  plugins: [tailwindcss(), cspDev(), horsBundle(), precache()],
 });


### PR DESCRIPTION
> **Base : `v2/main`, jamais `main`.** ADR-008 §3.

## Ce que ça change

Tailwind 4.3.3 est installé et **branché sur les jetons du HUD**. Il n'est utilisé par aucun
élément de l'app : le but n'est pas d'écrire des utilitaires, c'est que la première vue React
arrive plus tard sur un terrain déjà tranché.

**shadcn n'entre pas** : ses composants sont du React, il n'y a rien à poser sans lui. L'ADR prévoit
d'ailleurs cet ordre — le thème d'abord, la vue ensuite.

## Pourquoi : la recette évidente était fausse

Vérifié **en compilant** en bac à sable, pas en supposant.

| ce qu'on écrirait spontanément | ce que ça produit vraiment |
|---|---|
| `@theme { --color-acc: #ffb020 }` | `bg-acc/14` → `color-mix(in oklab, …)`, que Chromium calcule **`oklab(0.813 …)`** |
| la recette v3 `rgb(var(--x) / <alpha-value>)` | **morte** en v4, y compris via `@config` |
| `@theme inline { --color-acc: rgb(var(--acc-rgb)) }` | repli **silencieusement OPAQUE** — l'ambre à 100 % au lieu de 14 % |

Le premier cas est le piège réel : même couleur à l'œil, mais **chaîne différente**. Toutes les
assertions de couleur du dépôt comparent des `rgba(…)` — elles tomberaient le jour où une vue s'en
sert, et on chercherait la cause ailleurs.

**La voie qui marche** est l'utilitaire fonctionnel :

```css
@utility bg-* {
  background-color: rgb(--value(--canaux-*));
  background-color: rgb(--value(--canaux-*) / calc(--modifier(number) * 1%));
  background-color: rgb(--value(--canaux-*) / --modifier([*]));
}
```

`bg-acc/14` rend alors `rgb(var(--acc-rgb) / calc(14 * 1%))` — **aucune couleur réécrite**, la
valeur reste dans `:root` et nulle part ailleurs. L'**ordre** des trois déclarations *est* le
mécanisme : Tailwind supprime toute déclaration dont une fonction ne rend rien.

Deux détails ne s'improvisent pas, et sont commentés sur place : `--modifier()` n'existe **que** dans
un utilitaire `nom-*` — dans un utilitaire statique il est recopié tel quel, produisant du CSS
invalide sans que rien ne proteste — et `--modifier(number)` seul donne `rgb(… / 14)`, un alpha
supérieur à 1, donc **écrêté à l'opaque**.

## Trois décisions, chacune appuyée sur une mesure

**Pas de preflight.** Les couches nous protègent partout où `style.css` parle, mais elle est
**silencieuse** à des endroits précis : `.empty`, `.fee-off`, `.manifest-hint` et le `<p>` du pied de
page ne déclarent aucune marge — les deux `<p class="fee-off">` consécutifs se colleraient — et
**20 des 37 classes de `<button>`** n'ont pas de `font-family`, que `button { font: inherit }` ferait
basculer sur Chakra Petch en changeant glyphes et largeurs.

**`source(none)`, aucun scan automatique.** Sans lui, Tailwind fabrique **12 utilitaires (2,8 ko)** à
partir de *mots* trouvés dans le code — « flex », « hidden », « table » lus dans des valeurs CSS ou
des noms de balises, **jamais** dans un attribut `class`. Du CSS mort, payé par le visiteur. Ce que
la refonte utilisera s'ajoutera par `@source`, vue par vue.

**La palette de Tailwind est retirée** (`--color-*: initial`). Deux palettes côte à côte, c'est la
dérive que le thème existe pour empêcher : le jour où quelqu'un écrit `bg-amber-500` parce que ça
ressemble à notre ambre, l'identité commence à se dissoudre.

Zéro collision sur nos 444 classes : notre vocabulaire est français et métier, c'est ce qui nous
sauve.

## Vérification

Le relevé de styles calculés a été **étendu à 19 propriétés** — marges, padding, bordures, graisse,
`display` — précisément pour attraper un preflight qui passerait. Les 11 précédentes, toutes de
couleur et de typographie, ne l'auraient pas vu.

```
840 formes × 19 propriétés = 15 960 valeurs comparées
0 DIFFÉRENCE
```

```
node --test           ℹ tests 483 · ℹ pass 483 · ℹ fail 0
npx playwright test   200 collectés · 198 passés · 2 ignorés   (194 avant : 6 neufs)
coquille              394 683 o · 20 entrées   (plafond 420 000 / 24)
```

Les 6 tests neufs ne vérifient pas une apparence — rien n'utilise Tailwind — mais que la
**configuration produit ce qu'on croit**. Les deux pannes possibles ici sont silencieuses : un ordre
de couches inversé fait perdre la feuille maison sans erreur ni test rouge, et une couleur mal
branchée rend la bonne teinte sous une autre *forme*.

Le plus important est **le test des couches** : `style.css` est hors couche, donc elle bat tout
utilitaire. C'est ce qui garantit qu'installer Tailwind ne déplace pas un pixel tant que personne
n'écrit une classe.

## Ce qui n'est pas couvert

- **`[hidden] !important` est la seule brèche de la protection par couches**, et elle est nommée :
  pour les déclarations `!important`, la priorité est **inversée** — une couche l'emporte sur le
  hors-couche. Le preflight gagnerait donc ici… sauf qu'on ne l'importe pas. Sans conséquence
  aujourd'hui (aucun `hidden="until-found"` dans le dépôt), mais à savoir avant de changer d'avis.
- **Les effets HUD ne sont pas encore des primitives** — 24 `box-shadow`, 23 dégradés, le tramage
  animé, les scanlines. Ils font autant le caractère que les couleurs, et Tailwind n'a d'équivalent
  pour aucun. À poser en `@layer composants`, quand une vue en aura besoin.
- **`heritage` et `composants` sont des couches déclarées mais vides.** L'ordre est tranché
  maintenant pour n'être plus à trancher plus tard ; `style.css` n'y entrera que le jour où une vue
  React devra pouvoir la surcharger.
- **Le relevé des 840 formes reste un outil de PR**, pas un test permanent : l'inscrire dans la
  suite demanderait de figer 15 960 valeurs, qui bougeraient à chaque retouche légitime.

Refs #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)
