### PR TITLE
feat(tournee): la première vue passe en React, et le harnais l'a prouvée équivalente

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,6 +23,11 @@ import {
   encodeJourney, decodeJourney,
   migrerCorrections, exporterCorrections, exporterEntrepots,
 } from "./logic.ts";
+// Le premier îlot React (ADR-008, #96). `peindre` remplace `innerHTML` sur le conteneur de la
+// Tournée, et RIEN d'autre ne change : app.js reste le seul écrivain de l'état, refresh() reste
+// l'unique notification. Voir pont.js pour pourquoi il n'y a ni magasin ni abonnement.
+import { peindre } from "./pont.js";
+import { vueTournee, messageSouteVide, messageChargement, messageOuEsTu } from "./vues/tournee.tsx";
 
 // Libellé compact des caisses SCU standard, ex. « 8×32 · 1×16 · 1×4 · 1×2 · 1×1 ».
 // `maxBox` = plafond de caisse du terminal de CHARGEMENT, quand on le connaît : c'est une propriété
@@ -2536,20 +2541,17 @@ function renderTour() {
   const box = $("tour");
   if (!box) return;
   if (!SOUTE.length) {
-    box.innerHTML = `<div class="tour-vide"><p class="muted">Ta soute est vide — il n'y a rien à écouler.
-      Déclare ce que tu transportes avec <b>« + déclarer ce que j'ai à bord »</b> depuis une vue de recherche,
-      ou charge le manifeste d'une jambe avec <b>« ✓ chargé »</b>.</p></div>`;
+    peindre(box, messageSouteVide());
     return;
   }
   // Le graphe d'échange porte les débouchés. On passe `refresh` et non `renderTour` : c'est la règle
   // de withMarket — le fetch dure, et l'utilisateur peut avoir changé de vue entre-temps.
-  if (!MARKET) { withMarket(refresh); box.innerHTML = '<p class="muted tour-vide">Chargement du marché…</p>'; return; }
+  if (!MARKET) { withMarket(refresh); peindre(box, messageChargement()); return; }
   // Le champ de la vue prime sur la position du voyage : on peut vouloir simuler depuis ailleurs.
   const saisi = $("tourFrom").value.trim();
   const ici = saisi ? resolveStationLabel(saisi) : stationCourante();
   if (ici == null) {
-    box.innerHTML = `<div class="tour-vide"><p class="muted">Dis d'abord <b>où tu es</b> : une tournée part d'un terminal.
-      Le champ <b>Je suis à</b>, juste au-dessus, l'attend.</p></div>`;
+    peindre(box, messageOuEsTu());
     return;
   }
   const f = readFilters();
@@ -2559,7 +2561,7 @@ function renderTour() {
   // sur 114). L'ouvrir est un geste explicite, et le saut apparaît alors comme une ligne de coût.
   const ft = { ...f, sysFilter: toutSysteme ? f.sysFilter : systeme };
   const { tournee, alternative } = tourneesEcoulement(MARKET, SOUTE, ici, ft, effVals, feeResolver(f));
-  box.innerHTML = tourHTML(tournee, alternative, systeme, toutSysteme);
+  peindre(box, vueTournee({ tournee, alternative, systeme, toutSysteme, fmt }));
 }
 
 // ---------- Plan de vol : la vue de conclusion (ADR-004) ----------

--- a/e2e/pont.pw.mjs
+++ b/e2e/pont.pw.mjs
@@ -1,0 +1,107 @@
+import { test, expect } from "@playwright/test";
+
+// Le pont entre app.js et le premier îlot React (pont.js, ADR-008 #96).
+//
+// Ces tests ne regardent pas une apparence : ils regardent la PROPRIÉTÉ qui rend la cohabitation
+// tenable. Le dépôt a déjà payé cher la classe de bug visée — #24, #28, #38 et #55 sont tous des
+// variantes de « un re-rendu global efface ce que l'utilisateur était en train de faire », et
+// quatre tests de smoke.pw.mjs n'existent que pour ça.
+//
+// Le piège propre à React : `createRoot(el)` rappelé à chaque rendu REMONTE l'arbre au lieu de le
+// réconcilier. On reperdrait valeur et focus — c'est-à-dire qu'on réintroduirait ces quatre bugs
+// par l'outil même censé les supprimer. Et aucun test d'apparence ne le verrait : le DOM final est
+// identique, seul son IDENTITÉ change.
+
+async function souteDeclaree(page, scu = 400) {
+  await page.locator("#holdAddOpen").click();
+  await expect(page.locator("#holdAddName")).toBeVisible();
+  await expect.poll(() => page.locator("#commodityList option").count()).toBeGreaterThan(0);
+  const nom = await page.evaluate(() => document.querySelector("#commodityList option").value);
+  await page.fill("#holdAddName", nom);
+  await page.fill("#holdAddScu", String(scu));
+  await page.locator("#holdAddOk").click();
+  await expect(page.locator("#holdCard")).toBeVisible();
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/index.html");
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+});
+
+test("Pont : un re-rendu ne remonte PAS l'arbre React (#96)", async ({ page }) => {
+  // On marque un nœud rendu par React, on provoque un refresh() par un geste d'une AUTRE vue, et
+  // on vérifie que c'est le MÊME nœud. Si la racine était recréée, le marqueur disparaîtrait —
+  // signe que React a jeté son arbre au lieu de le réconcilier.
+  await souteDeclaree(page);
+  await page.click("#viewTour");
+  await page.fill("#tourFrom", "Megumi");
+  await expect(page.locator("#tour .tour-arret").first()).toBeVisible({ timeout: 15000 });
+
+  await page.evaluate(() => { document.querySelector("#tour .tour-arret").dataset.temoin = "1"; });
+
+  // Un geste qui passe par refresh() sans toucher à la Tournée : la soute est dans le bandeau,
+  // présent dans les huit vues.
+  await page.fill("#cargo", "120");
+  await page.waitForTimeout(400);
+
+  await expect(
+    page.locator('#tour .tour-arret[data-temoin="1"]'),
+    "l'arbre React a été remonté : la racine est recréée à chaque rendu au lieu d'être mémorisée"
+  ).toHaveCount(1);
+});
+
+test("Pont : les gestes des autres vues traversent jusqu'à la vue React (#96)", async ({ page }) => {
+  // L'autre sens : app.js écrit l'état, refresh() repeint, et l'îlot doit suivre. Sans ça la vue
+  // React afficherait des chiffres périmés — la panne la plus sournoise possible ici, puisque tout
+  // paraîtrait normal.
+  await souteDeclaree(page, 400);
+  await page.click("#viewTour");
+  await page.fill("#tourFrom", "Megumi");
+  await expect(page.locator("#tour .tour-arret").first()).toBeVisible({ timeout: 15000 });
+  const avant = await page.locator("#tour .tour-bilan").innerText();
+
+  // On DÉCLARE un second lot depuis le bandeau — un geste vanilla, dans une zone que la vue React
+  // ne connaît pas. Il écrit SOUTE, appelle refresh(), et le bilan de la tournée doit suivre.
+  // (Ouvrir la portée ne conviendrait pas : depuis Megumi la tournée est déjà optimale en un
+  // arrêt, donc le bilan ne bougerait pas — le test passerait sans rien prouver.)
+  await page.locator("#holdAddOpen").click();
+  await expect(page.locator("#holdAddName")).toBeVisible();
+  const second = await page.evaluate(() => document.querySelectorAll("#commodityList option")[1].value);
+  await page.fill("#holdAddName", second);
+  await page.fill("#holdAddScu", "150");
+  await page.locator("#holdAddOk").click();
+
+  await expect
+    .poll(() => page.locator("#tour .tour-bilan").innerText())
+    .not.toBe(avant);
+});
+
+test("Pont : la vue React survit à l'aller-retour entre vues (#96)", async ({ page }) => {
+  // switchView masque la section par `hidden`, il ne la vide pas. La racine React reste montée sur
+  // un conteneur caché, et doit repeindre correctement au retour.
+  await souteDeclaree(page);
+  await page.click("#viewTour");
+  await page.fill("#tourFrom", "Megumi");
+  await expect(page.locator("#tour .tour-arret").first()).toBeVisible({ timeout: 15000 });
+  const arrets = await page.locator("#tour .tour-arret").count();
+
+  await page.click("#viewRoutes");
+  await expect(page.locator("#tour")).toBeHidden();
+  await page.click("#viewTour");
+  await expect(page.locator("#tour")).toBeVisible();
+  await expect(page.locator("#tour .tour-arret")).toHaveCount(arrets);
+});
+
+test("Pont : les messages vides passent AUSSI par React (#96)", async ({ page }) => {
+  // Une seule branche restée en innerHTML sur un conteneur possédé par React se ferait écraser au
+  // rendu suivant, silencieusement — et seulement dans certains enchaînements.
+  await page.click("#viewTour");
+  await expect(page.locator("#tour .tour-vide")).toContainText(/déclarer ce que j'ai à bord/i);
+
+  await souteDeclaree(page);
+  await expect(page.locator("#tour .tour-vide")).toContainText(/où tu es/i);
+
+  await page.fill("#tourFrom", "Megumi");
+  await expect(page.locator("#tour .tour-arret").first()).toBeVisible({ timeout: 15000 });
+  await expect(page.locator("#tour .tour-vide")).toHaveCount(0);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,16 @@
       "name": "best-hauling",
       "version": "1.1.0",
       "license": "MIT",
+      "dependencies": {
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8"
+      },
       "devDependencies": {
         "@playwright/test": "^1.48.0",
         "@tailwindcss/vite": "^4.3.3",
+        "@types/react": "^19.2.18",
+        "@types/react-dom": "^19.2.4",
+        "@vitejs/plugin-react": "^6.0.5",
         "tailwindcss": "^4.3.3",
         "typescript": "^7.0.2",
         "vite": "^8.2.1"
@@ -915,6 +922,26 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@types/react": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
     "node_modules/@typescript/typescript-aix-ppc64": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
@@ -1254,6 +1281,39 @@
       "engines": {
         "node": ">=16.20.0"
       }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.5.tgz",
+      "integrity": "sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1712,6 +1772,27 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
@@ -1744,6 +1825,12 @@
         "@rolldown/binding-win32-arm64-msvc": "1.2.4",
         "@rolldown/binding-win32-x64-msvc": "1.2.4"
       }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   "devDependencies": {
     "@playwright/test": "^1.48.0",
     "@tailwindcss/vite": "^4.3.3",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.4",
+    "@vitejs/plugin-react": "^6.0.5",
     "tailwindcss": "^4.3.3",
     "typescript": "^7.0.2",
     "vite": "^8.2.1"
@@ -29,5 +32,9 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/0xkestrelnova/best-hauling.git"
+  },
+  "dependencies": {
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8"
   }
 }

--- a/pont.js
+++ b/pont.js
@@ -1,0 +1,25 @@
+// La seule couture entre les deux mondes, pendant la migration v2 (ADR-008).
+//
+// app.js reste le SEUL écrivain de l'état : ce module ne fait que remplacer `box.innerHTML = html`
+// par un rendu React idempotent. Il n'y a rien de plus à construire — pas de magasin, pas de bus,
+// pas d'abonnement — parce que le dépôt a déjà un point de propagation unique et complet :
+// TOUTE mutation d'état partagé finit par appeler `refresh()` dans la même pile (vérifié sur les
+// 17 écritures de SOUTE, les 8 de JOURNEY, les 5 d'OVERRIDES). Lui ajouter un rival créerait deux
+// vérités à tenir d'accord, ce que la refonte cherche justement à supprimer.
+import { createRoot } from "react-dom/client";
+import { flushSync } from "react-dom";
+
+// UNE racine par conteneur, créée UNE SEULE FOIS. La recréer à chaque rendu REMONTERAIT l'arbre :
+// on reperdrait la valeur et le focus des champs en cours de saisie — c'est-à-dire #24, #28, #38
+// et #55 réintroduits par l'outil même qui devait les supprimer. C'est le seul vrai piège
+// d'implémentation de cette étape, et aucun test d'apparence ne le verrait.
+const racines = new WeakMap();
+
+export function peindre(el, noeud, { synchrone = false } = {}) {
+  let r = racines.get(el);
+  if (!r) { r = createRoot(el); racines.set(el, r); }
+  // React rend en DIFFÉRÉ. Les rares appelants qui mesurent le DOM juste après doivent demander le
+  // rendu synchrone ; les autres non — React réserve flushSync au dernier recours.
+  if (synchrone) flushSync(() => r.render(noeud));
+  else r.render(noeud);
+}

--- a/scripts/coquille.test.mjs
+++ b/scripts/coquille.test.mjs
@@ -15,8 +15,24 @@ import { join, sep } from "node:path";
 // Un plafond qu'on relève sciemment dans une PR est une décision. Une coquille qui grossit sans que
 // personne ne le voie n'en est pas une. Ce test transforme la seconde en la première.
 
-const PLAFOND_OCTETS = 420_000;  // mesuré à 392 707 le 2026-08-15 (thème posé, avant Tailwind)
-const PLAFOND_ENTREES = 24;      // mesuré à 20
+// RELEVÉ LE 2026-08-15, et c'est une décision, pas une dérive — c'est très exactement ce que le
+// message d'échec ci-dessous réclamait.
+//
+//   avant React   394 683 o  (plafond 420 000)
+//   après React   586 751 o  → +192 068 o, dont 334 404 o de JS au total
+//
+// Ce que ça coûte VRAIMENT au visiteur : 119 596 o de JS+CSS gzippés sur le réseau. Le poste
+// dominant de la coquille reste les polices. Le coût est payé UNE fois — le service worker
+// précache atomiquement, puis sert depuis le cache.
+//
+// Pourquoi ne pas découper le bundle pour n'apporter React qu'aux vues migrées : le plugin de
+// précache ramasse TOUS les fragments émis, donc le visiteur télécharge l'ensemble de toute façon,
+// et chaque fragment de plus est une URL supplémentaire qu'un seul 404 suffirait à faire rejeter
+// en bloc. Le découpage se rediscutera quand la migration sera finie et `app.js` retiré.
+//
+// Le plafond garde sa marge : toute hausse ULTÉRIEURE redevient une décision à écrire.
+const PLAFOND_OCTETS = 620_000;  // mesuré à 586 751 le 2026-08-15 (React 19 + première vue migrée)
+const PLAFOND_ENTREES = 24;      // mesuré à 20 — inchangé, React n'ajoute aucun fragment
 
 const dist = join(process.cwd(), "dist");
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,7 +33,8 @@
     "noImplicitAny": false,
     "forceConsistentCasingInFileNames": true,
     "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "jsx": "react-jsx"
   },
-  "include": ["logic.ts", "types.ts"]
+  "include": ["logic.ts", "types.ts", "vues/**/*.tsx"]
 }

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,5 +1,6 @@
 import { defineConfig } from "vite";
 import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
 import { readFileSync, writeFileSync, readdirSync, statSync, mkdirSync, copyFileSync, existsSync } from "node:fs";
 import { join, relative, sep } from "node:path";
 
