### PR TITLE
feat(corrections): la vue Corrections passe en React — cinq vues sur huit

### DIFF
--- a/app.js
+++ b/app.js
@@ -31,6 +31,7 @@ import { vueTournee, messageSouteVide, messageChargement, messageOuEsTu } from "
 import { vueBoucles } from "./vues/boucles.tsx";
 import { vueChaine, indiceDepart, indiceSoute, indiceAucune } from "./vues/chaine.tsx";
 import { vueGrilleCommodites, aideBoard, vueDetailCommodite, inviteDetail } from "./vues/commodites.tsx";
+import { vueStation, vueBandeCorrections, inviteStation } from "./vues/corrections.tsx";
 import { KIND_ICON } from "./vues/communs.tsx";
 
 // Libellé compact des caisses SCU standard, ex. « 8×32 · 1×16 · 1×4 · 1×2 · 1×1 ».
@@ -3214,128 +3215,20 @@ function stationFeeHTML(S) {
 }
 
 // Tableau éditable des commodités d'une station (prix/stock à l'achat, prix/demande à la vente).
-function stationTableHTML(S, q) {
-  const t = MARKET.terminals[S];
-  // DEUX sections : ce qu'on peut acheter ici, puis ce qu'on peut y vendre. Mesuré sur
-  // l'instantané : aucune commodité n'est des deux côtés au même comptoir (0 sur 2 373 couples,
-  // 114 stations) — un terminal achète ou vend, jamais les deux. La règle « les deux -> avec les
-  // achats » est donc écrite mais inerte ; elle protège d'un changement de données, pas d'un cas
-  // observé. La répartition, elle, est très déséquilibrée : GrimHEX offre 3 achats pour 89 ventes,
-  // et ces trois-là se perdaient au milieu des quatre-vingt-neuf autres.
-  const achats = [], ventes = [];
-  MARKET.commodities.forEach((c) => {
-    if (q && !c.name.toLowerCase().includes(q)) return;
-    const b = c.buys.find((x) => x[0] === S);
-    const s = c.sells.find((x) => x[0] === S);
-    if (!b && !s) return;
-    const cote = (p, side, libelle, unite) => {
-      const e = effVals(c.name, t.name, side, p[1], p[2], p[3]);
-      // Les boutons de retour vivent sur LEUR PROPRE ligne, sous les valeurs. Glissés parmi
-      // elles, ils comprimaient le texte de l'étiquette dans une tuile large de 236 px : « aUEC ·
-      // stock » se coupait en deux.
-      const retours = retourUEX(c.name, t.name, side, "price", p[1], e.oprice)
-        + retourUEX(c.name, t.name, side, "vol", p[2], e.ovol);
-      return `<div class="scomm-side"><span class="scomm-lbl">${libelle}</span>` +
-        `${editv(c.name, t.name, side, "price", e.price, e.oprice, p[3])} aUEC · ${unite} ` +
-        `${editv(c.name, t.name, side, "vol", e.vol, e.ovol, p[3])}</div>` +
-        (retours ? `<div class="scomm-undos">${retours}</div>` : "");
-    };
-    // Une seule ligne par côté RÉEL : plus de « achat — » à afficher sous chaque vente.
-    const corps = (b ? cote(b, "buy", "achat", "stock") : "") + (s ? cote(s, "sell", "vente", "dem.") : "");
-    // La classe porte le côté : c'est elle qui donne au liseré et à l'étiquette leur couleur.
-    // Nécessaire depuis qu'une tuile n'affiche plus qu'une ligne — l'en-tête de section sort de
-    // l'écran au défilement, et il ne restait alors rien pour dire ce qu'on regarde.
-    const tuile = `<div class="scomm ${b ? "achat" : "vente"}">
-        <div class="scomm-name">${commodityIcon(c.kind)}<span>${esc(c.name)}${illegalTag(c.illegal)}</span></div>
-        ${corps}
-      </div>`;
-    (b ? achats : ventes).push(tuile);
-  });
-
-  // Le panneau de frais N'EST PLUS rendu ici : il part dans #correctionsFees, hors du conteneur que
-  // renderCorrections réécrit à chaque rendu (#24). Il en sortait par DEUX chemins — l'interpolation
-  // nominale et la branche « aucune commodité » ci-dessous.
-  const total = achats.length + ventes.length;
-  const hero = stationHeroHTML(S, total, q);
-  if (!total) return `${hero}<p class="empty">Aucune commodité ${q ? "correspondante " : ""}à ${esc(t.name)}.</p>`;
-  const section = (cle, titre, aide, tuiles) => tuiles.length
-    ? `<div class="station-section"><h4 class="station-section-head ${cle}">◈ ${titre} <span class="station-count">${tuiles.length}</span><span class="station-section-aide">${aide}</span></h4>
-       <div class="station-grid">${tuiles.join("")}</div></div>`
-    : "";
-  return `${hero}
-    ${section("achat", "On y achète", "ce que la station te vend — prix et stock", achats)}
-    ${section("vente", "On y vend", "ce qu'elle te reprend — prix et demande", ventes)}`;
-}
-
+// `stationTableHTML` a été remplacé par vues/corrections.tsx.
 // Bandeau COLLANT de la station affichée : sa photo, son nom, sa zone, son code, et ce qu'on y a
 // corrigé. Il remplace la ligne de titre, qui sortait de l'écran au premier coup de molette — après
 // quoi plus rien ne disait quelle station on éditait, au milieu de 92 tuiles.
