### PR TITLE
feat(plan): la vue Plan de vol passe en React — six vues sur huit

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,6 +32,7 @@ import { vueBoucles } from "./vues/boucles.tsx";
 import { vueChaine, indiceDepart, indiceSoute, indiceAucune } from "./vues/chaine.tsx";
 import { vueGrilleCommodites, aideBoard, vueDetailCommodite, inviteDetail } from "./vues/commodites.tsx";
 import { vueStation, vueBandeCorrections, inviteStation } from "./vues/corrections.tsx";
+import { enTetePlan, corpsPlan } from "./vues/plan.tsx";
 import { KIND_ICON } from "./vues/communs.tsx";
 
 // Libellé compact des caisses SCU standard, ex. « 8×32 · 1×16 · 1×4 · 1×2 · 1×1 ».
@@ -2557,64 +2558,9 @@ function planData() {
 // La soute EN GRAND : ce qu'il y a à bord commodité par commodité, la place libre, ce qui a été
 // payé. Le #holdCard du bandeau dit la même chose dans un encart latéral — mais il porte la vente,
 // le dépôt et le retrait de lot. Ici, aucun bouton : c'est la même donnée, en lecture.
-function planHoldHTML(d) {
-  if (!d.groupes.length) {
-    return `<div class="plan-card" id="planHold"><div class="plan-card-head">◈ Soute</div>
-      <p class="plan-muted">Rien à bord. Charge un manifeste depuis une jambe, ou déclare ce que tu transportes depuis le bandeau d'une vue de recherche.</p></div>`;
-  }
-  const icone = (nom) => { const c = MARKET && findCommodity(nom); return c ? commodityIcon(c.kind) : ""; };
-  const lignes = d.groupes.map((g) => {
-    // Part de la soute occupée par cette commodité : c'est le « visuel » que l'encart latéral, trop
-    // étroit, ne pouvait pas porter. Rapportée à la CAPACITÉ quand elle est connue, au chargement
-    // sinon — une barre sans dénominateur ne voudrait rien dire.
-    const base = d.f.useCargo && d.f.cargo > 0 ? d.f.cargo : d.scu;
-    const part = base > 0 ? Math.min(100, (g.units / base) * 100) : 0;
-    return `<div class="plan-hold-line">
-        <span class="plan-hold-name">${icone(g.name)}<span>${esc(g.name)}</span></span>
-        <span class="plan-hold-bar" aria-hidden="true"><i style="width:${part.toFixed(1)}%"></i></span>
-        <span class="plan-hold-scu"><b>${fmt(g.units)}</b> SCU</span>
-        <span class="plan-hold-paid" title="Prix payé au SCU${g.lots.length > 1 ? " (moyenne des lots)" : ""}">@ ${fmt(Math.round(g.paidMoyen))}</span>
-      </div>`;
-  }).join("");
-  return `<div class="plan-card" id="planHold">
-      <div class="plan-card-head">◈ Soute</div>
-      <div class="plan-hold-lines">${lignes}</div>
-      <div class="plan-card-meta"><b>${fmt(d.scu)}</b> SCU à bord${d.libre != null ? ` · <b>${fmt(d.libre)}</b> SCU libres` : ""} · capital engagé <b>${fmt(d.invest)}</b> aUEC</div>
-    </div>`;
-}
-
+// `planHoldHTML` a été remplacé par vues/plan.tsx.
 // Le parcours étape par étape, la jambe en cours et son manifeste, et ce qu'il reste à faire.
-function planRouteHTML(d) {
-  if (!JOURNEY) {
-    return `<div class="plan-card" id="planRoute"><div class="plan-card-head">◈ Parcours</div>
-      <p class="plan-muted">Aucun voyage engagé. Démarre-en un depuis <b>Trajets</b> — le ▶ d'une ligne — ou de zéro en posant un point de départ dans le bandeau.</p></div>`;
-  }
-  const chemin = d.stations
-    .map((s, i) => `<span class="plan-step${i === JOURNEY.current ? " here" : ""}"><span class="sys ${esc(s.system.toLowerCase())}">${esc(s.name)}</span></span>`)
-    .join('<span class="plan-sep">→</span>');
-  const jambes = d.jambes.map((j) => {
-    const cargo = j.lines.length
-      ? j.lines.map((l) => `<span class="plan-cargo-item">${commodityIcon(l.kind)}${esc(l.name)} <b>${fmt(l.units)} SCU</b></span>`).join("")
-      : '<span class="plan-muted">aucun fret rentable</span>';
-    const etat = j.faite ? "faite" : j.courante ? "courante" : "à venir";
-    return `<div class="plan-leg ${j.courante ? "current" : j.faite ? "done" : ""}">
-        <div class="plan-leg-head"><span class="plan-leg-n">${j.i + 1}</span>
-          <span class="plan-leg-route">${esc(j.from)} → ${esc(j.to)}</span>
-          <span class="plan-leg-state">${etat}${j.chargee ? " · chargée" : ""}</span>
-          <span class="plan-leg-profit ${classeProfit(j.profit)}">${signe(j.profit, fmtFee(j.profit, j.fees))}</span></div>
-        <div class="plan-leg-cargo">${cargo}</div>
-      </div>`;
-  }).join("");
-  const n = JOURNEY.legs.length;
-  return `<div class="plan-card" id="planRoute">
-      <div class="plan-card-head">◈ Parcours</div>
-      <div class="plan-path">${chemin}</div>
-      ${MARKET ? `<div class="plan-legs">${jambes}</div>` : '<p class="plan-muted">Calcul des manifestes…</p>'}
-      <div class="plan-card-meta"><b>${n}</b> saut${n > 1 ? "s" : ""} · <b>${d.reste}</b> à faire · <b>${fmt(d.totalScu)}</b> SCU transportés ·
-        profit ${MARKET ? `<b class="${classeProfit(d.totalProfit)}">${signe(d.totalProfit, fmtFee(d.totalProfit, d.totalFees))}</b> aUEC` : "…"}</div>
-    </div>`;
-}
-
+// `planRouteHTML` a été remplacé par vues/plan.tsx.
 function renderPlan() {
   const head = $("planHead"), body = $("planBody");
   if (!head || !body) return;
@@ -2623,11 +2569,24 @@ function renderPlan() {
   // l'utilisateur peut avoir changé de vue entre-temps.
   if (JOURNEY && !MARKET) withMarket(refresh);
   const d = planData();
-  head.innerHTML =
-    `<div class="plan-title"><span class="plan-kicker">◈ Plan de vol</span>
-       <button id="planCopy" class="plan-copy" type="button" title="Copier le récapitulatif en texte, à coller dans un salon">⧉ Copier le récapitulatif</button></div>
-     <div class="plan-hyp" id="planHypotheses" title="Ces quatre réglages changent le sens des chiffres ci-dessous. Pour les modifier, retourne dans une vue de recherche.">${planHypotheses(d.f).map(esc).join(" · ")}</div>`;
-  body.innerHTML = `<div class="plan-grid">${planHoldHTML(d)}${planRouteHTML(d)}</div>`;
+  peindre(head, enTetePlan(planHypotheses(d.f)));
+  // L'îlot ne lit AUCUNE globale : app.js lui passe tout, y compris le résolveur de `kind` (MARKET)
+  // et la base des barres de soute — la CAPACITÉ quand elle est connue, le chargement sinon. Une
+  // barre sans dénominateur ne voudrait rien dire.
+  peindre(body, corpsPlan({
+    hypotheses: planHypotheses(d.f),
+    stations: d.stations,
+    courante: JOURNEY ? JOURNEY.current : -1,
+    jambes: d.jambes,
+    groupes: d.groupes,
+    scu: d.scu, libre: d.libre, invest: d.invest,
+    totalScu: d.totalScu, totalProfit: d.totalProfit, totalFees: d.totalFees,
+    reste: d.reste, nbSauts: JOURNEY ? JOURNEY.legs.length : 0,
+    base: d.f.useCargo && d.f.cargo > 0 ? d.f.cargo : d.scu,
+    marchePret: !!MARKET,
+    kindDe: (nom) => { const c = MARKET && findCommodity(nom); return c ? c.kind : null; },
+    fmt, fmtProfit: fmtFee, signe,
+  }));
 }
 
 // Le récapitulatif EN TEXTE (ADR-004 §8). Pas une image : la CSP pose `img-src 'self' https:` sans

--- a/vues/plan.tsx
+++ b/vues/plan.tsx
@@ -1,0 +1,183 @@
+// La vue Plan de vol, sixième îlot React (ADR-008 #96).
+//
+// C'est une CONCLUSION, pas un tableau de bord (ADR-004) : on y arrive une fois tout paramétré,
+// pour REGARDER le résultat. Rien n'y est actionnable — pas un bouton de vente, pas un ✕, pas un
+// champ. Un seul bouton, celui qui copie le récapitulatif, et il ne modifie rien.
+//
+// Cette propriété la rend simple à migrer malgré ses 230 lignes : aucun état local, aucune
+// délégation propre, aucune valeur éditable. Elle n'a que du rendu.
+//
+// La carte SVG du parcours reste HORS de cet îlot : `#journeyMap` vit entre `#planHead` et
+// `#planBody` (et non dedans), parce qu'un élément à écouteurs directs se déménage en FRÈRE, jamais
+// en enfant d'un conteneur réécrit — c'est la leçon de #24, rappelée par l'ADR-004.
+import { Fragment } from "react";
+import { IconeCommodite } from "./communs.tsx";
+
+type Fmt = (n: number) => string;
+
+export type GroupeSoute = { name: string; units: number; paidMoyen: number; lots: unknown[] };
+export type LigneJambe = { name: string; kind: string; units: number };
+export type JambePlan = {
+  i: number; from: string; to: string;
+  scu: number; profit: number; fees: number;
+  faite: boolean; courante: boolean; chargee: boolean;
+  lines: LigneJambe[];
+};
+
+export type DonneesPlan = {
+  hypotheses: string[];
+  stations: { name: string; system: string }[];
+  courante: number;
+  jambes: JambePlan[];
+  groupes: GroupeSoute[];
+  scu: number; libre: number | null; invest: number;
+  totalScu: number; totalProfit: number; totalFees: number;
+  reste: number; nbSauts: number;
+  /** La capacité qui sert de dénominateur aux barres de soute — voir plus bas. */
+  base: number;
+  /** Le marché n'est pas encore là : les manifestes par jambe ne sont pas calculables. */
+  marchePret: boolean;
+  /** Le `kind` d'une commodité, pour son icône. app.js le résout : MARKET est une globale. */
+  kindDe: (nom: string) => string | null;
+  fmt: Fmt;
+  fmtProfit: (n: number, fees: number) => string;
+  signe: (n: number, texte: string) => string;
+};
+
+const classeProfit = (n: number) => (n < 0 ? "perte" : "profit");
+
+export function EnTetePlan({ hypotheses }: { hypotheses: string[] }) {
+  return (
+    <>
+      <div className="plan-title">
+        <span className="plan-kicker">◈ Plan de vol</span>
+        <button id="planCopy" className="plan-copy" type="button" title="Copier le récapitulatif en texte, à coller dans un salon">
+          ⧉ Copier le récapitulatif
+        </button>
+      </div>
+      {/* Les quatre réglages qui ne FILTRENT pas mais changent le SENS des chiffres (ADR-004 §6),
+          repris ici en lecture seule : une conclusion énonce ses hypothèses au lieu de les offrir
+          à la modification. Les taire la rendrait silencieusement ambiguë — on lirait un profit
+          sans savoir s'il est net. */}
+      <div className="plan-hyp" id="planHypotheses"
+           title="Ces quatre réglages changent le sens des chiffres ci-dessous. Pour les modifier, retourne dans une vue de recherche.">
+        {hypotheses.join(" · ")}
+      </div>
+    </>
+  );
+}
+
+function CarteSoute({ d }: { d: DonneesPlan }) {
+  if (!d.groupes.length) {
+    return (
+      <div className="plan-card" id="planHold">
+        <div className="plan-card-head">◈ Soute</div>
+        <p className="plan-muted">Rien à bord. Charge un manifeste depuis une jambe, ou déclare ce que tu transportes depuis le bandeau d'une vue de recherche.</p>
+      </div>
+    );
+  }
+  return (
+    <div className="plan-card" id="planHold">
+      <div className="plan-card-head">◈ Soute</div>
+      <div className="plan-hold-lines">
+        {d.groupes.map((g) => {
+          // La part de soute occupée est rapportée à la CAPACITÉ quand elle est connue, au
+          // chargement sinon : une barre sans dénominateur ne voudrait rien dire.
+          const part = d.base > 0 ? Math.min(100, (g.units / d.base) * 100) : 0;
+          const kind = d.kindDe(g.name);
+          return (
+            <div className="plan-hold-line" key={g.name}>
+              <span className="plan-hold-name">
+                {kind ? <IconeCommodite kind={kind} /> : null}
+                <span>{g.name}</span>
+              </span>
+              <span className="plan-hold-bar" aria-hidden="true"><i style={{ width: part.toFixed(1) + "%" }} /></span>
+              <span className="plan-hold-scu"><b>{d.fmt(g.units)}</b> SCU</span>
+              <span className="plan-hold-paid" title={"Prix payé au SCU" + (g.lots.length > 1 ? " (moyenne des lots)" : "")}>
+                @ {d.fmt(Math.round(g.paidMoyen))}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      <div className="plan-card-meta">
+        <b>{d.fmt(d.scu)}</b> SCU à bord
+        {d.libre != null ? <> · <b>{d.fmt(d.libre)}</b> SCU libres</> : null}
+        {" · capital engagé "}<b>{d.fmt(d.invest)}</b> aUEC
+      </div>
+    </div>
+  );
+}
+
+function CarteParcours({ d }: { d: DonneesPlan }) {
+  if (!d.stations.length && !d.jambes.length && !d.nbSauts) {
+    return (
+      <div className="plan-card" id="planRoute">
+        <div className="plan-card-head">◈ Parcours</div>
+        <p className="plan-muted">Aucun voyage engagé. Démarre-en un depuis <b>Trajets</b> — le ▶ d'une ligne — ou de zéro en posant un point de départ dans le bandeau.</p>
+      </div>
+    );
+  }
+  return (
+    <div className="plan-card" id="planRoute">
+      <div className="plan-card-head">◈ Parcours</div>
+      <div className="plan-path">
+        {d.stations.map((s, i) => (
+          // `Fragment` et non un <span> englobant : `.plan-path` est un conteneur flex, et
+          // envelopper ses enfants les en sortirait (mesuré sur `.chain-path`, PR #111).
+          <Fragment key={i}>
+            {i > 0 ? <span className="plan-sep">→</span> : null}
+            <span className={"plan-step" + (i === d.courante ? " here" : "")}>
+              <span className={"sys " + s.system.toLowerCase()}>{s.name}</span>
+            </span>
+          </Fragment>
+        ))}
+      </div>
+      {d.marchePret ? (
+        <div className="plan-legs">
+          {d.jambes.map((j) => (
+            <div className={"plan-leg " + (j.courante ? "current" : j.faite ? "done" : "")} key={j.i}>
+              <div className="plan-leg-head">
+                <span className="plan-leg-n">{j.i + 1}</span>
+                <span className="plan-leg-route">{j.from} → {j.to}</span>
+                <span className="plan-leg-state">{j.faite ? "faite" : j.courante ? "courante" : "à venir"}{j.chargee ? " · chargée" : ""}</span>
+                <span className={"plan-leg-profit " + classeProfit(j.profit)}>{d.signe(j.profit, d.fmtProfit(j.profit, j.fees))}</span>
+              </div>
+              <div className="plan-leg-cargo">
+                {j.lines.length
+                  ? j.lines.map((l, k) => (
+                      <span className="plan-cargo-item" key={k}>
+                        <IconeCommodite kind={l.kind} />{l.name} <b>{d.fmt(l.units)} SCU</b>
+                      </span>
+                    ))
+                  : <span className="plan-muted">aucun fret rentable</span>}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="plan-muted">Calcul des manifestes…</p>
+      )}
+      <div className="plan-card-meta">
+        <b>{d.nbSauts}</b> saut{d.nbSauts > 1 ? "s" : ""} · <b>{d.reste}</b> à faire · <b>{d.fmt(d.totalScu)}</b> SCU transportés ·
+        {" profit "}
+        {d.marchePret
+          ? <b className={classeProfit(d.totalProfit)}>{d.signe(d.totalProfit, d.fmtProfit(d.totalProfit, d.totalFees))}</b>
+          : "…"}
+        {d.marchePret ? " aUEC" : ""}
+      </div>
+    </div>
+  );
+}
+
+export function CorpsPlan({ d }: { d: DonneesPlan }) {
+  return (
+    <div className="plan-grid">
+      <CarteSoute d={d} />
+      <CarteParcours d={d} />
+    </div>
+  );
+}
+
+export const enTetePlan = (hypotheses: string[]) => <EnTetePlan hypotheses={hypotheses} />;
+export const corpsPlan = (d: DonneesPlan) => <CorpsPlan d={d} />;


### PR DESCRIPTION
Onzième livrable de la refonte v2 (#96).

C'est une CONCLUSION, pas un tableau de bord (ADR-004) : on y arrive une fois tout paramétré, pour
REGARDER le résultat. Rien n'y est actionnable — pas un bouton de vente, pas un ✕, pas un champ.
Cette propriété la rend simple à migrer malgré ses 230 lignes : aucun état local, aucune délégation
propre, aucune valeur éditable. Elle n'a que du rendu.

LA CARTE SVG RESTE HORS DE L'ÎLOT, et c'est le seul vrai point d'attention. `#journeyMap` vit ENTRE
`#planHead` et `#planBody`, pas dedans : un élément à écouteurs directs se déménage en FRÈRE, jamais
en enfant d'un conteneur réécrit. C'est la leçon de #24, que l'ADR-004 avait déjà appliquée — et
qu'un test couvre (« la carte garde ses écouteurs directs après un re-rendu »).

L'îlot ne lit AUCUNE globale : app.js lui passe tout, y compris le résolveur de `kind` (MARKET) et
la base des barres de soute — la CAPACITÉ quand elle est connue, le chargement sinon. Une barre sans
dénominateur ne voudrait rien dire.

Vérification — relevé scopé, clé par rang, 19 propriétés, avec un voyage engagé et de la soute :

    #planHead   4 formes ·  4 IDENTIQUES · 0 disparue · 0 apparue
    #planBody  47 formes · 46 identiques · 0 disparue · 0 apparue

L'unique écart est une marge `auto` à 0,015 px. Contrat identique : texte de la tête et du corps,
nombre de cartes, nombre de jambes, et la carte SVG toujours FRÈRE et visible.

    npx tsc --noEmit      0 erreur
    node --test           ℹ tests 483 · ℹ pass 483 · ℹ fail 0
    npx playwright test   209 collectés · 16/16 sur plan.pw.mjs

`planHoldHTML` et `planRouteHTML` sont retirés. `copierPlan` reste : il produit du TEXTE, pas du
DOM — la CSP interdit le procédé habituel de capture d'image (ADR-004 §8).

Refs #96

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R9bFh9qfqpqTr422gh8Wu1

> **Base : `v2/main`.** ADR-008 §3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)