### PR TITLE
feat(edition): l'édition sur place passe en React, et Commodités est finie

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,7 +30,7 @@ import { peindre } from "./pont.js";
 import { vueTournee, messageSouteVide, messageChargement, messageOuEsTu } from "./vues/tournee.tsx";
 import { vueBoucles } from "./vues/boucles.tsx";
 import { vueChaine, indiceDepart, indiceSoute, indiceAucune } from "./vues/chaine.tsx";
-import { vueGrilleCommodites, aideBoard } from "./vues/commodites.tsx";
+import { vueGrilleCommodites, aideBoard, vueDetailCommodite, inviteDetail } from "./vues/commodites.tsx";
 import { KIND_ICON } from "./vues/communs.tsx";
 
 // Libellé compact des caisses SCU standard, ex. « 8×32 · 1×16 · 1×4 · 1×2 · 1×1 ».
@@ -3435,38 +3435,32 @@ function lootValueHTML(p) {
 function paintCommodityDetail() {
   const box = $("commDetail");
   const loot = commBoard === "loot";
-  if (!commSelected) {
-    box.innerHTML = loot
-      ? '<p class="manifest-hint">Sélectionne une commodité pour savoir combien elle vaut au SCU et où l\'écouler.</p>'
-      : '<p class="manifest-hint">Sélectionne une commodité (ligne du tableau ou champ « Commodité ») pour voir tous ses points d\'achat et de vente.</p>';
-    return;
-  }
+  if (!commSelected) { peindre(box, inviteDetail(loot)); return; }
   // `effVals` : le détail affiche les valeurs CORRIGÉES, comme les tableaux. Et puisqu'elles le
-  // sont, elles passent par `editv` — le même composant qu'ailleurs : marqueur ✎ sur ce qui est
-  // corrigé, et clic pour corriger sur place. Le board devient ainsi le point d'entrée naturel
-  // pour rectifier un prix « chez toutes les stations qui vendent cette commodité ».
-  const p = commodityPoints(MARKET, commSelected, readFilters(), effVals); // avant-postes exclus si le filtre est actif
-  if (!p) { box.innerHTML = ""; return; }
-  const cell = (terminal, side, field, value, updated) =>
-    editv(p.name, terminal, side, field, value, isOv(p.name, terminal, side, field), updated);
-  const buyRow = (b) => `<tr><td class="loc"><div>${esc(b.terminal)}${sysBadge(b.system)}${outpostTag(b.outpost)}</div><div class="loc-sub">${esc(b.planet)}</div></td><td class="num">${cell(b.terminal, "buy", "price", b.price, b.updated)}</td><td class="num">${statusDot(b.status, "buy")} ${cell(b.terminal, "buy", "vol", b.stock, b.updated)}</td><td>${freshChip(b.updated)}</td></tr>`;
-  const sellRow = (s) => `<tr><td class="loc"><div>${esc(s.terminal)}${sysBadge(s.system)}${outpostTag(s.outpost)}</div><div class="loc-sub">${esc(s.planet)}</div></td><td class="num">${cell(s.terminal, "sell", "price", s.price, s.updated)}</td><td class="num">${statusDot(s.status, "sell")} ${cell(s.terminal, "sell", "vol", s.demand, s.updated)}</td><td>${freshChip(s.updated)}</td></tr>`;
-  const table = (rows, head, mapper) => rows.length
-    ? `<table class="comm-points"><thead><tr><th>Terminal</th><th class="num">Prix</th><th class="num">${head}</th><th>Relevé</th></tr></thead><tbody>${rows.map(mapper).join("")}</tbody></table>`
-    : '<p class="muted">Aucun point.</p>';
-  const cols = loot
-    ? `<div class="comm-cols one">
-         <div class="comm-col"><h4>◈ Où l'écouler <span class="muted">(${p.sells.length} · mieux payé d'abord)</span></h4>${table(p.sells, "Demande", sellRow)}</div>
-       </div>`
-    : `<div class="comm-cols">
-         <div class="comm-col"><h4>◈ Où acheter <span class="muted">(${p.buys.length} · moins cher d'abord)</span></h4>${table(p.buys, "Stock", buyRow)}</div>
-         <div class="comm-col"><h4>◈ Où vendre <span class="muted">(${p.sells.length} · mieux payé d'abord)</span></h4>${table(p.sells, "Demande", sellRow)}</div>
-       </div>`;
-  box.innerHTML =
-    `<div class="comm-detail-head">${commodityIcon(p.kind)}<span class="comm-detail-title">${p.code ? `<b class="comm-code">${esc(p.code)}</b> · ` : ""}${esc(p.name)}${illegalTag(p.illegal)}</span>${loot ? lootValueHTML(p) : ""}</div>
-     ${cols}`;
+  // sont, elles passent par une valeur éditable — clic pour corriger sur place. Le board est ainsi
+  // le point d'entrée naturel pour rectifier un prix « chez toutes les stations qui la vendent ».
+  const p = commodityPoints(MARKET, commSelected, readFilters(), effVals);
+  if (!p) { peindre(box, null); return; }
+  peindre(box, vueDetailCommodite({
+    points: p,
+    butin: loot,
+    fmt,
+    fmtVol,
+    estCorrige: (terminal, cote, champ) => isOv(p.name, terminal, cote, champ),
+    // L'ÉCRITURE reste à app.js : lui seul sait qu'un VOLUME doit d'abord figer les jambes déjà
+    // planifiées (avant d'écrire, pour capturer les SCU encore en vigueur), qu'un PRIX ne fige
+    // rien, et que le compteur de corrections doit suivre.
+    corriger: (terminal, cote, champ, valeur, releve) => {
+      if (champ === "vol") pinLegsForVolume(p.name, terminal, cote);
+      setOverride(p.name, terminal, cote, champ, valeur === "" ? null : valeur, Number(releve) || 0);
+      updateOvBadge();
+      refresh();
+    },
+    legendeAchat: BUY_STATUS,
+    legendeVente: SELL_STATUS,
+    texteCapaciteInconnue: VOL_UNKNOWN_HINT,
+  }));
 }
-
 // Textes d'aide : le board ne répond pas à la même question selon le mode.
 const COMM_HINT_MARKET = 'Le <b>board de marché</b> : chaque tuile = une commodité (code UEX) et sa <b>marge max</b>, colorée selon son intérêt. Clique une tuile — ou cherche via le champ <b>Commodité</b> — pour voir <b>tous ses points d\'achat / vente</b> (stock, demande, prix) et surtout <b>où l\'écouler</b> quand une station est saturée.';
 const COMM_HINT_LOOT = 'Tu as <b>trouvé</b> une ressource (minage, salvage, caisse abandonnée) ? Ce board liste <b>tout ce qui se vend</b>, y compris ce qui ne s\'achète nulle part, avec son <b>prix de revente max</b> au SCU. Clique une tuile pour voir <b>où l\'écouler</b>. Les tuiles en <b>pointillés</b> sont introuvables à l\'achat.';
@@ -3863,12 +3857,16 @@ async function init() {
     if (e.target.classList && e.target.classList.contains("jman-qty")) editLegQty(Number(e.target.dataset.leg), Number(e.target.dataset.i), e.target.value);
   });
   // Corrections locales : clic (ou Entrée/Espace) sur une valeur éditable ; bouton reset.
