### PR TITLE
feat(chaine): la vue Chaîne passe en React — et le relevé a attrapé une vraie régression

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,6 +29,7 @@ import {
 import { peindre } from "./pont.js";
 import { vueTournee, messageSouteVide, messageChargement, messageOuEsTu } from "./vues/tournee.tsx";
 import { vueBoucles } from "./vues/boucles.tsx";
+import { vueChaine, indiceDepart, indiceSoute, indiceAucune } from "./vues/chaine.tsx";
 import { KIND_ICON } from "./vues/communs.tsx";
 
 // Libellé compact des caisses SCU standard, ex. « 8×32 · 1×16 · 1×4 · 1×2 · 1×1 ».
@@ -1286,56 +1287,7 @@ function resolveChainOrigin() {
 
 // buildChainAdjacency vit dans logic.mjs (fonction pure) ; appelée avec MARKET + effVals.
 
-function chainCardHTML(chain, f) {
-  const T = (idx) => MARKET.terminals[idx];
-  // Un saut transporte un MANIFESTE (#56), que bestChain pose sur `leg.lines` — une seule ligne
-  // quand l'arc n'avait pas de remplissage à composer. Les totaux se lisent donc comme ceux
-  // d'« En route » : une base d'autoload PAR COMMODITÉ (manifestTotals), jamais un `haulFee` unique
-  // par saut, qui sous-facturait de plusieurs bases et affichait un profit que bestChain, lui,
-  // n'avait pas retenu pour choisir l'itinéraire.
-  const totaux = chain.legs.map((leg) => manifestTotals(leg.lines || [], leg.fee));
-  const invest = totaux[0] ? totaux[0].invest : 0;
-  let minutes = 0;
-  for (let i = 0; i < chain.legs.length; i++) {
-    minutes += tripMinutes(0, T(chain.path[i]).system !== T(chain.path[i + 1]).system);
-  }
-  const totalFees = totaux.reduce((s, t) => s + t.fees, 0);
-  const totalScu = totaux.reduce((s, t) => s + t.scu, 0);
-  const nodes = chain.path
-    .map((idx) => `<span class="snode term">${esc(T(idx).name)}</span>${sysBadge(T(idx).system)}`)
-    .join('<span class="chain-arrow">→</span>');
-  const legs = chain.legs
-    .map((leg, i) => {
-      const a = T(chain.path[i]), b = T(chain.path[i + 1]);
-      const t = totaux[i], lignes = leg.lines || [];
-      const fc = feeCell(feeCtx(f, a.name, b.name, a, b), t.fees, () => feeCargoText(lignes, a.maxBox), t.scu > 0);
-      // Une ligne par commodité chargée, aux mêmes colonnes que le manifeste d'« En route » : la
-      // somme des lignes affichées DOIT faire le total du saut affiché à droite, d'où le même
-      // décompte de frais des deux côtés (lineProfitText / manifestTotals).
-      const detail = lignes.map((l) =>
-        `<div class="chain-line"><div class="commodity-cell">${commodityIcon(l.kind)}<span>${esc(l.name)}${illegalTag(l.illegal)}</span></div>` +
-        `<span class="chain-line-scu"><b>${fmt(l.units)}</b> SCU</span>` +
-        `<span class="chain-line-price">${fmt(l.buyPrice)} → ${fmt(l.sellPrice)} <span class="muted">(marge ${fmt(l.margin)}/SCU)</span></span>` +
-        `<span class="chain-line-profit ${classeProfit(lineNet(l.units, l, leg.fee))}">${lineProfitText(l.units, l, leg.fee)}</span></div>`
-      ).join("");
-      return `<div class="chain-leg"><span class="chain-step">${i + 1}</span><div class="chain-leg-main">` +
-        // `.loc-sub` est un flex à gouttière : sans ce span, le volume chargé et son plafond
-        // deviennent deux éléments séparés par 6 px, et la barre de fraction se lit « 96 /96 ».
-        `<div class="loc-sub">${esc(a.name)} → ${esc(b.name)} · <span><b class="chain-leg-scu">${fmt(t.scu)}</b>/${fmt(f.cargo)} SCU</span> · ${lignes.length} commodité${lignes.length > 1 ? "s" : ""}</div>` +
-        `<div class="chain-lines">${detail}</div>` +
-        `</div><span class="chain-leg-profit profit"${fc.attr}>+${fmtFee(leg.profit, t.fees)}${fc.mark}</span></div>`;
-    })
-    .join("");
-  return `<div class="chain">
-      <div class="chain-head">
-        <span class="chain-path">${nodes}</span>
-        <span class="chain-tot">Profit <b class="profit">${fmtFee(chain.profit, totalFees)}</b> aUEC${totalFees > 0 ? ` · frais ≈ ${fmt(totalFees)}` : ""} · ${chain.legs.length} saut${chain.legs.length > 1 ? "s" : ""} · ${fmt(totalScu)} SCU chargés · capital de départ ${fmt(invest)} · ~${Math.round(minutes)} min</span>
-        <button id="chainToJourney" class="chain-pick" title="Ajouter cette chaîne au voyage en cours">▶ Ajouter au voyage</button>
-      </div>
-      <div class="chain-legs">${legs}</div>
-    </div>`;
-}
-
+// `chainCardHTML` a été remplacé par vues/chaine.tsx.
 function renderChain() {
   if (!MARKET) { withMarket(refresh); return; }
   if (!enrouteReady) setupEnRoute();
@@ -1343,17 +1295,28 @@ function renderChain() {
   const box = $("chainOut");
   const f = readFilters();
   shownChain = null;
-  const hint = (msg) => { box.innerHTML = `<div class="manifest-hint">${msg}</div>`; notifySuperseded(); };
-  if (chainOrigin == null) return hint("Choisis un <b>terminal de départ</b> pour calculer une chaîne rentable.");
-  if (!f.useCargo || !(f.cargo > 0)) return hint("Active la <b>soute (SCU)</b> pour dimensionner la chaîne.");
+  const hint = (noeud) => { peindre(box, noeud); notifySuperseded(); };
+  if (chainOrigin == null) return hint(indiceDepart());
+  if (!f.useCargo || !(f.cargo > 0)) return hint(indiceSoute());
   const hops = Number($("hops").value) || 3;
   // Les frais sont estampillés sur chaque leg par buildChainAdjacency — seul endroit de la chaîne
   // où les deux terminaux d'un saut coexistent — puis consommés par bestChain, dont l'élagage et la
   // sélection portent alors sur le profit NET.
   const chain = bestChain(buildChainAdjacency(MARKET, f, effVals, feeResolver(f)), chainOrigin, hops, { cargo: f.cargo });
-  if (!chain || !chain.legs.length) return hint("Aucune chaîne rentable depuis ce terminal avec ces filtres.");
+  if (!chain || !chain.legs.length) return hint(indiceAucune());
   shownChain = chain;
-  box.innerHTML = chainCardHTML(chain, f);
+  // Le calcul de présentation vit dans l'îlot (il n'appelle que logic.ts) ; app.js ne lui passe que
+  // ce qui dépend de l'ÉTAT : le résolveur de terminaux, et les deux fonctions de frais.
+  peindre(box, vueChaine({
+    chaine: chain,
+    cargo: f.cargo,
+    terminal: (idx) => MARKET.terminals[idx],
+    fmt,
+    fmtFee,
+    celluleFrais: (lignes, fee, a, b, scu, fees) =>
+      feeCell(feeCtx(f, a.name, b.name, a, b), fees, () => feeCargoText(lignes, a.maxBox), scu > 0),
+    texteProfitLigne: lineProfitText,
+  }));
   notifySuperseded();
 }
 

--- a/vues/chaine.tsx
+++ b/vues/chaine.tsx
@@ -1,0 +1,138 @@
+// La vue Chaîne, troisième îlot React (ADR-008 #96).
+//
+// Ce qu'elle ajoute aux deux précédentes : des CARTES imbriquées — une chaîne porte des sauts, un
+// saut porte un manifeste multi-commodités, et chaque ligne de manifeste porte son propre profit
+// net. La somme des lignes affichées DOIT faire le total du saut affiché à droite, sinon
+// l'incohérence saute aux yeux ; c'est pourquoi le décompte des frais passe par les MÊMES fonctions
+// des deux côtés (`lineProfitText` et `manifestTotals`).
+//
+// La répartition suit celle des deux vues précédentes : le CALCUL vient de logic.ts (pur, testé),
+// l'ÉTAT reste dans app.js — qui passe ici les seules fonctions dépendant de lui, celles des frais.
+import { Fragment } from "react";
+import { manifestTotals, tripMinutes, lineNet } from "../logic.ts";
+import type { Chaine, LigneManifeste, PaireFrais, Terminal } from "../types.ts";
+import { IconeCommodite, TagIllegal, BadgeSysteme } from "./communs.tsx";
+
+type Fmt = (n: number) => string;
+type CelluleFrais = { attr: string; mark: string; text: string };
+
+export type ProprietesChaine = {
+  chaine: Chaine;
+  cargo: number;
+  // `terminal(i)` résout un index en terminal : c'est MARKET qui les porte, et MARKET est une
+  // globale de app.js. L'îlot ne la connaît pas, il reçoit le résolveur.
+  terminal: (idx: number) => Terminal;
+  fmt: Fmt;
+  fmtFee: (n: number, fees: number) => string;
+  // Les frais dépendent de l'état (interrupteur d'autoload, relevés par station) : app.js les
+  // calcule et l'îlot n'en reçoit que le résultat.
+  celluleFrais: (lignes: LigneManifeste[], fee: PaireFrais | null, a: Terminal, b: Terminal, scu: number, fees: number) => CelluleFrais;
+  texteProfitLigne: (units: number, l: LigneManifeste, pair: PaireFrais | null) => string;
+};
+
+const classeProfit = (n: number) => (n < 0 ? "perte" : "profit");
+
+function LigneDeSaut({ l, fee, fmt, texteProfitLigne }: {
+  l: LigneManifeste; fee: PaireFrais | null; fmt: Fmt;
+  texteProfitLigne: ProprietesChaine["texteProfitLigne"];
+}) {
+  return (
+    <div className="chain-line">
+      <div className="commodity-cell">
+        <IconeCommodite kind={l.kind} />
+        <span>{l.name}<TagIllegal illegal={l.illegal} /></span>
+      </div>
+      <span className="chain-line-scu"><b>{fmt(l.units)}</b> SCU</span>
+      <span className="chain-line-price">
+        {fmt(l.buyPrice)} → {fmt(l.sellPrice)} <span className="muted">(marge {fmt(l.margin)}/SCU)</span>
+      </span>
+      <span className={"chain-line-profit " + classeProfit(lineNet(l.units, l, fee))}>
+        {texteProfitLigne(l.units, l, fee)}
+      </span>
+    </div>
+  );
+}
+
+export function VueChaine({ chaine, cargo, terminal, fmt, fmtFee, celluleFrais, texteProfitLigne }: ProprietesChaine) {
+  const totaux = chaine.legs.map((leg) => manifestTotals(leg.lines || [], leg.fee));
+  const invest = totaux[0] ? totaux[0].invest : 0;
+  const totalFees = totaux.reduce((s, t) => s + t.fees, 0);
+  const totalScu = totaux.reduce((s, t) => s + t.scu, 0);
+
+  let minutes = 0;
+  for (let i = 0; i < chaine.legs.length; i++) {
+    minutes += tripMinutes(0, terminal(chaine.path[i]).system !== terminal(chaine.path[i + 1]).system);
+  }
+
+  return (
+    <div className="chain">
+      <div className="chain-head">
+        <span className="chain-path">
+          {chaine.path.map((idx, i) => {
+            const t = terminal(idx);
+            // `Fragment` et NON un <span> englobant : `.chain-path` est un conteneur flex, et
+            // envelopper ses enfants les sortirait du contexte flex — mesuré, ils passaient de
+            // `display: block` à `inline`, et les espaces entre le nom et le badge disparaissaient
+            // (« MegumiPYRO » au lieu de « Megumi PYRO »). Le relevé par rang l'a vu ; une
+            // comparaison par classes ne l'aurait pas vu, les mêmes classes étant présentes.
+            return (
+              <Fragment key={i}>
+                {i > 0 ? <span className="chain-arrow">→</span> : null}
+                <span className="snode term">{t.name}</span>
+                <BadgeSysteme system={t.system} />
+              </Fragment>
+            );
+          })}
+        </span>
+        <span className="chain-tot">
+          Profit <b className="profit">{fmtFee(chaine.profit, totalFees)}</b> aUEC
+          {totalFees > 0 ? ` · frais ≈ ${fmt(totalFees)}` : ""}
+          {" · "}{chaine.legs.length} saut{chaine.legs.length > 1 ? "s" : ""}
+          {" · "}{fmt(totalScu)} SCU chargés · capital de départ {fmt(invest)} · ~{Math.round(minutes)} min
+        </span>
+        {/* L'id est un CONTRAT : app.js y attache l'ajout au voyage. Le renommer casserait le geste
+            sans qu'aucune erreur ne soit levée — le bouton resterait simplement inerte. */}
+        <button id="chainToJourney" className="chain-pick" title="Ajouter cette chaîne au voyage en cours">▶ Ajouter au voyage</button>
+      </div>
+      <div className="chain-legs">
+        {chaine.legs.map((leg, i) => {
+          const a = terminal(chaine.path[i]), b = terminal(chaine.path[i + 1]);
+          const t = totaux[i], lignes = leg.lines || [];
+          const fc = celluleFrais(lignes, leg.fee, a, b, t.scu, t.fees);
+          return (
+            <div className="chain-leg" key={i}>
+              <span className="chain-step">{i + 1}</span>
+              <div className="chain-leg-main">
+                {/* `.loc-sub` est un flex à gouttière : sans le <span> qui enveloppe le volume et
+                    son plafond, la fraction se lirait « 96 /96 » — 6 px les sépareraient. */}
+                <div className="loc-sub">
+                  {a.name} → {b.name} · <span><b className="chain-leg-scu">{fmt(t.scu)}</b>/{fmt(cargo)} SCU</span>
+                  {" · "}{lignes.length} commodité{lignes.length > 1 ? "s" : ""}
+                </div>
+                <div className="chain-lines">
+                  {lignes.map((l, j) => (
+                    <LigneDeSaut key={j} l={l} fee={leg.fee} fmt={fmt} texteProfitLigne={texteProfitLigne} />
+                  ))}
+                </div>
+              </div>
+              <span className="chain-leg-profit profit" title={fc.text || undefined}>
+                +{fmtFee(leg.profit, t.fees)}
+                {fc.mark ? <> <span className="nofee">⊘</span></> : null}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export const vueChaine = (p: ProprietesChaine) => <VueChaine {...p} />;
+
+// Les messages d'attente. Ils passent par React comme le reste : une seule branche restée en
+// innerHTML sur un conteneur possédé par React se ferait écraser au rendu suivant, silencieusement.
+export const indice = (contenu: React.ReactNode) => <div className="manifest-hint">{contenu}</div>;
+
+export const indiceDepart = () => indice(<>Choisis un <b>terminal de départ</b> pour calculer une chaîne rentable.</>);
+export const indiceSoute = () => indice(<>Active la <b>soute (SCU)</b> pour dimensionner la chaîne.</>);
+export const indiceAucune = () => indice(<>Aucune chaîne rentable depuis ce terminal avec ces filtres.</>);

--- a/vues/tournee.tsx
+++ b/vues/tournee.tsx
@@ -13,6 +13,7 @@
 //
 // Le calcul n'est pas ici : `tourneesEcoulement` vit dans logic.ts, pure et couverte par les tests
 // unitaires. Ce fichier ne fait que présenter.
+import { Fragment } from "react";
 import type { Tournee, Destination } from "../types.ts";
 
 // Le formateur de app.js est passé en prop plutôt qu'importé : app.js n'exporte rien (c'est un
@@ -167,11 +168,15 @@ export function VueTournee({ tournee: t, alternative: alt, systeme, toutSysteme,
             {alt.ecartPct != null ? <> <span className="muted">(+{alt.ecartPct.toFixed(1)} %)</span></> : null}
           </div>
           <div className="tour-alt-chemin">
+            {/* `Fragment` et non un <span> englobant : ici `.tour-alt-chemin` n'est pas un flex,
+                donc le rendu ne changerait pas — mais le motif est le même que celui qui a cassé
+                `.chain-path` (enfants sortis du contexte flex, espaces perdus). Autant ne pas le
+                laisser traîner. */}
             {alt.arrets.map((a, i) => (
-              <span key={i}>
+              <Fragment key={i}>
                 {i > 0 ? <span className="tour-fleche">→</span> : null}
                 {i > 0 ? " " : ""}{a.terminal} <span className="muted">({a.lignes.length})</span>{i < alt.arrets.length - 1 ? " " : ""}
-              </span>
+              </Fragment>
             ))}
           </div>
           <div className="tour-alt-note muted">À toi de trancher : l'app ne sait pas si tu as le temps, ni si c'est sur ton chemin.</div>


### PR DESCRIPTION
> **Base : `v2/main`, jamais `main`.** ADR-008 §3.

## Ce que ça change

**La vue Chaîne est rendue par React.** Trois vues sur huit y sont. Le rendu est identique — mesuré.

## Ce qu'elle ajoute aux deux précédentes

Des **cartes imbriquées** : une chaîne porte des sauts, un saut porte un manifeste
multi-commodités, et chaque ligne porte son propre profit net. La somme des lignes affichées doit
faire le total du saut affiché à droite — d'où le même décompte de frais des deux côtés
(`lineProfitText` et `manifestTotals`).

La répartition se stabilise : **l'îlot importe son calcul de `logic.ts`** (`manifestTotals`,
`tripMinutes`, `lineNet`) et ne reçoit de `app.js` que ce qui dépend de l'**état** — le résolveur de
terminaux (`MARKET` est une globale) et les deux fonctions de frais.

## Le relevé a attrapé une vraie régression

C'est la première fois qu'il sert, et il a servi contre **moi**.

Mes `<span key={i}>` autour de chaque nœud du chemin **enveloppaient** les enfants de
`.chain-path` — un conteneur flex.

```
avant   95 formes          première version   99 formes
display: block → inline sur 18 formes
texte   « Megumi PYRO → »  devenait  « MegumiPYRO → »
```

Les espaces entre le nom du terminal et son badge de système disparaissaient. Un `Fragment` porteur
de clé corrige : les enfants redeviennent enfants directs du flex.

**Ce qui compte ici** : l'ancienne version du relevé — celle qui comparait par
`tagname#id.classes` — **ne l'aurait pas vu**. Les mêmes classes étaient présentes des deux côtés ;
seuls le rang et le nombre changeaient. C'est exactement la panne que la correction de l'outil
(PR #109) visait, et elle s'est produite trois PR plus tard.

Le même motif traînait dans `vues/tournee.tsx` (`.tour-alt-chemin`), où il est inoffensif — ce
conteneur n'est pas un flex — mais il est aligné : autant ne pas laisser traîner un patron dangereux.

## Vérification

Relevé scopé à `#chainOut`, clé par rang, 19 propriétés :

```
95 formes comparées · 95 IDENTIQUES · 0 différente · 0 disparue · 0 apparue
texte rendu : identique
```

```
npx tsc --noEmit      0 erreur
node --test           ℹ tests 483 · ℹ pass 483 · ℹ fail 0
npx playwright test   204 collectés · 202 passés · 2 ignorés (1,2 min)
```

Aucun test n'a été touché.

## Ce qui n'est pas couvert

- **`#chainToJourney` garde son id.** `app.js` y attache l'ajout au voyage : le renommer aurait
  rendu le bouton **inerte sans lever d'erreur**.
- **`#chainOrigin` est encore écrit par « En route »** (`syncViewsToJourney`). Ce couplage-là ne se
  résoudra qu'à la migration d'« En route », en dernier.
- **`chainCardHTML` est retiré**, pas laissé mort.
- **Cinq vues restent** : Commodités, Corrections, Plan de vol, Trajets, et « En route » en dernier.

Refs #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)