-function stationHeroHTML(S, total, q) {
-  const t = MARKET.terminals[S];
-  const n = Object.keys(OVERRIDES).filter((k) => k.split("|")[1] === t.name).length;
-  const vign = vignetteStation({ name: t.name, system: t.system, code: t.code || "", shot: t.shot || "" });
-  // Crédit à l'auteur de la capture, et SEULEMENT s'il existe : 97 terminaux ont une photo pour 89
-  // auteurs, donc huit afficheraient sinon un « photo : » suivi de rien.
-  const credit = t.shot && t.shotBy ? `<span class="stn-hero-credit">photo : ${esc(t.shotBy)}</span>` : "";
-  return `<div class="stn-hero">
-    ${vign}
-    <div class="stn-hero-txt">
-      <div class="stn-hero-line">
-        <span class="stn-hero-name">${esc(t.name)}</span>${sysBadge(t.system)}
-        <span class="stn-hero-zone">${esc(t.planet || "Espace profond")}</span>
-        <span class="stn-hero-code">${esc(t.code || "")}</span>
-        <span class="station-count">${total} commodité${total > 1 ? "s" : ""}${q ? " filtrées" : ""}</span>
-        ${n ? `<button type="button" id="stnClear" class="reset-ov" title="Effacer les corrections de cette station">✕ ${n} correction${n > 1 ? "s" : ""}</button>` : ""}
-      </div>
-      <div class="stn-hero-sub">clique un chiffre pour le corriger localement${credit}</div>
-    </div>
-  </div>`;
-}
-
+// `stationHeroHTML` a été remplacé par vues/corrections.tsx.
 // Retour à la valeur UEX d'un chiffre corrigé. Contrôle DÉDIÉ, posé dans la tuile et hors du
 // `.editv` : celui-ci porte déjà `role="button"`, et y imbriquer un second bouton serait invalide en
 // ARIA — tandis que sortir le `✎` casserait la restauration de startEdit (qui mémorise puis rejoue
 // les childNodes du span) et l'assertion qui la couvre. Il annonce la valeur vers laquelle il
 // ramène : c'est ce que l'ancienne liste plate ne montrait jamais.
-function retourUEX(commodity, terminal, side, field, brut, ov) {
-  if (!ov) return "";
-  const v = Number.isFinite(Number(brut)) ? Number(brut) : null;
-  const quoi = field === "price" ? "le prix" : side === "buy" ? "le stock" : "la demande";
-  return `<button type="button" class="scomm-undo" data-c="${esc(commodity)}" data-t="${esc(terminal)}" data-s="${side}" data-f="${field}"` +
-    ` title="Revenir à ${quoi} publié par UEX">↺ ${fmtVol(v)}</button>`;
-}
-
+// `retourUEX` a été remplacé par vues/corrections.tsx.
 // La bande : une vignette par station corrigée, la station affichée épinglée en tête. C'est elle qui
 // remplace la liste plate — vingt corrections y tenaient en 900 px, elles tiennent ici en une rangée.