+  // `data-react` : le nœud est rendu par un îlot React, qui gère son édition PAR SON ÉTAT. Sans ce
+  // garde, `startEdit` viendrait le muter (`replaceChildren`) et React écraserait la saisie au
+  // rendu suivant, sans savoir qu'elle avait eu lieu — la classe de bug de #24, #28, #38 et #55.
   document.addEventListener("click", (e) => {
     const span = e.target.closest(".editv");
-    if (span && !span.querySelector("input")) startEdit(span);
+    if (span && !span.dataset.react && !span.querySelector("input")) startEdit(span);
   });
   document.addEventListener("keydown", (e) => {
     if ((e.key === "Enter" || e.key === " ") && e.target.classList && e.target.classList.contains("editv")) {
+      if (e.target.dataset.react) return;
       e.preventDefault();
       startEdit(e.target);
     }

--- a/e2e/edition.pw.mjs
+++ b/e2e/edition.pw.mjs
@@ -1,0 +1,112 @@
+import { test, expect } from "@playwright/test";
+
+// L'édition sur place DANS UN ÎLOT REACT (ADR-008 #96).
+//
+// C'était le dernier mécanisme qui empêchait de migrer une vue : `startEdit` (app.js) MUTE le nœud
+// (`span.replaceChildren(inp)`) depuis une délégation posée sur `document`. Un nœud possédé par
+// React et muté hors de React, c'est la seule situation où les deux modèles se contredisent
+// vraiment — React ne sait pas que le DOM a bougé et écraserait la saisie au rendu suivant.
+//
+// Aucun test n'exerçait l'édition ailleurs que dans la vue Trajets (`#rows`), restée vanilla. Ce
+// fichier couvre le pendant React, dans le détail du board Commodités, et il vérifie les TROIS
+// comportements que la version impérative avait durement acquis — chacun payé par un bug du dépôt.
+
+async function detailOuvert(page) {
+  await page.goto("/index.html");
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+  await page.click("#viewCommodities");
+  await expect(page.locator("#commGrid .comm-tile").first()).toBeVisible({ timeout: 20000 });
+  await expect(page.locator("#commDetail .comm-points tbody tr").first()).toBeVisible({ timeout: 20000 });
+}
+
+const compteur = (page) => page.locator("#viewCorrections .rl").innerText();
+
+test("Édition React : cliquer une valeur ouvre un champ, Entrée l'enregistre (#96)", async ({ page }) => {
+  await detailOuvert(page);
+  const avant = await compteur(page);
+
+  const cellule = page.locator("#commDetail .comm-points tbody .editv").first();
+  await cellule.click();
+  const champ = cellule.locator("input.editv-input");
+  await expect(champ, "le clic n'a pas ouvert de champ — la délégation a-t-elle été rendue inerte ?").toBeVisible();
+
+  await champ.fill("4321");
+  await champ.press("Enter");
+
+  await expect.poll(() => compteur(page), { timeout: 5000 }).not.toBe(avant);
+  await expect(page.locator("#viewCorrections .rl")).toContainText("(1)");
+});
+
+test("Édition React : CONSULTER un chiffre n'écrit rien (#96)", async ({ page }) => {
+  // Le comportement payé par un vrai bug : sans comparaison de valeur, cliquer un chiffre puis
+  // cliquer ailleurs créait une correction locale IDENTIQUE au relevé UEX — compteur, marqueur ✎,
+  // et plus tard un toast « correction périmée » à propos d'une correction fantôme.
+  await detailOuvert(page);
+  await expect(page.locator("#viewCorrections .rl")).toHaveText("Corrections");
+
+  const cellule = page.locator("#commDetail .comm-points tbody .editv").first();
+  await cellule.click();
+  await expect(cellule.locator("input.editv-input")).toBeVisible();
+  await page.locator("h1").click(); // on quitte sans rien changer
+
+  await expect(page.locator("#viewCorrections .rl"), "consulter a créé une correction fantôme").toHaveText("Corrections");
+});
+
+test("Édition React : Échap annule sans re-rendre toute la vue (#96)", async ({ page }) => {
+  // L'autre comportement acquis : un refresh() global détruirait le nœud entre le mousedown et le
+  // mouseup, ce qui avalait le clic suivant sur une AUTRE cellule. On vérifie donc qu'après une
+  // annulation, la cellule voisine s'ouvre du premier coup.
+  await detailOuvert(page);
+  const cellules = page.locator("#commDetail .comm-points tbody .editv");
+
+  await cellules.nth(0).click();
+  await expect(cellules.nth(0).locator("input.editv-input")).toBeVisible();
+  await cellules.nth(0).locator("input.editv-input").press("Escape");
+  await expect(cellules.nth(0).locator("input.editv-input")).toHaveCount(0);
+
+  await cellules.nth(1).click();
+  await expect(
+    cellules.nth(1).locator("input.editv-input"),
+    "le clic suivant a été avalé — l'annulation a re-rendu la vue au lieu de rendre la main"
+  ).toBeVisible();
+
+  await expect(page.locator("#viewCorrections .rl")).toHaveText("Corrections");
+});
+
+test("Édition React : la valeur corrigée porte son marqueur et survit au re-rendu (#96)", async ({ page }) => {
+  await detailOuvert(page);
+  const cellule = page.locator("#commDetail .comm-points tbody .editv").first();
+  await cellule.click();
+  await cellule.locator("input.editv-input").fill("777");
+  await cellule.locator("input.editv-input").press("Enter");
+
+  // Le ✎ reste DANS le span : le sortir casserait la restauration (#30).
+  const corrigee = page.locator("#commDetail .comm-points tbody .editv.ov").first();
+  await expect(corrigee).toBeVisible();
+  await expect(corrigee.locator(".ovmark")).toHaveCount(1);
+  await expect(corrigee).toContainText("777");
+
+  // Et elle survit à un re-rendu déclenché d'ailleurs — c'est tout l'intérêt d'une correction.
+  await page.click("#viewRoutes");
+  await page.click("#viewCommodities");
+  await expect(page.locator("#commDetail .comm-points tbody .editv.ov").first()).toContainText("777");
+});
+
+test("Édition React : app.js ne vient PAS muter un nœud possédé par React (#96)", async ({ page }) => {
+  // Le garde qui rend tout le reste possible : les deux délégations de app.js ignorent un `.editv`
+  // marqué `data-react`. S'il sautait, `startEdit` muterait le nœud — et le symptôme serait un
+  // DOUBLE champ, ou une saisie écrasée au rendu suivant.
+  await detailOuvert(page);
+  const cellule = page.locator("#commDetail .comm-points tbody .editv").first();
+  await expect(cellule).toHaveAttribute("data-react", "1");
+
+  await cellule.click();
+  await expect(cellule.locator("input.editv-input"), "deux champs : startEdit est venu muter le nœud React").toHaveCount(1);
+
+  // Et les valeurs éditables de la vue Trajets, elles, restent gérées par app.js.
+  await page.click("#viewRoutes");
+  const vanilla = page.locator("#rows .editv").first();
+  await expect(vanilla).not.toHaveAttribute("data-react", "1");
+  await vanilla.click();
+  await expect(vanilla.locator("input")).toBeVisible();
+});

--- a/vues/commodites.tsx
+++ b/vues/commodites.tsx
@@ -13,6 +13,7 @@
 // Ce qui passe ici : #commGrid (le gros du rendu, une tuile par commodité) et #commHint (le texte
 // d'aide, qui change avec le board).
 import type { ResumeCommodite } from "../types.ts";
+import { IconeCommodite, TagIllegal, BadgeSysteme } from "./communs.tsx";
 
 type Fmt = (n: number) => string;
 
@@ -106,3 +107,116 @@ export const AIDE_BUTIN = (
 );
 
 export const aideBoard = (butin: boolean) => (butin ? AIDE_BUTIN : AIDE_MARCHE);
+
+// ── Le panneau de DÉTAIL ───────────────────────────────────────────────────────────────────────
+// Il était resté en vanilla à la PR précédente parce qu'il rend des `.editv`, que `startEdit`
+// mutait impérativement. `ValeurEditable` (communs.tsx) lève cet obstacle : l'édition passe
+// désormais par l'état React, et les deux délégations d'app.js ignorent ces nœuds.
+import { ValeurEditable, PastilleStatut, PastilleFraicheur, TagAvantPoste } from "./communs.tsx";
+import type { DetailCommodite, PointAchatCommodite, PointVenteCommodite } from "../types.ts";
+
+export type ProprietesDetail = {
+  points: DetailCommodite;
+  butin: boolean;
+  fmt: Fmt;
+  fmtVol: (n: number | null) => string;
+  /** Une correction locale porte-t-elle déjà sur ce point ? */
+  estCorrige: (terminal: string, cote: "buy" | "sell", champ: "price" | "vol") => boolean;
+  /** app.js écrit la correction — il sait figer les jambes, mettre le compteur à jour et re-rendre. */
+  corriger: (terminal: string, cote: "buy" | "sell", champ: "price" | "vol", valeur: string, releve: number) => void;
+  legendeAchat: Record<number, [string, string]>;
+  legendeVente: Record<number, [string, string]>;
+  texteCapaciteInconnue: string;
+};
+
+function LignePoint({ p, cote, ...r }: { p: PointAchatCommodite | PointVenteCommodite; cote: "buy" | "sell" } & Omit<ProprietesDetail, "points" | "butin" | "fmt">) {
+  // Le champ de volume porte un NOM différent selon le côté — `stock` à l'achat, `demand` à la
+  // vente — et c'est voulu : ce ne sont pas la même chose. `demand: null` veut dire « capacité
+  // inconnue chez UEX », ni zéro ni illimitée.
+  const volume = cote === "buy"
+    ? (p as PointAchatCommodite).stock
+    : (p as PointVenteCommodite).demand;
+  const cellule = (champ: "price" | "vol", valeur: number | null | undefined) => (
+    <ValeurEditable
+      valeur={valeur ?? null}
+      corrige={r.estCorrige(p.terminal, cote, champ)}
+      fmtVol={r.fmtVol}
+      texteCapaciteInconnue={r.texteCapaciteInconnue}
+      onCorriger={(v) => r.corriger(p.terminal, cote, champ, v, p.updated)}
+    />
+  );
+  return (
+    <tr>
+      <td className="loc">
+        <div>{p.terminal}<BadgeSysteme system={p.system} /><TagAvantPoste outpost={p.outpost} /></div>
+        <div className="loc-sub">{p.planet}</div>
+      </td>
+      <td className="num">{cellule("price", p.price)}</td>
+      {/* L'espace entre la pastille et la valeur est LITTÉRAL dans la version d'origine, et il
+          subsiste seul quand le code de statut est absent. Reproduit tel quel. */}
+      <td className="num">
+        <PastilleStatut code={p.status} cote={cote}
+                        legende={cote === "buy" ? r.legendeAchat : r.legendeVente} />
+        {" "}
+        {cellule("vol", volume)}
+      </td>
+      <td><PastilleFraicheur updated={p.updated} /></td>
+    </tr>
+  );
+}
+
+function TablePoints({ lignes, entete, cote, ...r }: {
+  lignes: (PointAchatCommodite | PointVenteCommodite)[]; entete: string; cote: "buy" | "sell";
+} & Omit<ProprietesDetail, "points" | "butin" | "fmt">) {
+  if (!lignes.length) return <p className="muted">Aucun point.</p>;
+  return (
+    <table className="comm-points">
+      <thead><tr><th>Terminal</th><th className="num">Prix</th><th className="num">{entete}</th><th>Relevé</th></tr></thead>
+      <tbody>{lignes.map((p, i) => <LignePoint key={i} p={p} cote={cote} {...r} />)}</tbody>
+    </table>
+  );
+}
+
+export function VueDetailCommodite({ points: p, butin, fmt, ...r }: ProprietesDetail) {
+  const meilleur = p.sells[0];
+  return (
+    <>
+      <div className="comm-detail-head">
+        <IconeCommodite kind={p.kind} />
+        <span className="comm-detail-title">
+          {p.code ? <><b className="comm-code">{p.code}</b> · </> : null}
+          {p.name}<TagIllegal illegal={p.illegal} />
+        </span>
+        {/* La valeur de revente n'existe QU'en mode Butin : quand l'acquisition est gratuite, la
+            marge n'a pas de sens, seul compte le prix au SCU. */}
+        {butin ? (
+          meilleur
+            ? <span className="loot-value"><b>{fmt(meilleur.price)}</b> aUEC/SCU<span className="loot-where">au mieux — {meilleur.terminal} ({meilleur.system})</span></span>
+            : <span className="loot-value muted">aucun point de vente</span>
+        ) : null}
+      </div>
+      <div className={butin ? "comm-cols one" : "comm-cols"}>
+        {butin ? null : (
+          <div className="comm-col">
+            <h4>◈ Où acheter <span className="muted">({p.buys.length} · moins cher d'abord)</span></h4>
+            <TablePoints lignes={p.buys} entete="Stock" cote="buy" {...r} />
+          </div>
+        )}
+        <div className="comm-col">
+          <h4>◈ Où {butin ? "l'écouler" : "vendre"} <span className="muted">({p.sells.length} · mieux payé d'abord)</span></h4>
+          <TablePoints lignes={p.sells} entete="Demande" cote="sell" {...r} />
+        </div>
+      </div>
+    </>
+  );
+}
+
+export const vueDetailCommodite = (p: ProprietesDetail) => <VueDetailCommodite {...p} />;
+
+export const inviteDetail = (butin: boolean) => (
+  <p className="manifest-hint">
+    {butin
+      ? "Sélectionne une commodité pour savoir combien elle vaut au SCU et où l'écouler."
+      : "Sélectionne une commodité (ligne du tableau ou champ « Commodité ») pour voir tous ses points d'achat et de vente."}
+  </p>
+);

--- a/vues/communs.tsx
+++ b/vues/communs.tsx
@@ -68,3 +68,110 @@ export function CelluleFiabilite({ f, age, part }: { f: number; age: number | nu
     </div>
   );
 }
+
+// ── L'édition sur place ────────────────────────────────────────────────────────────────────────
+// Le pendant React d'`editv` + `startEdit` (app.js). C'était le dernier mécanisme qui empêchait de
+// migrer une vue : `startEdit` MUTE le nœud (`span.replaceChildren(inp)`) depuis une délégation
+// posée sur `document`, et un nœud possédé par React et muté hors de React, c'est la seule
+// situation où les deux modèles se contredisent vraiment.
+//
+// Ici l'édition passe par l'ÉTAT, pas par la mutation — ce qui rend gratuit ce que la version
+// impérative devait organiser : elle mémorisait les enfants détachés pour pouvoir annuler sans
+// re-rendu global. React n'a qu'à repasser `enEdition` à false.
+//
+// TROIS COMPORTEMENTS À PRÉSERVER, chacun payé par un bug du dépôt :
+//   1. CONSULTER n'écrit rien. Sans la comparaison de valeur, cliquer un chiffre puis cliquer
+//      ailleurs créait une correction locale IDENTIQUE au relevé UEX — compteur, marqueur ✎, et
+//      plus tard un toast « correction périmée » à propos d'une correction fantôme.
+//   2. ANNULER ne re-rend pas globalement. Un refresh() détruirait le nœud entre le mousedown et
+//      le mouseup, ce qui avalait le clic suivant sur une autre cellule.
+//   3. Le `✎` reste DANS le span. Le sortir casserait la restauration (#30, cf. app.js).
+import { useState, useRef, useEffect } from "react";
+
+export type ProprietesValeurEditable = {
+  valeur: number | null;
+  /** true quand une correction locale porte déjà sur ce point : le ✎ s'affiche. */
+  corrige: boolean;
+  /** Rend « n.c. » pour une capacité qu'UEX ne publie pas — ni zéro, ni illimitée. */
+  fmtVol: (n: number | null) => string;
+  /** Appelé UNIQUEMENT si la valeur a changé. app.js écrit alors la correction et re-rend. */
+  onCorriger: (valeur: string) => void;
+  texteCapaciteInconnue: string;
+};
+
+export function ValeurEditable({ valeur, corrige, fmtVol, onCorriger, texteCapaciteInconnue }: ProprietesValeurEditable) {
+  const [enEdition, setEnEdition] = useState(false);
+  const champ = useRef<HTMLInputElement>(null);
+  const fini = useRef(false);
+
+  useEffect(() => {
+    if (enEdition && champ.current) { champ.current.focus(); champ.current.select(); }
+  }, [enEdition]);
+
+  const inconnue = valeur == null || !Number.isFinite(Number(valeur));
+  const v = inconnue ? "" : String(valeur);
+
+  const ouvrir = () => { fini.current = false; setEnEdition(true); };
+
+  const clore = (enregistrer: boolean) => {
+    if (fini.current) return;
+    fini.current = true;
+    const saisi = champ.current ? champ.current.value : v;
+    // On sort de l'édition DANS TOUS LES CAS, et avant d'écrire. React réutilise l'instance du
+    // composant au même emplacement : après `refresh()`, l'état local SURVIT au re-rendu, et le
+    // champ resterait ouvert sur l'ancienne valeur. La version impérative n'avait pas ce problème —
+    // elle recréait le DOM entier. Mesuré : sans cette ligne, la cellule corrigée gardait son
+    // <input> et son ✎ n'apparaissait jamais.
+    setEnEdition(false);
+    // Comportement 1 : rien n'a changé, rien ne s'écrit. Comportement 2 : l'annulation ne déclenche
+    // aucun re-rendu global — sortir de l'édition suffit.
+    if (enregistrer && saisi !== v) onCorriger(saisi);
+  };
+
+  if (enEdition) {
+    return (
+      <span className={"editv" + (inconnue ? " nc" : "") + (corrige ? " ov" : "")} data-react="1">
+        <input
+          ref={champ}
+          type="number"
+          min="0"
+          defaultValue={v}
+          className="editv-input"
+          onKeyDown={(e) => {
+            if (e.key === "Enter") { e.preventDefault(); clore(true); }
+            else if (e.key === "Escape") { e.preventDefault(); clore(false); }
+          }}
+          onBlur={() => clore(true)}
+        />
+      </span>
+    );
+  }
+
+  return (
+    // `data-react` fait que les deux délégations d'app.js (clic et clavier) passent leur chemin :
+    // ce nœud gère son édition lui-même. Sans ce marqueur, `startEdit` viendrait le muter et React
+    // écraserait la saisie au rendu suivant, sans savoir qu'elle avait eu lieu.
+    <span
+      className={"editv" + (inconnue ? " nc" : "") + (corrige ? " ov" : "")}
+      data-react="1"
+      role="button"
+      tabIndex={0}
+      title={inconnue ? `${texteCapaciteInconnue}. Clic pour le corriger localement` : "Clic pour corriger localement ce chiffre"}
+      onClick={ouvrir}
+      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); ouvrir(); } }}
+    >
+      {fmtVol(valeur)}
+      {corrige ? <span className="ovmark" title="Corrigé localement">✎</span> : null}
+    </span>
+  );
+}
+
+// La pastille de statut d'inventaire UEX. Elle rend RIEN quand le code est absent — et l'espace qui
+// la sépare de la valeur reste alors seul en tête de cellule, comme dans la version d'origine.
+export function PastilleStatut({ code, cote, legende }: {
+  code: number; cote: "buy" | "sell"; legende: Record<number, [string, string]>;
+}) {
+  const s = legende[code];
+  if (!s) return null;
+  return <span className={"sdot s-" + s[1]} title={(cote === "buy" ? "Stock à l'achat" : "Demande à la vente") + " : " + s[0]} />;
+}


