### PR TITLE
feat(boucles): la vue Boucles passe en React, délégation et contrat intacts

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,6 +28,8 @@ import {
 // l'unique notification. Voir pont.js pour pourquoi il n'y a ni magasin ni abonnement.
 import { peindre } from "./pont.js";
 import { vueTournee, messageSouteVide, messageChargement, messageOuEsTu } from "./vues/tournee.tsx";
+import { vueBoucles } from "./vues/boucles.tsx";
+import { KIND_ICON } from "./vues/communs.tsx";
 
 // Libellé compact des caisses SCU standard, ex. « 8×32 · 1×16 · 1×4 · 1×2 · 1×1 ».
 // `maxBox` = plafond de caisse du terminal de CHARGEMENT, quand on le connaît : c'est une propriété
@@ -98,15 +100,9 @@ function outpostTag(isOutpost) {
   return isOutpost ? ' <span class="outpost" title="Avant-poste : élévateur de fret parfois en panne">⚠ avant-poste</span>' : "";
 }
 
-// Icône emoji par catégorie de commodité (repère visuel).
-const KIND_ICON = {
-  metal: "🔩", alloy: "⛓️", mineral: "💎", raw: "⛏️", nonmetal: "🪨",
-  gas: "💨", halogen: "⚗️", fuel: "⛽",
-  agricultural: "🌾", food: "🍎", natural: "🌿", organic: "🧬",
-  drug: "☠️", vice: "🍸", medical: "⚕️",
-  scrap: "♻️", waste: "🗑️", manmade: "⚙️", explosive: "💥",
-  temporary: "⏳", other: "📦",
-};
+// Icône emoji par catégorie de commodité (repère visuel). La table vit désormais dans
+// vues/communs.tsx, importée en tête : une seule source, sans quoi les deux copies divergeraient
+// sans qu'aucun test ne le voie.
 function commodityIcon(kind) {
   const k = kind || "other";
   const emoji = KIND_ICON[k] || KIND_ICON.other;
@@ -650,37 +646,16 @@ function renderLoops() {
   }
   shownLoops = rows;
 
-  $("loopRows").innerHTML = rows
-    .map((l, i) => {
-      // Quatre opérations par boucle : on charge et on décharge à chacun des deux bouts.
-      const fc = feeCell(l.feeInfo, l.fees, () => `${fmt(l.unitsOut)} + ${fmt(l.unitsBack)} SCU, 4 opérations (charge et décharge à chaque bout)`, l.units > 0);
-      return `
-      <tr data-row="${i}"${l._fromHere ? ' class="from-here"' : ""}>
-        <td class="loc loop-cell">
-          <button class="journey-pick" data-row="${i}" title="Ajouter cette boucle au voyage" aria-label="Ajouter au voyage">▶</button>
-          <div class="loop-ends">
-            <div class="loop-end"><span class="term-name">${esc(l.a.terminal)}</span>${sysBadge(l.a.system)}${outpostTag(l.a.outpost)}</div>
-            <div class="loop-mid"><span class="loop-arrow">⇄</span>${l.cross ? '<span class="cross">⚡ inter-système</span>' : ""}</div>
-            <div class="loop-end"><span class="term-name">${esc(l.b.terminal)}</span>${sysBadge(l.b.system)}${outpostTag(l.b.outpost)}</div>
-            <div class="loc-fresh">${freshChip(l.out.updated && l.back.updated ? Math.min(l.out.updated, l.back.updated) : l.out.updated || l.back.updated || 0)}</div>
-          </div>
-        </td>
-        <td>
-          <div class="commodity-cell">${commodityIcon(l.out.kind)}<span>${esc(l.out.commodity)}${illegalTag(l.out.illegal)}</span></div>
-          <div class="loc-sub">${fmt(l.out.buyPrice)} → ${fmt(l.out.sellPrice)} · marge ${fmt(l.out.margin)}</div>
-        </td>
-        <td>
-          <div class="commodity-cell">${commodityIcon(l.back.kind)}<span>${esc(l.back.commodity)}${illegalTag(l.back.illegal)}</span></div>
-          <div class="loc-sub">${fmt(l.back.buyPrice)} → ${fmt(l.back.sellPrice)} · marge ${fmt(l.back.margin)}</div>
-        </td>
-        <td>${fiabiliteCell(l.fiabilite, l.age, l.partVolume)}</td>
-        <td class="num">${fmt(l.loopMargin)}</td>
-        <td class="num">${l.units == null ? "—" : fmt(l.unitsOut) + " + " + fmt(l.unitsBack)}</td>
-        <td class="num profit"${fc.attr}>${fmtFee(l.profit, l.fees)}${fc.mark}</td>
-        <td class="num profit" title="${withFeeText(`Estimation ${Math.round(l.minutes)} min/boucle`, fc)}">${fmtFee(l.profitHour, l.fees)}</td>
-      </tr>`;
-    })
-    .join("");
+  // Le <tbody> passe à React ; le <thead> et ses `th[data-sort-loop]` restent dans index.html,
+  // câblés par setupLoopSort. `data-row` reproduit le rang dans `shownLoops`, que la délégation
+  // posée sur document lit au clic sur `.journey-pick` — c'est un contrat, pas un détail.
+  peindre($("loopRows"), vueBoucles({
+    lignes: rows,
+    fmt,
+    celluleFrais: (l) => feeCell(l.feeInfo, l.fees, () => `${fmt(l.unitsOut)} + ${fmt(l.unitsBack)} SCU, 4 opérations (charge et décharge à chaque bout)`, l.units > 0),
+    fmtFee,
+    avecTexteFrais: (base, cell) => (cell.text ? `${base} · ${cell.text}` : base),
+  }));
 
   $("empty").hidden = rows.length > 0;
   notifySuperseded();

--- a/vues/boucles.tsx
+++ b/vues/boucles.tsx
@@ -1,0 +1,125 @@
+// La vue Boucles, second îlot React (ADR-008 #96).
+//
+// Plus exigeante que la Tournée malgré ses 73 lignes, et c'est pour ça qu'elle vient en second :
+// elle exerce trois choses que la Tournée n'avait pas.
+//
+//   1. Elle rend des LIGNES INTERACTIVES. Chaque `<tr>` porte `data-row`, et une délégation posée
+//      sur `document` (app.js) lit `shownLoops[btn.dataset.row]` au clic sur `.journey-pick`.
+//      L'index doit donc correspondre EXACTEMENT au rang dans le tableau que app.js a rangé dans
+//      la globale. React ne change rien à ce contrat : il le reproduit.
+//   2. Elle vit dans un `<tbody>` dont le `<thead>` reste VANILLA (index.html), avec ses
+//      `th[data-sort-loop]` câblés par `setupLoopSort`. React ne possède que le corps du tableau.
+//   3. Ses cellules passent par des aides PARTAGÉES avec d'autres vues — d'où `communs.tsx`.
+//
+// Ce qui reste dans app.js, et doit y rester tant que Trajets n'est pas migrée : l'écriture de
+// `#empty`, le `<p>` de message vide PARTAGÉ par Trajets, Boucles et « En route ». Le déplacer ici
+// le ferait disparaître des deux autres vues.
+import type { Boucle } from "../types.ts";
+import { BadgeSysteme, TagAvantPoste, TagIllegal, IconeCommodite, PastilleFraicheur, CelluleFiabilite } from "./communs.tsx";
+
+type Fmt = (n: number) => string;
+
+// Ce que `feeCell` (app.js) rend déjà : un title, un marqueur, et le texte brut. On le reçoit tel
+// quel plutôt que de le recalculer — c'est app.js qui connaît le contexte de frais, et le
+// dupliquer ferait diverger deux façons de dire le même montant.
+type CelluleFrais = { attr: string; mark: string; text: string };
+
+// La boucle ÉVALUÉE : la ligne de data/loops.json enrichie par `evaluateLoop` (app.js) des champs
+// que `loopMetrics` calcule. `_fromHere` est posé par la vue quand la boucle part de la fin du
+// parcours en cours — elle remonte alors en tête, sans être filtrée.
+export type BoucleEvaluee = Boucle & {
+  cross: boolean;
+  fiabilite: number; age: number | null; partVolume: number;
+  units: number | null; unitsOut: number; unitsBack: number;
+  profit: number; profitHour: number; minutes: number; fees: number;
+  feeInfo: unknown;
+  _fromHere?: boolean;
+};
+
+export type ProprietesBoucles = {
+  lignes: BoucleEvaluee[];
+  fmt: Fmt;
+  // Les trois fonctions que app.js garde : elles connaissent l'état des frais, que l'îlot ignore.
+  celluleFrais: (l: BoucleEvaluee) => CelluleFrais;
+  fmtFee: (n: number, fees: number) => string;
+  avecTexteFrais: (base: string, cell: CelluleFrais) => string;
+};
+
+function LigneBoucle({ l, i, fmt, celluleFrais, fmtFee, avecTexteFrais }: {
+  l: BoucleEvaluee; i: number; fmt: Fmt;
+  celluleFrais: ProprietesBoucles["celluleFrais"];
+  fmtFee: ProprietesBoucles["fmtFee"];
+  avecTexteFrais: ProprietesBoucles["avecTexteFrais"];
+}) {
+  const fc = celluleFrais(l);
+  // Le title des frais arrive déjà échappé depuis app.js (` title="…"`). React échappe de son côté,
+  // donc on prend le TEXTE et on laisse React poser l'attribut — sinon on afficherait les guillemets.
+  const titreFrais = fc.text || undefined;
+
+  // La fraîcheur de la boucle est celle du plus ANCIEN des deux relevés : une boucle ne vaut pas
+  // mieux que sa jambe la moins sûre.
+  const releve = l.out.updated && l.back.updated
+    ? Math.min(l.out.updated, l.back.updated)
+    : l.out.updated || l.back.updated || 0;
+
+  return (
+    <tr data-row={i} className={l._fromHere ? "from-here" : undefined}>
+      <td className="loc loop-cell">
+        <button className="journey-pick" data-row={i} title="Ajouter cette boucle au voyage" aria-label="Ajouter au voyage">▶</button>
+        <div className="loop-ends">
+          <div className="loop-end">
+            <span className="term-name">{l.a.terminal}</span>
+            <BadgeSysteme system={l.a.system} />
+            <TagAvantPoste outpost={l.a.outpost} />
+          </div>
+          <div className="loop-mid">
+            <span className="loop-arrow">⇄</span>
+            {l.cross ? <span className="cross">⚡ inter-système</span> : null}
+          </div>
+          <div className="loop-end">
+            <span className="term-name">{l.b.terminal}</span>
+            <BadgeSysteme system={l.b.system} />
+            <TagAvantPoste outpost={l.b.outpost} />
+          </div>
+          <div className="loc-fresh"><PastilleFraicheur updated={releve} /></div>
+        </div>
+      </td>
+      <td>
+        <div className="commodity-cell">
+          <IconeCommodite kind={l.out.kind} />
+          <span>{l.out.commodity}<TagIllegal illegal={l.out.illegal} /></span>
+        </div>
+        <div className="loc-sub">{fmt(l.out.buyPrice)} → {fmt(l.out.sellPrice)} · marge {fmt(l.out.margin)}</div>
+      </td>
+      <td>
+        <div className="commodity-cell">
+          <IconeCommodite kind={l.back.kind} />
+          <span>{l.back.commodity}<TagIllegal illegal={l.back.illegal} /></span>
+        </div>
+        <div className="loc-sub">{fmt(l.back.buyPrice)} → {fmt(l.back.sellPrice)} · marge {fmt(l.back.margin)}</div>
+      </td>
+      <td><CelluleFiabilite f={l.fiabilite} age={l.age} part={l.partVolume} /></td>
+      <td className="num">{fmt(l.loopMargin)}</td>
+      <td className="num">{l.units == null ? "—" : fmt(l.unitsOut) + " + " + fmt(l.unitsBack)}</td>
+      <td className="num profit" title={titreFrais}>
+        {fmtFee(l.profit, l.fees)}
+        {fc.mark ? <> <span className="nofee">⊘</span></> : null}
+      </td>
+      <td className="num profit" title={avecTexteFrais(`Estimation ${Math.round(l.minutes)} min/boucle`, fc)}>
+        {fmtFee(l.profitHour, l.fees)}
+      </td>
+    </tr>
+  );
+}
+
+export function VueBoucles({ lignes, fmt, celluleFrais, fmtFee, avecTexteFrais }: ProprietesBoucles) {
+  return (
+    <>
+      {lignes.map((l, i) => (
+        <LigneBoucle key={i} l={l} i={i} fmt={fmt} celluleFrais={celluleFrais} fmtFee={fmtFee} avecTexteFrais={avecTexteFrais} />
+      ))}
+    </>
+  );
+}
+
+export const vueBoucles = (p: ProprietesBoucles) => <VueBoucles {...p} />;

--- a/vues/communs.tsx
+++ b/vues/communs.tsx
@@ -1,0 +1,70 @@
+// Les fragments de présentation partagés par plusieurs vues (refonte v2, ADR-008 #96).
+//
+// Ils existaient en tant que fonctions de app.js rendant des CHAÎNES HTML — `sysBadge`,
+// `outpostTag`, `illegalTag`, `commodityIcon`, `freshChip`, `fiabiliteCell`. Chacune est courte et
+// entièrement échappée ; les réécrire en composants ne demandait donc aucune décision de design,
+// seulement de la transcription vérifiée.
+//
+// UNE SEULE SOURCE : `KIND_ICON` est exporté ICI et importé par app.js, qui a perdu sa copie. Le
+// dupliquer aurait créé deux tables d'emoji vouées à diverger — et une divergence d'emoji ne fait
+// rougir aucun test.
+//
+// Ce qu'ils ne font PAS : lire une globale, ni décider. Le calcul reste dans logic.ts (d'où
+// `ageDays` et `scoreBarWidth` viennent), et l'état reste dans app.js.
+import { ageDays, scoreBarWidth } from "../logic.ts";
+
+// Le badge de système. Sa classe porte le nom en minuscules — `.sys.pyro`, `.sys.stanton` — et
+// c'est l'une des 29 classes que le dépôt n'écrit que par interpolation : elle doit sortir d'ici
+// exactement pareil, sans quoi la couleur du système disparaît sans qu'un test le voie.
+export const BadgeSysteme = ({ system }: { system: string }) => (
+  <span className={"sys " + system.toLowerCase()}>{system}</span>
+);
+
+// L'espace qui précède ces deux marqueurs est SIGNIFICATIF : il séparait le nom du terminal dans
+// les chaînes d'origine (`${esc(nom)}${outpostTag(...)}`), et le retirer collerait les mots.
+export const TagAvantPoste = ({ outpost }: { outpost: boolean }) =>
+  outpost ? <> <span className="outpost" title="Avant-poste : élévateur de fret parfois en panne">⚠ avant-poste</span></> : null;
+
+export const TagIllegal = ({ illegal }: { illegal: boolean }) =>
+  illegal ? <> <span className="illegal" title="Commodité illégale : contrebande, risque de scan">⛔ illégal</span></> : null;
+
+// Icône emoji par catégorie de commodité. La classe `k-${kind}` porte la palette catégorielle des
+// 12 familles (style.css) — c'est encore l'une des 29 classes interpolées.
+export const KIND_ICON: Record<string, string> = {
+  metal: "🔩", alloy: "⛓️", mineral: "💎", raw: "⛏️", nonmetal: "🪨",
+  gas: "💨", halogen: "⚗️", fuel: "⛽",
+  agricultural: "🌾", food: "🍎", natural: "🌿", organic: "🧬",
+  drug: "☠️", vice: "🍸", medical: "⚕️",
+  scrap: "♻️", waste: "🗑️", manmade: "⚙️", explosive: "💥",
+  temporary: "⏳", other: "📦",
+};
+
+export const IconeCommodite = ({ kind }: { kind: string | null | undefined }) => {
+  const k = kind || "other";
+  return <span className={"cicon k-" + k} title={k}>{KIND_ICON[k] || KIND_ICON.other}</span>;
+};
+
+// Pastille de fraîcheur du relevé UEX. Le seuil est le même que dans app.js : moins d'un jour →
+// bon, moins de trois → bon, moins de sept → correct, au-delà → vieux.
+export function PastilleFraicheur({ updated }: { updated: number }) {
+  const d = ageDays(updated);
+  if (d == null) return <span className="fresh f-old" title="Date de relevé inconnue">?</span>;
+  let cls: string, label: string;
+  if (d < 1) { cls = "f-good"; label = d < 1 / 24 ? "<1 h" : Math.round(d * 24) + " h"; }
+  else { label = Math.round(d) + " j"; cls = d < 3 ? "f-good" : d < 7 ? "f-ok" : "f-old"; }
+  return <span className={"fresh " + cls} title={"Relevé UEX il y a " + label}>{label}</span>;
+}
+
+// La cellule de fiabilité. Elle N'ENTRE PAS DANS LE TRI, et son title le dit — c'est une décision
+// de l'ADR-005 : la fiabilité informe, elle ne classe pas.
+export function CelluleFiabilite({ f, age, part }: { f: number; age: number | null; part: number }) {
+  const tier = f >= 70 ? "s-good" : f >= 40 ? "s-ok" : "s-low";
+  const quoi = age == null ? "date du relevé inconnue" : `relevé vieux de ${Math.round(age)} j`;
+  const titre = `Fiabilité ${f}/100 — ${quoi}, ${Math.round(part * 100)} % du volume publié par UEX. N'entre pas dans le tri.`;
+  return (
+    <div className="score-cell" title={titre}>
+      <span className={"scorebar " + tier}><i style={{ width: scoreBarWidth(f) + "%" }} /></span>
+      <b>{f}</b>
+    </div>
+  );
+}


### PR DESCRIPTION
> **Base : `v2/main`, jamais `main`.** ADR-008 §3.

## Ce que ça change

**La vue Boucles est rendue par React.** Deux vues sur huit y sont maintenant. Le rendu est
identique — mesuré, pas espéré.

## Pourquoi elle en second

Pas parce qu'elle est facile : parce qu'elle exerce **trois choses que la Tournée n'avait pas**.

**Des lignes interactives.** Chaque `<tr>` porte `data-row`, et une délégation posée sur `document`
lit `shownLoops[btn.dataset.row]` au clic sur `.journey-pick`. L'index doit correspondre exactement
au rang dans la globale rangée par `app.js`. C'est un contrat, pas un détail — et le relevé le
vérifie nommément.

**Un DOM en propriété partagée.** Le `<thead>` et ses `th[data-sort-loop]` restent dans `index.html`,
câblés par `setupLoopSort`. React ne possède que le `<tbody>`.

**Des cellules construites par des aides partagées** avec d'autres vues.

## `vues/communs.tsx`, et un déménagement plutôt qu'une copie

`sysBadge`, `outpostTag`, `illegalTag`, `commodityIcon`, `freshChip` et `fiabiliteCell` deviennent
des composants. Aucune décision de design là-dedans, seulement de la transcription vérifiée : elles
étaient courtes et entièrement échappées. Deux d'entre elles s'appuient sur `logic.ts` (`ageDays`,
`scoreBarWidth`), donc rien n'est recalculé en double.

**`KIND_ICON` déménage au lieu d'être copié.** La table des 21 emoji vit maintenant dans
`communs.tsx`, et `app.js` l'importe. Deux copies auraient divergé sans qu'aucun test ne le voie —
une icône de catégorie n'est assertée nulle part.

## Ce qui reste dans `app.js`, délibérément

L'écriture de **`#empty`**. Ce `<p>` de message vide est **partagé** par Trajets, Boucles et
« En route » — le commentaire d'`app.js` le dit depuis toujours. Le déplacer dans cet îlot le ferait
disparaître des deux autres vues. Il migrera avec Trajets.

## Vérification

Relevé de styles calculés scopé à `#loopRows`, clé par rang, 19 propriétés :

```
5 590 formes comparées · 5 590 IDENTIQUES · 0 différente · 0 disparue · 0 apparue
```

Et le contrat de la délégation, vérifié explicitement :

```
160 lignes avant, 160 après
data-row des <tr>            identiques
data-row des .journey-pick   identiques
```

```
npx tsc --noEmit      0 erreur
node --test           ℹ tests 483 · ℹ pass 483 · ℹ fail 0
npx playwright test   204 collectés · 202 passés · 2 ignorés (1,2 min)
```

**Aucun test n'a été touché.** Le relevé est cette fois 233 fois plus large que pour la Tournée
(5 590 formes contre 24) : c'est une vue à 160 lignes de tableau, chacune à huit cellules — donc une
épreuve autrement plus sévère du mécanisme.

## Ce qui n'est pas couvert

- **Le `<thead>` reste vanilla**, avec son tri. Il migrera quand Trajets migrera : les deux tableaux
  partagent `setupLoopSort` et son jumeau.
- **`shownLoops` reste une globale de `app.js`**, écrite par lui. L'îlot ne la connaît pas ; il
  reproduit seulement les index. Sortir ces tableaux indexés par rang est une PR distincte, et
  probablement la dernière de la migration.
- **Six vues restent** : Chaîne, Commodités, Corrections, Plan de vol, Trajets, et « En route » en
  dernier — elle écrit six globales dont `JOURNEY` et dans le DOM de deux autres vues.
- **shadcn n'est toujours pas entré.** Aucune des deux vues migrées n'a de composant complexe à lui
  offrir.

Refs #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)