-function correctionsIndexHTML() {
-  const actif = stationSel != null ? MARKET.terminals[stationSel].name : null;
-  const groupes = groupOverridesByTerminal(OVERRIDES, actif);
-  if (!groupes.length) {
-    return '<p class="empty">Aucune correction locale pour l\'instant. Cherche une station ci-dessus pour en créer.</p>';
-  }
-  const autres = groupes.filter((g) => !g.actif);
-  const total = groupes.reduce((s, g) => s + g.corrections, 0);
-  const tuiles = groupes.map((g) => {
-    const t = termByName.get(g.terminal);
-    // Terminal disparu de market.json : la vignette s'affiche quand même, sinon la correction
-    // deviendrait invisible ET ineffaçable. Elle n'est simplement pas cliquable.
-    const vign = vignetteStation({ name: g.terminal, system: t ? t.system : "", code: t ? t.code || "" : "", shot: t ? t.shot || "" : "" });
-    return `<button type="button" class="stn-tile${g.actif ? " active" : ""}${t ? "" : " orphelin"}"` +
-      `${g.actif ? ' aria-current="true"' : ""} data-terminal="${esc(g.terminal)}"${t ? "" : " disabled"}>` +
-      `${vign}<span class="stn-tile-name">${esc(g.terminal)}</span>` +
-      `<span class="stn-tile-meta">${t ? sysBadge(t.system) : '<span class="sys">inconnu</span>'}` +
-      `<b>${g.corrections}</b></span>` +
-      `${g.actif ? '<span class="stn-tile-flag">en cours</span>' : ""}</button>`;
-  }).join("");
-  // Le bouton d'export précède « Tout réinitialiser » — c'est l'ordre des gestes : on emporte ses
-  // relevés avant de les effacer. Comme la bande, il n'existe que s'il y a quelque chose à sortir.
-  return `<div class="corr-list-head">
-      <span>◈ ${autres.length ? `${autres.length} autre${autres.length > 1 ? "s" : ""} station${autres.length > 1 ? "s" : ""} · ` : ""}${total} correction${total > 1 ? "s" : ""}</span>
-      <button id="exportCorrections" class="copy-btn" title="Copier toutes les corrections locales, avec leur date de saisie et leur date UEX">⧉ Exporter</button>
-      <button id="resetAll" class="reset-ov">Tout réinitialiser</button>
-    </div><div class="stn-band">${tuiles}</div>`;
-}
-
+// `correctionsIndexHTML` a été remplacé par vues/corrections.tsx.
 // Les corrections, en JSON daté, dans le presse-papiers. Du JSON et non du texte libre — celui-ci
 // est fait pour être RELU (cf. relireCorrections), et une correction qu'on ne peut pas dater est
 // une correction qu'on réappliquerait aveuglément des semaines plus tard.
@@ -3357,17 +3250,78 @@ function autoloadListHTML() {
   return `<div class="corr-list-head"><span>${keys.length} relevé${keys.length > 1 ? "s" : ""} d'autoload</span><button id="resetAllK" class="reset-ov">Tout oublier</button></div>${items}`;
 }
 