### PR DESCRIPTION
> **Base : `v2/main`, jamais `main`.** ADR-008 §3.

## Ce que ça change

**L'édition sur place fonctionne dans un îlot React**, et la vue Commodités est finie — son panneau
de détail était resté en vanilla à la PR précédente à cause de ce mécanisme.

C'était le dernier obstacle **transversal** : il bloquait aussi Corrections et Trajets.

## Le problème

`startEdit` **mute** le nœud — `span.replaceChildren(inp)` — depuis une délégation posée sur
`document`. Un nœud possédé par React et muté hors de React, c'est la **seule** situation où les
deux modèles se contredisent vraiment : React ne sait pas que le DOM a bougé, et son prochain rendu
écrase la saisie.

## La solution, et ce qu'elle simplifie

L'édition passe par **l'état**, pas par la mutation. Ce qui rend gratuit ce que la version
impérative devait organiser : elle mémorisait les enfants détachés pour pouvoir annuler sans
re-rendu global — React n'a qu'à repasser `enEdition` à `false`.

Les deux délégations d'`app.js` ignorent désormais un `.editv` marqué `data-react`. Les valeurs
éditables des vues encore vanilla (Trajets, En route) continuent de passer par `startEdit`,
inchangé — **un test le vérifie des deux côtés**.