@@ -239,5 +240,5 @@ export default defineConfig({
   // nôtres quoi qu'on écrive. Nos trois-là n'en souffrent pas — ils n'agissent qu'en
   // generateBundle/closeBundle, soit après toute transformation, et `precache` liste dist/ tel
   // qu'il est : le CSS retravaillé par Tailwind y entre seul, sous son nom haché.
-  plugins: [tailwindcss(), cspDev(), horsBundle(), precache()],
+  plugins: [react(), tailwindcss(), cspDev(), horsBundle(), precache()],
 });

--- a/vues/tournee.tsx
+++ b/vues/tournee.tsx
@@ -1,0 +1,214 @@
+// La vue Tournée, premier îlot React de la refonte v2 (ADR-008, #96).
+//
+// POURQUOI CELLE-CI EN PREMIÈRE. Mesuré sur les huit vues : 125 lignes exclusives, 4 `#id` et
+// 3 classes au contrat e2e, 10 tests dont 8 exclusifs et TOUS dans un seul fichier — et surtout,
+// elle n'écrit AUCUNE globale de app.js et ne touche au DOM d'aucune autre vue. Son rendu est même
+// totalement inerte : pas un gestionnaire d'événement. C'est la seule qui prouve le mécanisme sans
+// rien risquer d'autre. (À l'opposé, « En route » écrit six globales dont JOURNEY, référencée par
+// 33 déclarations, et écrit dans le DOM de deux autres vues.)
+//
+// CE QUI NE CHANGE PAS, et c'est le contrat : les classes, la structure et les textes sont
+// reproduits à l'identique. La suite e2e est le harnais de migration — si elle passe sans qu'on
+// l'ait touchée, c'est que la vue rend la même chose.
+//
+// Le calcul n'est pas ici : `tourneesEcoulement` vit dans logic.ts, pure et couverte par les tests
+// unitaires. Ce fichier ne fait que présenter.
+import type { Tournee, Destination } from "../types.ts";
+
+// Le formateur de app.js est passé en prop plutôt qu'importé : app.js n'exporte rien (c'est un
+// script d'entrée), et le dupliquer ici ferait diverger deux formatages de nombres.
+type Fmt = (n: number) => string;
+
+type ProprietesArret = { a: Destination; rang: number; fmt: Fmt };
+
+// Le badge de système. Sa classe porte le nom en minuscules — `.sys.pyro`, `.sys.stanton` — et
+// style.css la teinte via les jetons. C'est l'une des 29 classes que le dépôt n'écrit que par
+// interpolation : elle doit sortir d'ici exactement pareil, sans quoi la couleur disparaît.
+const BadgeSysteme = ({ system }: { system: string }) => (
+  <span className={"sys " + system.toLowerCase()}>{system}</span>
+);
+
+const MAX_LIGNES = 12;
+
+function ArretDeTournee({ a, rang, fmt }: ProprietesArret) {
+  const visibles = a.lignes.slice(0, MAX_LIGNES);
+  const reste = a.lignes.length - visibles.length;
+
+  // Les trois états de certitude, et ils ne disent PAS la même chose : une capacité publiée, une
+  // capacité qu'UEX ne publie pas (ni zéro ni illimitée — 84 % des points de vente), et un entre-deux.
+  const certitude =
+    a.certitude === "connue" ? (
+      <span className="ec-sur" title="Capacité publiée par UEX">{fmt(a.garanti)} SCU garantis</span>
+    ) : a.certitude === "inconnue" ? (
+      <span className="ec-flou" title="UEX ne publie pas la capacité de ce point : ni zéro, ni illimitée">capacité inconnue</span>
+    ) : (
+      <span className="ec-flou" title="Capacité publiée pour une partie seulement">{fmt(a.garanti)} SCU garantis, reste inconnu</span>
+    );
+
+  return (
+    <div className="tour-arret">
+      <div className="tour-arret-head">
+        <span className="tour-n">{rang}</span>
+        <span className="tour-nom">
+          {a.terminal}
+          <BadgeSysteme system={a.system} />
+          {a.cross ? <> <span className="cross" title="Changement de système">⚡</span></> : null}
+          {a.outpost ? <> <span className="outpost" title="Avant-poste : élévateur de fret parfois en panne">⚠ avant-poste</span></> : null}
+        </span>
+        <span className="tour-lignes-n">
+          {a.lignes.length} ligne{a.lignes.length > 1 ? "s" : ""} · <b>{fmt(a.scu)}</b> SCU
+        </span>
+        <span
+          className="tour-encaisse"
+          title={`Encaissement brut. Profit, prix d'achat déduit : ${a.profit >= 0 ? "+" : ""}${fmt(Math.round(a.profit))} aUEC.`}
+        >
+          {fmt(Math.round(a.encaisse))}
+        </span>
+      </div>
+      <div className="tour-arret-lignes">
+        {visibles.map((l, i) => (
+          <span key={i} className={"tour-ligne" + (l.sousLePrixPaye ? " perte" : "")}>
+            {l.name} <b>{fmt(l.absorbe)}</b>
+            {l.reste > 0 ? `/${fmt(l.absorbe + l.reste)}` : ""} SCU
+          </span>
+        ))}
+        {reste > 0 ? (
+          <span className="tour-ligne muted">+ {reste} autre{reste > 1 ? "s" : ""}</span>
+        ) : null}
+      </div>
+      <div className="tour-arret-meta">
+        {certitude}
+        {a.aPerte ? (
+          <> · <span className="ec-perte" title="Le prix ici est inférieur à ce que tu as payé">sous le prix payé</span></>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export type ProprietesTournee = {
+  tournee: Tournee;
+  alternative: Tournee | null;
+  systeme: string;
+  toutSysteme: boolean;
+  fmt: Fmt;
+};
+
+export function VueTournee({ tournee: t, alternative: alt, systeme, toutSysteme, fmt }: ProprietesTournee) {
+  if (!t.arrets.length && !t.sansDebouche.length) {
+    return (
+      <div className="tour-vide">
+        <p className="muted">
+          Aucun comptoir ne reprend ce fret {toutSysteme ? "où que ce soit" : `dans ${systeme}`} avec ces filtres.
+          Ouvre la portée aux autres systèmes, ou <b>dépose</b> le fret à une station : il n'est alors ni vendu ni perdu.
+        </p>
+      </div>
+    );
+  }
+
+  // Le PLANCHER, dit AVANT les chiffres, et c'est une exigence de l'ADR-007 : 307 des 1 879 points
+  // de vente publient leur capacité. Le nombre d'arrêts est presque toujours faux vers le bas, et un
+  // total ne s'affiche jamais sans dire s'il est garanti ou parié.
+  const parie = t.certitude !== "connue";
+
+  return (
+    <>
+      <div className="tour-head">
+        <span className="tour-titre">◈ Tournée d'écoulement</span>
+        <span className="tour-bilan">
+          <b>{t.arrets.length}</b> arrêt{t.arrets.length > 1 ? "s" : ""}
+          {t.sauts > 0 ? <> · <b>{t.sauts}</b> saut{t.sauts > 1 ? "s" : ""} de système</> : null}
+          {" · "}<b>{fmt(t.scu)}</b> SCU écoulés
+          {t.resteScu > 0 ? <> · <b className="tour-reste">{fmt(t.resteScu)}</b> SCU resteraient à bord</> : <> · <b>soute vidée</b></>}
+        </span>
+        <span
+          className="tour-total"
+          title={`Encaissement brut de la tournée. Profit, prix d'achat déduit : ${t.profit >= 0 ? "+" : ""}${fmt(Math.round(t.profit))} aUEC.`}
+        >
+          {fmt(Math.round(t.encaisse))} <span>aUEC</span>
+        </span>
+      </div>
+
+      <div className={"tour-plancher " + (parie ? "parie" : "sur")}>
+        {parie ? (
+          <>Plancher : UEX ne publie la capacité que d'un point de vente sur six. Il faudra sans doute <b>plus d'arrêts</b> que ce qui est annoncé — la tournée se recalcule après chaque arrêt réel.</>
+        ) : (
+          <>Toutes les capacités de cette tournée sont publiées par UEX : le nombre d'arrêts est <b>garanti</b>.</>
+        )}
+      </div>
+
+      {/* Les lignes qui ne s'écoulent nulle part sont NOMMÉES : les taire ferait annoncer une soute
+          vidée qui ne l'est pas. 15 commodités sur 113 n'ont aucun débouché dans Pyro. */}
+      {t.sansDebouche.length ? (
+        <div className="tour-orphelines">
+          <b>
+            {t.sansDebouche.length} ligne{t.sansDebouche.length > 1 ? "s ne s'écoulent" : " ne s'écoule"} nulle part{" "}
+            {toutSysteme ? "dans la portée" : `dans ${systeme}`}
+          </b>
+          {" :"}{" "}
+          {t.sansDebouche.map((g, i) => (
+            <span key={i} className="tour-orph">{g.name} {fmt(g.units)} SCU</span>
+          ))}
+          <span className="muted">— ouvre la portée, dépose-les à une station, ou garde-les à bord.</span>
+        </div>
+      ) : null}
+
+      <div className="tour-arrets">
+        {t.arrets.map((a, i) => <ArretDeTournee key={i} a={a} rang={i + 1} fmt={fmt} />)}
+      </div>
+
+      {/* L'alternative « un arrêt de plus », chiffrée. L'ordre reste lexicographique STRICT : la
+          plus courte gagne. Un seuil serait un paramètre invérifiable — l'app ne sait pas si tu as
+          le temps, si c'est sur ton chemin, ou si tu veux juste te coucher. On montre les deux. */}
+      {alt ? (
+        <div className="tour-alt">
+          <div className="tour-alt-head">
+            Un arrêt de plus : <b className="profit">+{fmt(Math.round(alt.ecart))}</b> aUEC
+            {alt.ecartPct != null ? <> <span className="muted">(+{alt.ecartPct.toFixed(1)} %)</span></> : null}
+          </div>
+          <div className="tour-alt-chemin">
+            {alt.arrets.map((a, i) => (
+              <span key={i}>
+                {i > 0 ? <span className="tour-fleche">→</span> : null}
+                {i > 0 ? " " : ""}{a.terminal} <span className="muted">({a.lignes.length})</span>{i < alt.arrets.length - 1 ? " " : ""}
+              </span>
+            ))}
+          </div>
+          <div className="tour-alt-note muted">À toi de trancher : l'app ne sait pas si tu as le temps, ni si c'est sur ton chemin.</div>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+// ── Les fabriques exposées à app.js ────────────────────────────────────────────────────────────
+// app.js reste un fichier .js SANS JSX, et c'est délibéré : le renommer en .jsx déplacerait le
+// fichier sur lequel tout le harnais est calé — la ligne d'assemblage du déploiement le nomme, le
+// service worker aussi, et scripts/csp.test.mjs vérifie les deux. Faire traverser le JSX à tout
+// le .js du dépôt pour un seul fichier serait payer cher un confort d'écriture.
+//
+// Ces fabriques rendent des éléments React déjà construits : app.js n'a qu'à les passer à
+// `peindre`, sans connaître ni JSX ni React.
+
+export const vueTournee = (p: ProprietesTournee) => <VueTournee {...p} />;
+
+export const messageSouteVide = () => (
+  <div className="tour-vide">
+    <p className="muted">
+      Ta soute est vide — il n'y a rien à écouler.
+      Déclare ce que tu transportes avec <b>« + déclarer ce que j'ai à bord »</b> depuis une vue de recherche,
+      ou charge le manifeste d'une jambe avec <b>« ✓ chargé »</b>.
+    </p>
+  </div>
+);
+
+export const messageChargement = () => <p className="muted tour-vide">Chargement du marché…</p>;
+
+export const messageOuEsTu = () => (
+  <div className="tour-vide">
+    <p className="muted">
+      Dis d'abord <b>où tu es</b> : une tournée part d'un terminal.
+      Le champ <b>Je suis à</b>, juste au-dessus, l'attend.
+    </p>
+  </div>
+);


### PR DESCRIPTION
> **Base : `v2/main`, jamais `main`.** ADR-008 §3.

## Ce que ça change

**La Tournée est rendue par React.** Les sept autres vues restent en vanilla. C'est le premier
livrable de la refonte qui touche ce que l'utilisateur voit — et il ne le voit pas, parce que le
rendu est identique.

## Pourquoi cette vue

Mesuré sur les huit :

| | Tournée | En route (la dernière à migrer) |
|---|---|---|
| lignes exclusives | **125** | 371 |
| globales **écrites** | **aucune** | 6, dont `JOURNEY` (33 références) |
| tests e2e | 10, dont 8 exclusifs, **un seul fichier** | 42 sur 4 fichiers |
| écrit dans le DOM d'autres vues | **non** | oui — `#chainOrigin`, `#empty` |
| gestionnaires d'événement | **aucun** | plusieurs délégations |

C'est la seule qui prouve le mécanisme sans rien risquer d'autre.

## Il n'y a ni magasin, ni bus, ni abonnement

C'est le point le plus important de cette PR, et c'est une **soustraction**.

Le dépôt a déjà un point de propagation unique et **prouvé complet** : toute mutation d'état remonte
à `refresh()` dans la même pile — vérifié sur les 17 écritures de `SOUTE`, les 8 de `JOURNEY`, les 5
d'`OVERRIDES`. Lui ajouter un rival créerait deux vérités à tenir d'accord, exactement ce que la
refonte cherche à supprimer.

`pont.js` ne fait donc qu'une chose : remplacer `innerHTML` par un rendu React **idempotent**.

Et son seul vrai piège tient en six lignes. `createRoot(el)` rappelé à chaque rendu **remonte**
l'arbre au lieu de le réconcilier : on reperdrait valeur et focus des champs en cours de saisie —
c'est-à-dire **#24, #28, #38 et #55 réintroduits par l'outil censé les supprimer**. Aucun test
d'apparence ne le verrait : le DOM final est identique, seule son *identité* change. D'où la
`WeakMap` de racines, et `e2e/pont.pw.mjs` qui marque un nœud et vérifie qu'il survit à un
`refresh()`.

`app.js` reste un fichier `.js` **sans JSX** — l'îlot exporte des fabriques d'éléments. Le renommer
en `.jsx` déplacerait le fichier sur lequel tout le harnais est calé : la ligne d'assemblage du
déploiement le nomme, le service worker aussi, et `csp.test.mjs` vérifie les deux.

## La preuve — et il a fallu commencer par réparer l'outil

Le relevé de styles calculés, celui qui a servi aux trois PR précédentes, compare par
`tagname#id.classes`. **Une forme qui disparaît n'est jamais comparée, donc jamais signalée.**
Mesuré : il annonçait `0 différence` sur 361 formes pendant qu'un `div.tour-arret` s'évaporait.

Sans danger jusqu'ici — le DOM ne bougeait pas. Dès que React le réécrit, il aurait déclaré
« équivalent » ce qu'il n'avait pas regardé. Corrigé : clé par **rang**, relevé **scopé** à la vue,
et rapport en **cinq** nombres.

```
24 formes comparées · 22 identiques · 2 différentes · 0 DISPARUE · 0 APPARUE
```

Les 2 écarts sont des marges `auto` à **0,015 px** près. Cause connue et bénigne : le template
literal produisait des espaces blancs par son indentation, que React n'émet pas — dans un conteneur
flex ils ne génèrent aucune boîte. La **structure des balises est identique**, et les captures
avant/après sont indiscernables.

## Le budget de coquille, relevé avec son chiffre

```
avant React   394 683 o                    après   586 751 o   (+192 068)
plafond       420 000 → 620 000            réseau  119 596 o de JS+CSS gzippés
```

Le test posé à la PR du thème a fait exactement son travail : il a **refusé**, et exigé une décision
écrite plutôt qu'une dérive silencieuse.

Pas de découpage de bundle pour n'apporter React qu'aux vues migrées : le plugin de précache ramasse
**tous** les fragments, donc le visiteur télécharge l'ensemble de toute façon, et chaque fragment de
plus est une URL qu'un seul 404 suffit à faire rejeter en bloc — `addAll` est atomique. À
rediscuter quand `app.js` aura disparu.

## Vérification

```
npx tsc --noEmit      0 erreur
node --test           ℹ tests 483 · ℹ pass 483 · ℹ fail 0
npx playwright test   204 collectés · 203 passés · 1 ignoré (1,2 min)
```

**Les 10 tests de la Tournée passent sans avoir été touchés.** C'est ce que « la suite e2e est le
harnais de migration » voulait dire, et c'est la première fois qu'on peut le vérifier.

Un test ignoré est d'ailleurs devenu vert (2 → 1) : ces deux-là dépendent des **données** et non du
code, ce que l'amendement du §4 disait déjà. Le critère est « tous les tests collectés passent »,
pas un compte figé — s'il avait été chiffré en dur, il serait faux aujourd'hui.

## Ce qui n'est pas couvert

- **shadcn n'entre pas.** Ses composants sont du React, et la Tournée n'a aucun composant complexe à
  lui offrir — pas de menu, pas de dialogue, pas d'infobulle. Il viendra avec sa **propre** hausse de
  plafond, pour que le coût reste attribuable. Son CLI ne devra jamais écrire dans `style.css` : il y
  redéfinirait `--muted`, qui chez lui est une *surface* et chez nous un *texte gris* référencé
  92 fois.
- **`#tourControls` reste dans `index.html`**, hors du périmètre de React. `collectState()` fait
  `$(id).value` sur les champs d'état et **lève sur `null`** : si React démontait `#tourFrom`, la
  sauvegarde casserait pour **les huit vues**, permalien et localStorage compris. Sortir les champs
  d'état du DOM est une PR distincte.
- **Le relevé corrigé reste un outil de PR**, pas un test permanent — mais sa version corrigée est
  celle à reprendre pour les sept vues suivantes.
- **Les sept autres vues** sont inchangées. L'ordre suggéré part du moins couplé : Boucles et Chaîne
  ensuite, « En route » en dernier.

Refs #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)