+// Prépare les tuiles d'une station pour l'îlot : app.js reste le seul à lire MARKET et à appeler
+// `effVals` — dont la purge d'une correction périmée est un effet de bord assumé.
+function tuilesStation(S, q) {
+  const t = MARKET.terminals[S];
+  const tuiles = [];
+  MARKET.commodities.forEach((c) => {
+    if (q && !c.name.toLowerCase().includes(q)) return;
+    const b = c.buys.find((x) => x[0] === S);
+    const s = c.sells.find((x) => x[0] === S);
+    if (!b && !s) return;
+    const cote = (p, side, libelle, unite) => {
+      const e = effVals(c.name, t.name, side, p[1], p[2], p[3]);
+      return {
+        cote: side, libelle, unite,
+        prix: e.price, volume: e.vol,
+        prixCorrige: e.oprice, volumeCorrige: e.ovol,
+        prixBrut: p[1], volumeBrut: p[2],
+        releve: p[3],
+      };
+    };
+    const cotes = [];
+    if (b) cotes.push(cote(b, "buy", "achat", "stock"));
+    if (s) cotes.push(cote(s, "sell", "vente", "dem."));
+    // Une seule ligne par côté RÉEL. La classe de la tuile porte le côté : c'est elle qui donne au
+    // liseré et à l'étiquette leur couleur, nécessaire depuis que l'en-tête de section sort de
+    // l'écran au défilement.
+    tuiles.push({ nom: c.name, kind: c.kind, illegal: c.illegal, achat: !!b, cotes });
+  });
+  return tuiles;
+}
+
+// Les stations corrigées, la station affichée épinglée en tête.
+function groupesCorrections() {
+  const actif = stationSel != null ? MARKET.terminals[stationSel].name : null;
+  return groupOverridesByTerminal(OVERRIDES, actif).map((g) => ({
+    terminal: g.terminal,
+    corrections: g.corrections,
+    actif: g.actif,
+    // `null` quand le terminal a disparu de market.json : la vignette s'affiche quand même, sinon
+    // la correction deviendrait invisible ET ineffaçable.
+    info: termByName.get(g.terminal) || null,
+  }));
+}
+
 function renderCorrections() {
   if (!MARKET) { withMarket(refresh); return; }
   if (!enrouteReady) setupEnRoute();
   resolveStation();
   const q = $("search").value.trim().toLowerCase();
-  const station = stationSel != null ? stationTableHTML(stationSel, q) : '<p class="manifest-hint">Cherche une station ci-dessus pour voir et corriger ses prix et stocks.</p>';
-  // La bande est peinte APRÈS le panneau, bien qu'elle s'affiche au-dessus : stationTableHTML
-  // appelle effVals, dont la purge des volumes périmés est un effet de bord. Compter d'abord
-  // afficherait une correction que le rendu suivant vient d'effacer.
-  $("correctionsStation").innerHTML = station;
-  $("correctionsIndex").innerHTML = correctionsIndexHTML();
+  // La bande est peinte APRÈS le panneau, bien qu'elle s'affiche au-dessus : la préparation des
+  // tuiles appelle effVals, dont la purge des volumes périmés est un EFFET DE BORD. Compter d'abord
+  // afficherait une correction que le rendu suivant vient d'effacer. L'ordre est donc un contrat.
+  if (stationSel == null) peindre($("correctionsStation"), inviteStation());
+  else {
+    const t = MARKET.terminals[stationSel];
+    peindre($("correctionsStation"), vueStation({
+      terminal: t,
+      tuiles: tuilesStation(stationSel, q),
+      filtre: !!q,
+      nbCorrections: Object.keys(OVERRIDES).filter((k) => k.split("|")[1] === t.name).length,
+      fmtVol,
+      texteCapaciteInconnue: VOL_UNKNOWN_HINT,
+      // L'ÉCRITURE reste à app.js : lui seul sait qu'un VOLUME fige d'abord les jambes planifiées.
+      corriger: (commodite, cote, champ, valeur, releve) => {
+        if (champ === "vol") pinLegsForVolume(commodite, t.name, cote);
+        setOverride(commodite, t.name, cote, champ, valeur === "" ? null : valeur, Number(releve) || 0);
+        updateOvBadge();
+        refresh();
+      },
+    }));
+  }
+  peindre($("correctionsIndex"), vueBandeCorrections({ groupes: groupesCorrections() }));
   // Le panneau de frais n'est réécrit QUE si son contenu a changé (#24). Le sortir de
   // #correctionsStation ne suffisait pas : renderCorrections réécrivait son nouveau conteneur tout
   // aussi inconditionnellement, et un montant en cours de frappe repartait à vide au moindre
@@ -3443,6 +3397,7 @@ function paintCommodityDetail() {
   if (!p) { peindre(box, null); return; }
   peindre(box, vueDetailCommodite({
     points: p,
+    nomCommodite: p.name,
     butin: loot,
     fmt,
     fmtVol,

--- a/vues/commodites.tsx
+++ b/vues/commodites.tsx
@@ -117,6 +117,8 @@ import type { DetailCommodite, PointAchatCommodite, PointVenteCommodite } from "
 
 export type ProprietesDetail = {
   points: DetailCommodite;
+  /** Le nom de la commodité, porté par `data-c` sur chaque valeur éditable. */
+  nomCommodite: string;
   butin: boolean;
   fmt: Fmt;
   fmtVol: (n: number | null) => string;
@@ -139,6 +141,7 @@ function LignePoint({ p, cote, ...r }: { p: PointAchatCommodite | PointVenteComm
   const cellule = (champ: "price" | "vol", valeur: number | null | undefined) => (
     <ValeurEditable
       valeur={valeur ?? null}
+      commodite={r.nomCommodite} terminal={p.terminal} cote={cote} champ={champ} releve={p.updated}
       corrige={r.estCorrige(p.terminal, cote, champ)}
       fmtVol={r.fmtVol}
       texteCapaciteInconnue={r.texteCapaciteInconnue}

--- a/vues/communs.tsx
+++ b/vues/communs.tsx
@@ -90,6 +90,15 @@ import { useState, useRef, useEffect } from "react";
 
 export type ProprietesValeurEditable = {
   valeur: number | null;
+  /** Les quatre `data-*` du contrat e2e : plusieurs tests visent une cellule PRÉCISE par
+   *  `[data-c][data-s][data-f]`, et lisent sa valeur dans `data-v`. Ce sont eux qui identifient un
+   *  chiffre parmi les 92 tuiles d'une station — les omettre rend ces tests inécrivables. */
+  commodite: string;
+  terminal: string;
+  cote: "buy" | "sell";
+  champ: "price" | "vol";
+  /** Date UEX du point, mémorisée comme base de fraîcheur de la correction. */
+  releve: number;
   /** true quand une correction locale porte déjà sur ce point : le ✎ s'affiche. */
   corrige: boolean;
   /** Rend « n.c. » pour une capacité qu'UEX ne publie pas — ni zéro, ni illimitée. */
@@ -99,13 +108,13 @@ export type ProprietesValeurEditable = {
   texteCapaciteInconnue: string;
 };
 
-export function ValeurEditable({ valeur, corrige, fmtVol, onCorriger, texteCapaciteInconnue }: ProprietesValeurEditable) {
+export function ValeurEditable({ valeur, commodite, terminal, cote, champ, releve, corrige, fmtVol, onCorriger, texteCapaciteInconnue }: ProprietesValeurEditable) {
   const [enEdition, setEnEdition] = useState(false);
-  const champ = useRef<HTMLInputElement>(null);
+  const saisie = useRef<HTMLInputElement>(null);
   const fini = useRef(false);
 
   useEffect(() => {
-    if (enEdition && champ.current) { champ.current.focus(); champ.current.select(); }
+    if (enEdition && saisie.current) { saisie.current.focus(); saisie.current.select(); }
   }, [enEdition]);
 
   const inconnue = valeur == null || !Number.isFinite(Number(valeur));
@@ -116,7 +125,7 @@ export function ValeurEditable({ valeur, corrige, fmtVol, onCorriger, texteCapac
   const clore = (enregistrer: boolean) => {
     if (fini.current) return;
     fini.current = true;
-    const saisi = champ.current ? champ.current.value : v;
+    const saisi = saisie.current ? saisie.current.value : v;
     // On sort de l'édition DANS TOUS LES CAS, et avant d'écrire. React réutilise l'instance du
     // composant au même emplacement : après `refresh()`, l'état local SURVIT au re-rendu, et le
     // champ resterait ouvert sur l'ancienne valeur. La version impérative n'avait pas ce problème —
@@ -130,9 +139,11 @@ export function ValeurEditable({ valeur, corrige, fmtVol, onCorriger, texteCapac
 
   if (enEdition) {
     return (
-      <span className={"editv" + (inconnue ? " nc" : "") + (corrige ? " ov" : "")} data-react="1">
+      <span className={"editv" + (inconnue ? " nc" : "") + (corrige ? " ov" : "")} data-react="1"
+            data-c={commodite} data-t={terminal} data-s={cote} data-f={champ}
+            data-v={inconnue ? "" : v} data-u={String(Number(releve) || 0)}>
         <input
-          ref={champ}
+          ref={saisie}
           type="number"
           min="0"
           defaultValue={v}
@@ -154,6 +165,8 @@ export function ValeurEditable({ valeur, corrige, fmtVol, onCorriger, texteCapac
     <span
       className={"editv" + (inconnue ? " nc" : "") + (corrige ? " ov" : "")}
       data-react="1"
+      data-c={commodite} data-t={terminal} data-s={cote} data-f={champ}
+      data-v={inconnue ? "" : v} data-u={String(Number(releve) || 0)}
       role="button"
       tabIndex={0}
       title={inconnue ? `${texteCapaciteInconnue}. Clic pour le corriger localement` : "Clic pour corriger localement ce chiffre"}

--- a/vues/corrections.tsx
+++ b/vues/corrections.tsx
@@ -1,0 +1,253 @@
+// La vue Corrections, cinquième îlot React (ADR-008 #96) — et la plus grosse des huit.
+//
+// Elle n'était PAS migrable avant la PR précédente : son cœur est l'édition sur place, que
+// `startEdit` mutait impérativement. `ValeurEditable` (communs.tsx) l'a levée.
+//
+// Trois conteneurs, écrits séparément et pour des raisons différentes :
+//   #correctionsStation  le panneau de la station affichée (hero + tuiles par commodité) ;
+//   #correctionsIndex    la bande de vignettes, une par station corrigée ;
+//   #correctionsFees     le panneau de frais, dont app.js garde le contrôle de re-rendu.
+//
+// Ce dernier n'est réécrit QUE si sa signature change (#24) : un montant en cours de frappe
+// repartait à vide au moindre re-rendu — un filtre tapé, une correction ailleurs. React
+// réconcilierait sans doute correctement, mais changer ce garde ET migrer la vue dans la même PR
+// rendrait un échec inexploitable. Il reste donc à app.js, à revoir séparément.
+import { Fragment } from "react";
+import type { Terminal } from "../types.ts";
+import { BadgeSysteme, IconeCommodite, TagIllegal, ValeurEditable } from "./communs.tsx";
+
+type Fmt = (n: number | null) => string;
+
+// ── La vignette de station ─────────────────────────────────────────────────────────────────────
+// La photo se pose EN ABSOLU par-dessus le repli, dans un conteneur commun. La superposer à coups
+// de marge négative les décalait de la valeur du `gap` flex, et le code débordait derrière la photo
+// (« TA » derrière celle de Nyx Gateway (Stanton), dont le code est NYXSTA).
+export function VignetteStation({ nom, systeme, code, photo }: {
+  nom: string; systeme: string; code: string; photo: string;
+}) {
+  const affichable = photo && /^https:\/\//i.test(photo);
+  return (
+    <span className={"stn-vign sys-" + (systeme || "").toLowerCase()}>
+      <span className="stn-shot-gen">{code}</span>
+      {affichable ? <img className="stn-shot" src={photo} alt="" loading="lazy" referrerPolicy="no-referrer" /> : null}
+    </span>
+  );
+}
+
+// ── Le bandeau collant de la station ───────────────────────────────────────────────────────────
+// Il remplace la ligne de titre, qui sortait de l'écran au premier coup de molette — après quoi
+// plus rien ne disait quelle station on éditait, au milieu de 92 tuiles.
+function HeroStation({ t, total, filtre, nbCorrections }: {
+  t: Terminal; total: number; filtre: boolean; nbCorrections: number;
+}) {
+  return (
+    <div className="stn-hero">
+      <VignetteStation nom={t.name} systeme={t.system} code={t.code || ""} photo={t.shot || ""} />
+      <div className="stn-hero-txt">
+        <div className="stn-hero-line">
+          <span className="stn-hero-name">{t.name}</span><BadgeSysteme system={t.system} />
+          <span className="stn-hero-zone">{t.planet || "Espace profond"}</span>
+          <span className="stn-hero-code">{t.code || ""}</span>
+          <span className="station-count">{total} commodité{total > 1 ? "s" : ""}{filtre ? " filtrées" : ""}</span>
+          {nbCorrections ? (
+            <button type="button" id="stnClear" className="reset-ov" title="Effacer les corrections de cette station">
+              ✕ {nbCorrections} correction{nbCorrections > 1 ? "s" : ""}
+            </button>
+          ) : null}
+        </div>
+        <div className="stn-hero-sub">
+          clique un chiffre pour le corriger localement
+          {/* Crédit à l'auteur de la capture, et SEULEMENT s'il existe : 97 terminaux ont une photo
+              pour 89 auteurs — huit afficheraient sinon un « photo : » suivi de rien. */}
+          {t.shot && t.shotBy ? <span className="stn-hero-credit">photo : {t.shotBy}</span> : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Le retour à la valeur UEX ──────────────────────────────────────────────────────────────────
+// Contrôle DÉDIÉ, posé dans la tuile et HORS du `.editv` : celui-ci porte déjà `role="button"`, et
+// y imbriquer un second bouton serait invalide en ARIA. Il annonce la valeur vers laquelle il
+// ramène — ce que l'ancienne liste plate ne montrait jamais.
+// Il ne porte PAS de gestionnaire : la délégation d'app.js le prend déjà par ses `data-*`, et elle
+// sait ce que React ignore — qu'un retour de VOLUME doit d'abord figer les jambes déjà planifiées,
+// et où retrouver la date de base de la correction. Lui ajouter un onClick doublerait l'action.
+function RetourUEX({ commodite, terminal, cote, champ, brut, fmtVol }: {
+  commodite: string; terminal: string; cote: "buy" | "sell"; champ: "price" | "vol";
+  brut: number | null; fmtVol: Fmt;
+}) {
+  const quoi = champ === "price" ? "le prix" : cote === "buy" ? "le stock" : "la demande";
+  const v = Number.isFinite(Number(brut)) ? Number(brut) : null;
+  return (
+    <button type="button" className="scomm-undo"
+            data-c={commodite} data-t={terminal} data-s={cote} data-f={champ}
+            title={`Revenir à ${quoi} publié par UEX`}>
+      ↺ {fmtVol(v)}
+    </button>
+  );
+}
+
+export type CoteCommodite = {
+  cote: "buy" | "sell";
+  libelle: string; unite: string;
+  prix: number | null; volume: number | null;
+  prixCorrige: boolean; volumeCorrige: boolean;
+  prixBrut: number | null; volumeBrut: number | null;
+  releve: number;
+};
+
+export type TuileCommodite = {
+  nom: string; kind: string; illegal: boolean;
+  achat: boolean;
+  cotes: CoteCommodite[];
+};
+
+export type ProprietesStation = {
+  terminal: Terminal;
+  tuiles: TuileCommodite[];
+  filtre: boolean;
+  nbCorrections: number;
+  fmtVol: Fmt;
+  texteCapaciteInconnue: string;
+  corriger: (commodite: string, cote: "buy" | "sell", champ: "price" | "vol", valeur: string, releve: number) => void;
+};
+
+function Tuile({ t, terminal, fmtVol, texteCapaciteInconnue, corriger }: {
+  t: TuileCommodite; terminal: string;
+} & Pick<ProprietesStation, "fmtVol" | "texteCapaciteInconnue" | "corriger">) {
+  return (
+    <div className={"scomm " + (t.achat ? "achat" : "vente")}>
+      <div className="scomm-name">
+        <IconeCommodite kind={t.kind} />
+        <span>{t.nom}<TagIllegal illegal={t.illegal} /></span>
+      </div>
+      {t.cotes.map((c) => {
+        const retours = [
+          c.prixCorrige ? { champ: "price" as const, brut: c.prixBrut } : null,
+          c.volumeCorrige ? { champ: "vol" as const, brut: c.volumeBrut } : null,
+        ].filter(Boolean) as { champ: "price" | "vol"; brut: number | null }[];
+        return (
+          <Fragment key={c.cote}>
+            <div className="scomm-side">
+              <span className="scomm-lbl">{c.libelle}</span>
+              <ValeurEditable valeur={c.prix} corrige={c.prixCorrige} fmtVol={fmtVol}
+                              commodite={t.nom} terminal={terminal} cote={c.cote} champ="price" releve={c.releve}
+                              texteCapaciteInconnue={texteCapaciteInconnue}
+                              onCorriger={(v) => corriger(t.nom, c.cote, "price", v, c.releve)} />
+              {" aUEC · "}{c.unite}{" "}
+              <ValeurEditable valeur={c.volume} corrige={c.volumeCorrige} fmtVol={fmtVol}
+                              commodite={t.nom} terminal={terminal} cote={c.cote} champ="vol" releve={c.releve}
+                              texteCapaciteInconnue={texteCapaciteInconnue}
+                              onCorriger={(v) => corriger(t.nom, c.cote, "vol", v, c.releve)} />
+            </div>
+            {/* Les boutons de retour vivent sur LEUR PROPRE ligne, sous les valeurs. Glissés parmi
+                elles, ils comprimaient l'étiquette dans une tuile de 236 px : « aUEC · stock » se
+                coupait en deux. */}
+            {retours.length ? (
+              <div className="scomm-undos">
+                {retours.map((r) => (
+                  <RetourUEX key={r.champ} commodite={t.nom} terminal={terminal} cote={c.cote}
+                             champ={r.champ} brut={r.brut} fmtVol={fmtVol} />
+                ))}
+              </div>
+            ) : null}
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+}
+
+export function VueStation({ terminal, tuiles, filtre, nbCorrections, ...r }: ProprietesStation) {
+  const achats = tuiles.filter((t) => t.achat);
+  const ventes = tuiles.filter((t) => !t.achat);
+  const total = tuiles.length;
+
+  // DEUX sections : ce qu'on peut acheter ici, puis ce qu'on peut y vendre. Mesuré sur l'instantané,
+  // aucune commodité n'est des deux côtés au même comptoir — mais la répartition est très
+  // déséquilibrée (GrimHEX : 3 achats pour 89 ventes), et ces trois-là se perdaient au milieu.
+  const Section = ({ cle, titre, aide, liste }: { cle: string; titre: string; aide: string; liste: TuileCommodite[] }) =>
+    liste.length ? (
+      <div className="station-section">
+        <h4 className={"station-section-head " + cle}>
+          ◈ {titre} <span className="station-count">{liste.length}</span>
+          <span className="station-section-aide">{aide}</span>
+        </h4>
+        <div className="station-grid">
+          {liste.map((t) => <Tuile key={t.nom + "|" + (t.achat ? "b" : "s")} t={t} terminal={terminal.name} {...r} />)}
+        </div>
+      </div>
+    ) : null;
+
+  return (
+    <>
+      <HeroStation t={terminal} total={total} filtre={filtre} nbCorrections={nbCorrections} />
+      {!total ? (
+        <p className="empty">Aucune commodité {filtre ? "correspondante " : ""}à {terminal.name}.</p>
+      ) : (
+        <>
+          <Section cle="achat" titre="On y achète" aide="ce que la station te vend — prix et stock" liste={achats} />
+          <Section cle="vente" titre="On y vend" aide="ce qu'elle te reprend — prix et demande" liste={ventes} />
+        </>
+      )}
+    </>
+  );
+}
+
+// ── La bande des stations corrigées ────────────────────────────────────────────────────────────
+export type GroupeCorrections = {
+  terminal: string; corrections: number; actif: boolean;
+  /** null quand le terminal a disparu de market.json. */
+  info: Terminal | null;
+};
+
+export type ProprietesBande = { groupes: GroupeCorrections[] };
+
+export function VueBandeCorrections({ groupes }: ProprietesBande) {
+  if (!groupes.length) {
+    return <p className="empty">Aucune correction locale pour l'instant. Cherche une station ci-dessus pour en créer.</p>;
+  }
+  const autres = groupes.filter((g) => !g.actif);
+  const total = groupes.reduce((s, g) => s + g.corrections, 0);
+
+  return (
+    <>
+      <div className="corr-list-head">
+        <span>
+          ◈ {autres.length ? `${autres.length} autre${autres.length > 1 ? "s" : ""} station${autres.length > 1 ? "s" : ""} · ` : ""}
+          {total} correction{total > 1 ? "s" : ""}
+        </span>
+        {/* L'export précède « Tout réinitialiser » — c'est l'ordre des gestes : on emporte ses
+            relevés avant de les effacer. */}
+        <button id="exportCorrections" className="copy-btn" title="Copier toutes les corrections locales, avec leur date de saisie et leur date UEX">⧉ Exporter</button>
+        <button id="resetAll" className="reset-ov">Tout réinitialiser</button>
+      </div>
+      <div className="stn-band">
+        {groupes.map((g) => (
+          // Terminal disparu de market.json : la vignette s'affiche quand même, sinon la correction
+          // deviendrait invisible ET ineffaçable. Elle n'est simplement pas cliquable.
+          <button key={g.terminal} type="button"
+                  className={"stn-tile" + (g.actif ? " active" : "") + (g.info ? "" : " orphelin")}
+                  aria-current={g.actif ? "true" : undefined}
+                  data-terminal={g.terminal} disabled={!g.info}>
+            <VignetteStation nom={g.terminal} systeme={g.info ? g.info.system : ""}
+                             code={g.info ? g.info.code || "" : ""} photo={g.info ? g.info.shot || "" : ""} />
+            <span className="stn-tile-name">{g.terminal}</span>
+            <span className="stn-tile-meta">
+              {g.info ? <BadgeSysteme system={g.info.system} /> : <span className="sys">inconnu</span>}
+              <b>{g.corrections}</b>
+            </span>
+            {g.actif ? <span className="stn-tile-flag">en cours</span> : null}
+          </button>
+        ))}
+      </div>
+    </>
+  );
+}
+
+export const vueStation = (p: ProprietesStation) => <VueStation {...p} />;
+export const vueBandeCorrections = (p: ProprietesBande) => <VueBandeCorrections {...p} />;
+export const inviteStation = () => (
+  <p className="manifest-hint">Cherche une station ci-dessus pour voir et corriger ses prix et stocks.</p>
+);


### PR DESCRIPTION
> **Base : `v2/main`, jamais `main`.** ADR-008 §3.

## Ce que ça change

**La vue Corrections est rendue par React.** C'est la plus grosse des huit — 196 lignes exclusives,
37 tests e2e, 11 `#id` au contrat — et elle n'était **pas migrable** avant la PR précédente : son
cœur est l'édition sur place.

Cinq vues sur huit y sont maintenant.

## Ce qui reste à `app.js`, et pourquoi

**`#correctionsFees`.** Il n'est réécrit que si sa signature change (#24) : un montant en cours de
frappe repartait à vide au moindre re-rendu — un filtre tapé, une correction ailleurs. React
réconcilierait sans doute correctement, mais changer ce garde **et** migrer la vue dans la même PR
rendrait un échec inexploitable.

**L'ordre de peinture**, qui est un contrat : la bande est peinte **après** le panneau bien qu'elle
s'affiche au-dessus, parce que la préparation des tuiles appelle `effVals`, dont la purge d'un
volume périmé est un **effet de bord**. Compter d'abord afficherait une correction que le rendu
suivant vient d'effacer.

**Le bouton `↺`**, qui ne porte aucun gestionnaire React : la délégation d'`app.js` le prend déjà
par ses `data-*`, et elle sait ce que l'îlot ignore — qu'un retour de **volume** doit figer les
jambes déjà planifiées, et où retrouver la date de base. Un `onClick` aurait **doublé l'action**.

## Le harnais a attrapé un contrat cassé

Deuxième fois de la migration, après le wrapper flex de la vue Chaîne.

Mon composant `ValeurEditable` ne rendait pas les `data-c` / `data-t` / `data-s` / `data-f` /
`data-v`. Trois tests visent une cellule **précise** par ces attributs et lisent sa valeur dans
`data-v` :

```
locator('#correctionsStation .editv[data-c="Copper"][data-s="buy"][data-f="vol"]')
```

Ce sont eux qui identifient un chiffre parmi les **92 tuiles** d'une station — sans eux, ces tests
sont inécrivables. Ils sont désormais portés par le composant, donc aussi dans le détail Commodités
où ils manquaient depuis la PR précédente **sans que rien ne le signale**.

## Vérification

Relevé scopé, clé par rang, 19 propriétés, avec une correction posée pour que la bande et les
boutons `↺` existent :

```
#correctionsStation   303 formes · 303 IDENTIQUES · 0 disparue · 0 apparue
#correctionsIndex      14 formes ·  13 identiques · 0 disparue · 0 apparue
```

L'unique écart est une marge `auto` à **0,015 px**. Et le contrat, vérifié à part, est identique sur
ses sept champs :

```
tuiles · .editv · IDENTIFIANTS data-* · boutons ↺ · vignettes · texte de la bande · texte du hero
```

```
npx tsc --noEmit      0 erreur
node --test           ℹ tests 483 · ℹ pass 483 · ℹ fail 0
npx playwright test   209 collectés · 208 passés · 1 ignoré (1,5 min)
```

Aucun test n'a été modifié.

## Ce qui n'est pas couvert

- **`#correctionsFees`** reste vanilla, avec son garde de signature — à revoir séparément.
- **`vignetteStation` reste dans `app.js`** : l'autocomplétion de station l'utilise encore. Elle
  existe aussi en composant, et les deux disparaîtront ensemble quand l'autocomplétion migrera.
- `stationTableHTML`, `correctionsIndexHTML`, `stationHeroHTML` et `retourUEX` sont **retirés**.
- **Trois vues restent** : Plan de vol, Trajets — qui dénouera `#empty` et le `<thead>` de tri — et
  « En route » en dernier.

Refs #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)