## Trois comportements préservés, chacun payé par un bug

| comportement | ce qu'il évite |
|---|---|
| **consulter n'écrit rien** | une correction identique au relevé UEX, puis un toast « correction périmée » à propos d'une correction fantôme |
| **annuler ne re-rend pas** | un `refresh()` détruirait le nœud entre le mousedown et le mouseup, avalant le clic suivant |
| **le `✎` reste dans le span** | casserait la restauration (#30) |

Aucun n'était couvert : la suite n'éditait que dans la vue Trajets, restée vanilla. Ils le sont
maintenant, y compris le deuxième — le test ouvre une cellule, annule, et vérifie que la **voisine
s'ouvre du premier coup**.

## Un bug trouvé par son propre test

Après validation, le composant **restait en mode édition**. React réutilise l'instance au même
emplacement, donc l'état local **survit** au `refresh()` — là où la version impérative recréait le
DOM entier. La cellule corrigée gardait son `<input>` et son `✎` n'apparaissait jamais :

```
"<span class=\"editv ov\" data-react=\"1\"><input … value=\"283500\"></span>"
```

Ni le typecheck ni les 204 tests existants ne l'auraient vu. C'est un bug qui **n'existe que parce
qu'on est passé à React**, et il ne pouvait être attrapé que par un test écrit pour ce mécanisme.

## Vérification

Relevé scopé à `#commDetail`, clé par rang, 19 propriétés, dans les **deux modes** :

```
MARCHÉ   54 formes · 54 identiques · 0 disparue · 0 apparue · texte identique
BUTIN    33 formes · 32 identiques · 0 disparue · 0 apparue · texte identique
```

L'unique écart est une marge `auto` à **0,047 px** près (513,797 → 513,75) : le même motif que dans
la Tournée — les espaces d'indentation que le template produisait et que React n'émet pas, dans un
conteneur poussé à droite.

```
npx tsc --noEmit      0 erreur
node --test           ℹ tests 483 · ℹ pass 483 · ℹ fail 0
npx playwright test   209 collectés · 207 passés · 2 ignorés (1,4 min)   (204 avant : 5 neufs)
```

## Ce qui n'est pas couvert

- **`#empty` reste bloqué** : le message vide partagé par Trajets, Boucles et En route. Il migrera
  avec Trajets.
- **Les tableaux indexés par rang** (`shownRoutes`, `shownLoops`…) que les délégations `document`
  lisent — probablement la dernière PR de la migration.
- **`startEdit` n'est pas retiré** : il sert encore les vues vanilla. Il disparaîtra avec la
  dernière d'entre elles.
- **Trois vues restent** : Corrections (dont c'est le cœur, désormais débloquée), Plan de vol,
  Trajets, et « En route » en dernier.

Refs #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)
