### PR TITLE
feat(commodites): la grille et l'aide passent en React, le détail reste vanilla

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,6 +30,7 @@ import { peindre } from "./pont.js";
 import { vueTournee, messageSouteVide, messageChargement, messageOuEsTu } from "./vues/tournee.tsx";
 import { vueBoucles } from "./vues/boucles.tsx";
 import { vueChaine, indiceDepart, indiceSoute, indiceAucune } from "./vues/chaine.tsx";
+import { vueGrilleCommodites, aideBoard } from "./vues/commodites.tsx";
 import { KIND_ICON } from "./vues/communs.tsx";
 
 // Libellé compact des caisses SCU standard, ex. « 8×32 · 1×16 · 1×4 · 1×2 · 1×1 ».
@@ -3419,30 +3420,7 @@ function marginTier(m) {
 // Une tuile du board : code UEX + valeur compacte (K/M), colorée par palier.
 // En Marché la valeur est la marge (heatmap linéaire) ; en Butin le prix de revente
 // (heatmap par rang, cf. valueTiers — les prix s'étalent sur cinq ordres de grandeur).
-function commodityTileHTML(c) {
-  const loot = commBoard === "loot";
-  const val = loot ? c.bestSell : c.margin;
-  const tier = loot ? commTiers.get(c.name) || "t-none" : marginTier(c.margin);
-  const carried = commCarried.has(c.name);
-  const cls = [
-    "comm-tile", tier,
-    c.name === commSelected ? "selected" : "",
-    c.illegal ? "illegal" : "",
-    carried ? "carried" : "",
-    loot && c.sellOnly ? "sell-only" : "",
-  ].filter(Boolean).join(" ");
-  const title = loot
-    ? `${c.name}${c.illegal ? " (illégal)" : ""} — revente max ${fmt(c.bestSell)} aUEC/SCU · ${c.nSell} point(s) de vente${c.sellOnly ? " · introuvable à l'achat — butin / minage" : ""}`
-    : `${c.name}${c.illegal ? " (illégal)" : ""}${carried ? " — transportée dans ton voyage" : ""} — marge max ${fmt(c.margin)} aUEC/SCU · ${c.nBuy} achat(s) / ${c.nSell} vente(s)`;
-  // Le code ne sert d'étiquette que s'il identifie SA commodité ; sinon on retombe sur le nom
-  // (tronqué par CSS), seul moyen de distinguer deux tuiles qui partagent un code UEX.
-  const label = c.code && !commDupCodes.has(c.code) ? c.code : c.name;
-  return `<button class="${cls}" data-name="${esc(c.name)}" title="${esc(title)}">
-      <span class="tile-code">${carried ? '<span class="tile-carried" title="Dans ton voyage">◆</span>' : ""}${esc(label)}</span>
-      <span class="tile-val">${val == null ? "—" : compactValue(val)}</span>
-    </button>`;
-}
-
+// `commodityTileHTML` a été remplacé par vues/commodites.tsx.
 // Mode Butin : la réponse directe à « ça vaut combien ». `p.sells` est déjà trié par prix
 // décroissant, le meilleur point est donc en tête. Prix au SCU seulement — le joueur multiplie
 // par ce qu'il a trouvé, on ne suppose pas une soute pleine.
@@ -3500,7 +3478,7 @@ function syncCommBoardUI() {
   document.querySelectorAll("#commBoardModes button").forEach((b) => b.classList.toggle("active", b.dataset.board === commBoard));
   const first = document.querySelector('#commSortModes button[data-sort="margin"]');
   if (first) first.textContent = loot ? "Revente" : "Marge";
-  $("commHint").innerHTML = loot ? COMM_HINT_LOOT : COMM_HINT_MARKET;
+  peindre($("commHint"), aideBoard(loot));
 }
 
 function setCommBoard(board) {
@@ -3509,6 +3487,24 @@ function setCommBoard(board) {
   commBoard = board;
   renderCommodities(); // la sélection courante est revalidée par le rendu (elle peut disparaître)
   saveState();
+}
+
+// La grille, peinte à part : la sélection d'une tuile la repeint SANS tout recalculer. Avant React,
+// la délégation basculait la classe `selected` à la main sur les nœuds — une mutation qu'un arbre
+// React ne voit pas, et qu'il écraserait au rendu suivant sans savoir qu'elle avait eu lieu.
+function peindreGrilleCommodites() {
+  peindre($("commGrid"), vueGrilleCommodites({
+    lignes: shownCommodities,
+    butin: commBoard === "loot",
+    selection: commSelected,
+    transportees: commCarried,
+    codesAmbigus: commDupCodes,
+    // La heatmap est calculée par app.js : celle du Marché lit une globale (commMaxMargin), celle
+    // du Butin vient de logic.ts (valeurTiers, par rang). L'îlot ne connaît ni l'une ni l'autre.
+    palier: (c) => (commBoard === "loot" ? commTiers.get(c.name) || "t-none" : marginTier(c.margin)),
+    valeurCompacte: compactValue,
+    fmt,
+  }));
 }
 
 function renderCommodities() {
@@ -3535,7 +3531,7 @@ function renderCommodities() {
   // Sélection : garde la commodité choisie si toujours visible, sinon prend la 1re.
   if (commSelected && !rows.some((r) => r.name === commSelected)) commSelected = null;
   if (!commSelected && rows.length) commSelected = rows[0].name;
-  $("commGrid").innerHTML = rows.map(commodityTileHTML).join("");
+  peindreGrilleCommodites();
   // Bouton de mode de tri actif.
   document.querySelectorAll("#commSortModes button").forEach((b) => b.classList.toggle("active", b.dataset.sort === commMode));
   syncCommBoardUI();
@@ -3613,7 +3609,7 @@ async function init() {
     const tile = e.target.closest(".comm-tile");
     if (!tile) return;
     commSelected = tile.dataset.name;
-    document.querySelectorAll("#commGrid .comm-tile").forEach((t) => t.classList.toggle("selected", t.dataset.name === commSelected));
+    peindreGrilleCommodites();
     paintCommodityDetail();
     saveState();
   });

--- a/vues/commodites.tsx
+++ b/vues/commodites.tsx
@@ -1,0 +1,108 @@
+// La vue Commodités — sa GRILLE et son AIDE (ADR-008 #96). Quatrième îlot React.
+//
+// PÉRIMÈTRE VOLONTAIREMENT PARTIEL, et c'est la première fois de la migration. Le panneau de détail
+// (#commDetail) reste en vanilla, parce qu'il rend des `.editv` : des valeurs éditables sur place
+// que `startEdit` MUTE IMPÉRATIVEMENT (`span.replaceChildren(inp)`), depuis une délégation posée sur
+// `document`. Un nœud possédé par React et muté hors de React, c'est la seule situation où les deux
+// modèles se contredisent vraiment — React ne sait pas que le DOM a bougé sous lui.
+//
+// Ce n'est pas une difficulté propre à cette vue : `.editv` est TRANSVERSAL (Commodités,
+// Corrections, Trajets). Il mérite sa propre décision plutôt qu'un contournement local, exactement
+// comme `#empty` a été laissé à app.js lors de la migration de Boucles.
+//
+// Ce qui passe ici : #commGrid (le gros du rendu, une tuile par commodité) et #commHint (le texte
+// d'aide, qui change avec le board).
+import type { ResumeCommodite } from "../types.ts";
+
+type Fmt = (n: number) => string;
+
+export type ProprietesGrille = {
+  lignes: ResumeCommodite[];
+  /** "market" | "loot" — le board change la STRUCTURE, pas seulement des valeurs. */
+  butin: boolean;
+  selection: string | null;
+  /** Les commodités transportées dans le voyage en cours, à surligner. */
+  transportees: Set<string>;
+  /** Les codes UEX qui désignent PLUSIEURS commodités : ils ne peuvent pas servir d'étiquette. */
+  codesAmbigus: Set<string>;
+  /** La classe de heatmap, calculée par app.js : elle diffère selon le board (rang en Butin,
+   *  ratio à la marge max en Marché) et l'une des deux lit une globale. */
+  palier: (c: ResumeCommodite) => string;
+  valeurCompacte: (n: number) => string;
+  fmt: Fmt;
+};
+
+function Tuile({ c, butin, selection, transportees, codesAmbigus, palier, valeurCompacte, fmt }: {
+  c: ResumeCommodite;
+} & Omit<ProprietesGrille, "lignes">) {
+  const val = butin ? c.bestSell : c.margin;
+  const transportee = transportees.has(c.name);
+
+  const classes = [
+    "comm-tile", palier(c),
+    c.name === selection ? "selected" : "",
+    c.illegal ? "illegal" : "",
+    transportee ? "carried" : "",
+    butin && c.sellOnly ? "sell-only" : "",
+  ].filter(Boolean).join(" ");
+
+  // Le title diffère ENTIÈREMENT selon le board — en Butin il omet « transportée dans ton voyage »
+  // alors que la classe `carried` et le ◆ restent posés. Reproduit tel quel.
+  const title = butin
+    ? `${c.name}${c.illegal ? " (illégal)" : ""} — revente max ${fmt(c.bestSell)} aUEC/SCU · ${c.nSell} point(s) de vente${c.sellOnly ? " · introuvable à l'achat — butin / minage" : ""}`
+    : `${c.name}${c.illegal ? " (illégal)" : ""}${transportee ? " — transportée dans ton voyage" : ""} — marge max ${fmt(c.margin)} aUEC/SCU · ${c.nBuy} achat(s) / ${c.nSell} vente(s)`;
+
+  // Le code ne sert d'étiquette que s'il identifie SA commodité ; sinon on retombe sur le nom
+  // (tronqué par CSS), seul moyen de distinguer deux tuiles qui partagent un code UEX. C'est aussi
+  // pourquoi `code` ne peut JAMAIS servir de clé React — deux tuiles peuvent le partager.
+  const etiquette = c.code && !codesAmbigus.has(c.code) ? c.code : c.name;
+
+  return (
+    <button className={classes} data-name={c.name} title={title}>
+      <span className="tile-code">
+        {transportee ? <span className="tile-carried" title="Dans ton voyage">◆</span> : null}
+        {etiquette}
+      </span>
+      <span className="tile-val">{val == null ? "—" : valeurCompacte(val)}</span>
+    </button>
+  );
+}
+
+export function VueGrilleCommodites({ lignes, ...reste }: ProprietesGrille) {
+  // PAS de wrapper autour de la liste : `.comm-grid` est un `display: grid`, et envelopper ses
+  // enfants ferait de TOUT le board une seule cellule de grille. Le même piège a déjà cassé
+  // `.chain-path` (flex) — ici il serait bien plus visible.
+  return (
+    <>
+      {lignes.map((c) => (
+        <Tuile key={c.name} c={c} {...reste} />
+      ))}
+    </>
+  );
+}
+
+export const vueGrilleCommodites = (p: ProprietesGrille) => <VueGrilleCommodites {...p} />;
+
+// ── L'aide du board ────────────────────────────────────────────────────────────────────────────
+// Son texte est aussi DUPLIQUÉ en dur dans index.html (le rendu initial, avant que le marché
+// n'arrive). Les deux doivent rester d'accord : le test ci-dessous n'existe pas, mais un écart se
+// verrait à l'écran pendant la première seconde de chargement.
+export const AIDE_MARCHE = (
+  <>
+    Le <b>board de marché</b> : chaque tuile = une commodité (code UEX) et sa <b>marge max</b>,
+    colorée selon son intérêt. Clique une tuile — ou cherche via le champ <b>Commodité</b> — pour
+    voir <b>tous ses points d'achat / vente</b> (stock, demande, prix) et surtout <b>où l'écouler</b>
+    {" "}quand une station est saturée.
+  </>
+);
+
+export const AIDE_BUTIN = (
+  <>
+    Tu as <b>trouvé</b> une ressource (minage, salvage, caisse abandonnée) ? Ce board liste{" "}
+    <b>tout ce qui se vend</b>, y compris ce qui ne s'achète nulle part, avec son{" "}
+    <b>prix de revente max</b> au SCU. Clique une tuile pour voir <b>où l'écouler</b>. Les tuiles en{" "}
+    <b>pointillés</b> sont introuvables à l'achat.
+  </>
+);
+
+export const aideBoard = (butin: boolean) => (butin ? AIDE_BUTIN : AIDE_MARCHE);


### PR DESCRIPTION
> **Base : `v2/main`, jamais `main`.** ADR-008 §3.

## Ce que ça change

**La grille et l'aide de la vue Commodités sont rendues par React.** Le panneau de détail reste en
vanilla — et c'est une décision, pas un abandon.

## Pourquoi partielle

Le détail rend des **`.editv`** : des valeurs éditables sur place que `startEdit` **mute
impérativement** (`span.replaceChildren(inp)`), depuis une délégation posée sur `document`.

Un nœud possédé par React et muté hors de React, c'est la **seule** situation où les deux modèles se
contredisent vraiment : React ne sait pas que le DOM a bougé sous lui, et son prochain rendu peut
effacer une saisie en cours — la classe de bug que #24, #28, #38 et #55 ont déjà coûtée au dépôt.

Et ce n'est pas propre à cette vue : `.editv` est **transversal** (Commodités, Corrections,
Trajets). Il mérite sa propre décision plutôt qu'un contournement local — exactement comme `#empty`
a été laissé à `app.js` lors de la migration de Boucles.

## Une mutation silencieuse corrigée au passage

La délégation de la grille basculait la classe `selected` **à la main** sur les nœuds
(`classList.toggle`), sans re-rendre. Sur un arbre React, cette mutation est **invisible** : React
ne l'a pas faite, ne la voit pas, et l'écraserait au rendu suivant sans savoir qu'elle avait eu
lieu. La sélection repeint désormais la grille — même coût, et cohérent avec le reste.

## Deux pièges de transcription évités

Tous deux déjà payés ailleurs dans cette migration :

- **Pas de wrapper autour de la liste.** `.comm-grid` est un `display: grid` : envelopper ses
  enfants aurait fait de **tout le board une seule cellule**. Le même piège a cassé `.chain-path`
  (flex) à la PR précédente.
- **`code` ne peut pas servir de clé React.** Deux commodités peuvent partager un code UEX, et un
  e2e l'exige explicitement (« deux tuiles ne portent jamais la même étiquette »). La clé est `name`.

## Vérification

Relevé scopé, clé par rang, 19 propriétés — **sur les deux modes du board**, parce qu'il change la
*structure* et pas seulement des valeurs (classe `sell-only`, nombre de tuiles différent, `title`
entièrement réécrit) :

```
MARCHÉ   grille 231 formes · 231 identiques · 0 disparue · 0 apparue
BUTIN    grille 339 formes · 339 identiques · 0 disparue · 0 apparue
aide       5 formes identiques dans les deux modes
```

Et un **contrat** vérifié en plus du style, sur ce qu'un relevé de formes ne voit pas — identique
dans les deux modes sur les neuf champs :

```
nombre de tuiles · ORDRE · étiquettes · valeurs · classes · titres
sélection · texte de l'aide · texte du détail
```

```
npx tsc --noEmit      0 erreur
node --test           ℹ tests 483 · ℹ pass 483 · ℹ fail 0
npx playwright test   204 collectés · 202 passés · 2 ignorés (1,2 min)
```

Aucun test n'a été touché.

## Ce qui n'est pas couvert

- **`#commDetail` reste en vanilla**, avec ses `.editv`. La question de l'édition sur place se
  traitera pour les trois vues concernées d'un coup.
- **Les boutons de tri et de board restent en vanilla** : ce sont des contrôles statiques
  d'`index.html`, hors de tout conteneur React.
- **`marginTier` reste dans `app.js` et n'a aucun test unitaire** — c'est la heatmap du mode Marché,
  impure (elle lit une globale). Celle du Butin, elle, vit dans `logic.ts` et est testée.
- **`commodityTileHTML` est retiré**, pas laissé mort.
- **Trois vues et demie restent** : Corrections, Plan de vol, Trajets, « En route », plus le détail
  de celle-ci.

Refs #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)
