### PR TITLE
feat(soute): les tables « Trajets » et « En route » passent en React, à l'identique

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,6 +33,7 @@ import { vueChaine, indiceDepart, indiceSoute, indiceAucune } from "./vues/chain
 import { vueGrilleCommodites, aideBoard, vueDetailCommodite, inviteDetail } from "./vues/commodites.tsx";
 import { vueStation, vueBandeCorrections, inviteStation } from "./vues/corrections.tsx";
 import { enTetePlan, corpsPlan } from "./vues/plan.tsx";
+import { vueTrajets, vueTrajetsMulti } from "./vues/trajets.tsx";
 import { KIND_ICON } from "./vues/communs.tsx";
 
 // Libellé compact des caisses SCU standard, ex. « 8×32 · 1×16 · 1×4 · 1×2 · 1×1 ».
@@ -465,6 +466,46 @@ const isMultiRoutes = () => view === "routes" && $("multiCommodity").checked;
 // remise à zéro en tête de rendu, un état vide légitime affichait le message d'une AUTRE vue.
 const EMPTY_DEFAULT = "Aucune route ne correspond aux filtres.";
 
+// Ce que les deux modes de Trajets partagent. app.js garde l'ÉTAT — les frais dépendent de
+// l'interrupteur d'autoload et des relevés par station, l'écriture d'une correction doit figer les
+// jambes déjà planifiées, et `#empty` reste écrit ici (il est partagé par trois vues).
+function propsTrajetsCommunes() {
+  return {
+    fmt, fmtVol, fmtFee,
+    avecTexteFrais: (base, cell) => (cell.text ? `${base} · ${cell.text}` : base),
+    texteCapaciteInconnue: VOL_UNKNOWN_HINT,
+    legendeAchat: BUY_STATUS,
+    legendeVente: SELL_STATUS,
+    corriger: (commodite, terminal, cote, champ, valeur, releve) => {
+      if (champ === "vol") pinLegsForVolume(commodite, terminal, cote);
+      setOverride(commodite, terminal, cote, champ, valeur === "" ? null : valeur, Number(releve) || 0);
+      updateOvBadge();
+      refresh();
+    },
+  };
+}
+
+// Ce qui se calcule LIGNE PAR LIGNE, et qui vaut pour les deux tables à lignes simples : « Trajets »
+// (`#rows`) et « En route » (`#enrouteRows`). Elles ont toujours partagé leur rendu — c'était la
+// fonction `routeRowHTML`, appelée des deux endroits. L'îlot React la remplace, donc il doit servir
+// les deux appelants : ne peindre que `#rows` laisserait « En route » sans lignes.
+function propsLignesSimples() {
+  return {
+    celluleFrais: (r) => feeCell(r.feeInfo, r.fees, () => feeLoadText(r.units, (termByName.get(r.buy.terminal) || {}).maxBox), r.units > 0),
+    suspect: (r) => {
+      const d = pairAge(r.buy.updated, r.sell.updated);
+      if (d != null && d > 10) return "relevé de plus de 10 jours";
+      if (r.refSell > 0 && r.refBuy > 0 && (r.sell.price > r.refSell * 1.5 || r.buy.price < r.refBuy * 0.67))
+        return "prix très éloigné de la moyenne UEX";
+      return null;
+    },
+    // Le plafond de caisse vient du MARCHÉ, pas du contexte de frais : c'est une propriété physique
+    // de la station. Le prendre dans `feeInfo` le faisait disparaître dès l'interrupteur relâché, et
+    // la ligne annonçait « 3×32 » à côté d'un manifeste qui affichait « 6×16 » pour la même cargaison.
+    libelleCaisses: (r) => (r.units ? scuBoxesLabel(r.units, (termByName.get(r.buy.terminal) || {}).maxBox) : null),
+  };
+}
+
 function render() {
   const f = readFilters();
   $("empty").textContent = EMPTY_DEFAULT;
@@ -476,7 +517,11 @@ function render() {
   rows.sort(bySort(sortKey, sortDir));
 
   shownRoutes = rows;
-  $("rows").innerHTML = rows.map(routeRowHTML).join("");
+  peindre($("rows"), vueTrajets({
+    ...propsTrajetsCommunes(),
+    ...propsLignesSimples(),
+    lignes: rows,
+  }));
   $("empty").hidden = rows.length > 0;
   notifySuperseded();
 }
@@ -489,7 +534,7 @@ function renderMulti(f) {
   // Sans soute bornée, « remplir la soute » n'a pas de sens (cf. manifeste d'« En route »).
   if (!f.useCargo || !(f.cargo > 0)) {
     shownMulti = [];
-    $("rows").innerHTML = "";
+    peindre($("rows"), null);
     empty.hidden = false;
     empty.textContent = "Active la soute (SCU) pour calculer des trajets multi-commodité.";
     return;
@@ -500,7 +545,7 @@ function renderMulti(f) {
   // #empty reste masqué : le tableau n'est pas vide à cause des filtres, le marché n'est pas là.
   if (!MARKET) {
     shownMulti = [];
-    $("rows").innerHTML = "";
+    peindre($("rows"), null);
     empty.hidden = true;
     withMarket(refresh);
     return;
@@ -511,7 +556,14 @@ function renderMulti(f) {
     .map((t) => ({ ...t, feeInfo: feeCtx(f, t.origin.name, t.dest.name, t.origin, t.dest), ...tripMetrics(t) }));
   trips.sort(bySort(sortKey, sortDir));
   shownMulti = trips;
-  $("rows").innerHTML = trips.map(multiRowHTML).join("");
+  peindre($("rows"), vueTrajetsMulti({
+    ...propsTrajetsCommunes(),
+    lignes: trips,
+    celluleFrais: (t) => feeCell(t.feeInfo, t.fees, () => feeCargoText(t.lines, t.origin.maxBox), t.units > 0),
+    libelleCaisses: (t) => (t.units ? cargoBoxesLabel(t.lines, t.origin.maxBox) : null),
+    // Le relevé le plus ANCIEN du chargement : un trajet ne vaut pas mieux que sa ligne la moins sûre.
+    releveLePlusAncien: (t) => t.lines.reduce((m, l) => { const u = lineFreshUpdated(l); return m && u ? Math.min(m, u) : m || u; }, 0),
+  }));
   empty.hidden = trips.length > 0;
   // Rappel : seuls les chargements COMBINÉS (≥ 2 commodités) sont listés ici — un trajet dont le
   // remplissage optimal tient en une seule commodité est déjà dans la vue « Trajets » normale.
@@ -524,47 +576,7 @@ function renderMulti(f) {
 }
 
 // Ligne de tableau d'un trajet multi-commodité (mêmes colonnes que les trajets simples).
-function multiRowHTML(t, i) {
-  const n = t.lines.length;
-  const fc = feeCell(t.feeInfo, t.fees, () => feeCargoText(t.lines, t.origin.maxBox), t.units > 0);
-  const cross = t.cross ? '<span class="cross">⚡ saut inter-système</span>' : "";
-  const icons = t.lines.slice(0, 6).map((l) => commodityIcon(l.kind)).join("");
-  const more = n > 6 ? `<span class="muted">+${n - 6}</span>` : "";
-  const names = t.lines.map((l) => `${l.name} (${fmt(l.units)} SCU)`).join(" · ");
-  const oldest = t.lines.reduce((m, l) => { const u = lineFreshUpdated(l); return m && u ? Math.min(m, u) : m || u; }, 0);
-  return `
-      <tr data-row="${i}">
-        <td class="loc">
-          <div class="commodity-cell"><button class="journey-pick" data-row="${i}" title="Faire ce trajet — compagnon de voyage" aria-label="Sélectionner ce trajet">▶</button><button class="route-toggle" data-row="${i}" title="Voir le chargement" aria-label="Voir le chargement">📦</button><span class="multi-icons" title="${esc(names)}">${icons}${more}</span><span class="cname">${n} commodité${n > 1 ? "s" : ""}</span></div>
-          <div class="loc-badges">${t.lines.some((l) => l.illegal) ? illegalTag(true) : ""}${cross}</div>
-        </td>
-        <td class="loc">
-          <div class="term-name">${esc(t.origin.name)}</div>
-          <div class="loc-badges">${sysBadge(t.origin.system)}${outpostTag(t.origin.outpost)}</div>
-          <div class="loc-sub">${esc(t.origin.planet)}</div>
-          <div class="loc-fresh">${freshChip(oldest)}</div>
-        </td>
-        <td class="loc">
-          <div class="term-name">${esc(t.dest.name)}</div>
-          <div class="loc-badges">${sysBadge(t.dest.system)}${outpostTag(t.dest.outpost)}</div>
-          <div class="loc-sub">${esc(t.dest.planet)}</div>
-        </td>
-        <td>${fiabiliteCell(t.fiabilite, t.age, t.partVolume)}</td>
-        <td class="num" title="${withFeeText("Marge moyenne pondérée par SCU chargé", fc)}">${fmtFee(t.margin, t.fees)}</td>
-        <td class="num roi-badge"${fc.attr}>${t.fees > 0 ? "≈ " : ""}${t.roi}%</td>
-        <td class="num"${t.units ? ` title="Caisses : ${cargoBoxesLabel(t.lines, t.origin.maxBox)}"` : ""}>${fmt(t.units)}</td>
-        <td class="num">${fmt(t.investment)}</td>
-        <td class="num profit"${fc.attr}>${fmtFee(t.profit, t.fees)}${fc.mark}</td>
-        <td class="num profit" title="${withFeeText(`Estimation ${Math.round(t.minutes)} min/voyage (distance approchée)`, fc)}">${fmtFee(t.profitHour, t.fees)}</td>
-      </tr>`;
-}
-
-// Détail déplié d'un trajet multi-commodité : le CHARGEMENT, ligne par ligne — et rien d'autre.
-// Il portait aussi un schéma « système › planète › terminal », retiré avec les autres dépliants
-// (#30) : la carte 2D du parcours montre la même géographie. Ce dépliant-ci survit parce que la
-// carte, elle, n'affiche aucun chiffre — c'est le seul endroit qui dit ce que contient une ligne
-// « 3 commodités ». La durée du trajet, qui vivait dans le schéma, reste lisible dans l'infobulle
-// de la colonne « Profit/h ».
+// `multiRowHTML` a été remplacé par vues/trajets.tsx.
 function multiCargoHTML(t) {
   const lines = t.lines.map((l) =>
     `<div class="sline">${commodityIcon(l.kind)}` +
@@ -578,44 +590,7 @@ function multiCargoHTML(t) {
 }
 
 // Ligne de tableau pour une route évaluée (partagée par « Trajets simples » et « En route »).
-function routeRowHTML(r, i) {
-  // Plafond de caisse du terminal d'ACHAT, lu du marché et non du contexte de frais : c'est une
-  // propriété physique de la station (cf. scuBoxesLabel). Le prendre dans `feeInfo` le faisait
-  // disparaître dès l'interrupteur relâché, et la ligne du tableau annonçait alors « 3×32 » à côté
-  // d'un manifeste qui, lui, affichait « 6×16 » pour la même cargaison au même terminal.
-  const maxBox = (termByName.get(r.buy.terminal) || {}).maxBox;
-  const fc = feeCell(r.feeInfo, r.fees, () => feeLoadText(r.units, maxBox), r.units > 0);
-  const cross = r.same_system ? "" : '<span class="cross">⚡ saut inter-système</span>';
-  return `
-      <tr data-row="${i}">
-        <td class="loc">
-          <div class="commodity-cell"><button class="journey-pick" data-row="${i}" title="Faire ce trajet — compagnon de voyage" aria-label="Sélectionner ce trajet">▶</button>${commodityIcon(r.kind)}<span class="cname">${esc(r.commodity)}</span></div>
-          <div class="loc-badges">${illegalTag(r.illegal)}${suspectTag(r)}${cross}</div>
-        </td>
-        <td class="loc">
-          <div class="term-name">${esc(r.buy.terminal)}</div>
-          <div class="loc-badges">${sysBadge(r.buy.system)}${outpostTag(r.buy.outpost)}</div>
-          <div class="loc-sub">${esc(r.buy.planet)} · ${editv(r.commodity, r.buy.terminal, "buy", "price", r.buy.price, r.buy.ovPrice, r.buy.updated)} aUEC · ${statusDot(r.buy.status, "buy")}<span class="stock" title="Stock disponible à l'achat (relevé UEX)">stock ${editv(r.commodity, r.buy.terminal, "buy", "vol", r.buy.stock, r.buy.ovVol, r.buy.updated)} SCU</span></div>
-          <div class="loc-fresh">${freshChip(r.buy.updated)}</div>
-        </td>
-        <td class="loc">
-          <div class="term-name">${esc(r.sell.terminal)}</div>
-          <div class="loc-badges">${sysBadge(r.sell.system)}${outpostTag(r.sell.outpost)}</div>
-          <div class="loc-sub">${esc(r.sell.planet)} · ${editv(r.commodity, r.sell.terminal, "sell", "price", r.sell.price, r.sell.ovPrice, r.sell.updated)} aUEC · ${statusDot(r.sell.status, "sell")}<span class="stock" title="Demande à la vente = capacité restante du terminal (relevé UEX)">demande ${editv(r.commodity, r.sell.terminal, "sell", "vol", r.sell.demand, r.sell.ovVol, r.sell.updated)} SCU</span></div>
-          <div class="loc-fresh">${freshChip(r.sell.updated)}</div>
-        </td>
-        <td>${fiabiliteCell(r.fiabilite, r.age, r.partVolume)}</td>
-        <td class="num"${fc.attr}>${fmtFee(r.margin, r.fees)}</td>
-        <td class="num roi-badge"${fc.attr}>${r.fees > 0 ? "≈ " : ""}${r.roi}%</td>
-        <td class="num"${r.units ? ` title="Caisses : ${scuBoxesLabel(r.units, maxBox)}"` : ""}>${fmt(r.units)}</td>
-        <td class="num">${fmt(r.investment)}</td>
-        <td class="num profit"${fc.attr}>${fmtFee(r.profit, r.fees)}${fc.mark}</td>
-        <td class="num profit" title="${withFeeText(`Estimation ${Math.round(r.minutes)} min/voyage`, fc)}">${fmtFee(r.profitHour, r.fees)}</td>
-      </tr>`;
-}
-
-// ---------- Vue "Boucles aller-retour" ----------
-// Corrige un segment de boucle (achat au terminal `buyT`, vente au terminal `sellT`).
+// `routeRowHTML` a été remplacé par vues/trajets.tsx, pour `#rows` ET `#enrouteRows`.
 function effLeg(leg, buyT, sellT) {
   const b = effVals(leg.commodity, buyT, "buy", leg.buyPrice, leg.stock, leg.updated);
   const s = effVals(leg.commodity, sellT, "sell", leg.sellPrice, leg.demand, leg.updated);
@@ -1255,7 +1230,7 @@ function renderEnRoute() {
   renderManifest(enrouteOrigin, $("destSystem").value, f, enrouteDest);
 
   if (enrouteOrigin == null) {
-    $("enrouteRows").innerHTML = "";
+    peindre($("enrouteRows"), null);
     emptyMsg.hidden = false;
     emptyMsg.textContent = "Choisis un terminal de départ pour voir le fret à emporter.";
     return;
@@ -1273,7 +1248,7 @@ function renderEnRoute() {
 
   deals.sort(bySort(sortKey, sortDir));
   shownEnroute = deals;
-  $("enrouteRows").innerHTML = deals.map(routeRowHTML).join("");
+  peindre($("enrouteRows"), vueTrajets({ ...propsTrajetsCommunes(), ...propsLignesSimples(), lignes: deals }));
   emptyMsg.hidden = deals.length > 0;
   if (!deals.length) emptyMsg.textContent = "Aucun fret rentable depuis ce terminal avec ces filtres.";
   notifySuperseded();

--- a/e2e/edition.pw.mjs
+++ b/e2e/edition.pw.mjs
@@ -103,9 +103,16 @@ test("Édition React : app.js ne vient PAS muter un nœud possédé par React (#
   await cellule.click();
   await expect(cellule.locator("input.editv-input"), "deux champs : startEdit est venu muter le nœud React").toHaveCount(1);
 
-  // Et les valeurs éditables de la vue Trajets, elles, restent gérées par app.js.
+  // Et le garde n'a pas rendu `startEdit` inerte pour autant : les valeurs éditables du MANIFESTE
+  // sont encore écrites en HTML par app.js (`editv()`, app.js:424) et s'ouvrent par la délégation.
+  // C'était la vue Trajets qui tenait ce rôle ici ; elle est passée à React avec « En route »
+  // (elles partageaient leur rendu de ligne), et le manifeste est désormais le dernier `.editv`
+  // vanilla — donc le seul endroit où les deux chemins se distinguent encore vraiment.
   await page.click("#viewRoutes");
-  const vanilla = page.locator("#rows .editv").first();
+  await page.locator("#rows tr").first().locator(".journey-pick").click();
+  await page.click("#viewEnroute");
+  const vanilla = page.locator("#manifest .editv").first();
+  await expect(vanilla).toBeVisible({ timeout: 8000 });
   await expect(vanilla).not.toHaveAttribute("data-react", "1");
   await vanilla.click();
   await expect(vanilla.locator("input")).toBeVisible();

--- a/vues/communs.tsx
+++ b/vues/communs.tsx
@@ -87,6 +87,7 @@ export function CelluleFiabilite({ f, age, part }: { f: number; age: number | nu
 //      le mouseup, ce qui avalait le clic suivant sur une autre cellule.
 //   3. Le `✎` reste DANS le span. Le sortir casserait la restauration (#30, cf. app.js).
 import { useState, useRef, useEffect } from "react";
+import { flushSync } from "react-dom";
 
 export type ProprietesValeurEditable = {
   valeur: number | null;
@@ -120,7 +121,15 @@ export function ValeurEditable({ valeur, commodite, terminal, cote, champ, relev
   const inconnue = valeur == null || !Number.isFinite(Number(valeur));
   const v = inconnue ? "" : String(valeur);
 
-  const ouvrir = () => { fini.current = false; setEnEdition(true); };
+  // OUVERTURE SYNCHRONE, et c'est un contrat, pas un raffinement. La version impérative faisait
+  // `span.replaceChildren(inp)` — le champ existait dès le retour du gestionnaire. React, lui,
+  // groupe les états et rend au tour suivant : le champ n'apparaîtrait qu'après.
+  //
+  // Quatorze tests dépendent de la première forme. Ils dispatchent un clic PROGRAMMATIQUE puis
+  // lisent `span.querySelector("input")` dans la foulée — sans `flushSync`, ils lisent `null`.
+  // Ce n'est pas un artefact de test : c'est le comportement que le dépôt a toujours eu, et le
+  // rendre asynchrone le changerait pour tout appelant qui mesure le DOM juste après.
+  const ouvrir = () => { fini.current = false; flushSync(() => setEnEdition(true)); };
 
   const clore = (enregistrer: boolean) => {
     if (fini.current) return;

--- a/vues/trajets.tsx
+++ b/vues/trajets.tsx
@@ -1,0 +1,238 @@
+// La vue Trajets, septième îlot React (ADR-008 #96) — et la vue par DÉFAUT.
+//
+// C'est celle que 74 tests e2e traversent explicitement, plus 49 qui n'en changent jamais : la
+// moindre divergence y est visible partout. Elle a deux modes qui partagent le même `<tbody>` :
+//   — SIMPLE   : une ligne = un couple achat/vente d'UNE commodité, avec ses valeurs éditables ;
+//   — MULTI    : une ligne = un chargement A→B composé de PLUSIEURS commodités, dépliable.
+//
+// Ce qui reste à app.js et n'a jamais été un obstacle : `#empty`, le <p> de message vide PARTAGÉ
+// par Trajets, Boucles et « En route ». Il n'est écrit que par `textContent` et `hidden` — jamais
+// en HTML — donc aucun îlot ne le possède et il n'entre en conflit avec rien. Le migrer n'aurait
+// rien apporté.
+//
+// Le `<thead>` et son tri restent eux aussi dans index.html, câblés par `setupSort` : React ne
+// possède que le corps du tableau, comme pour Boucles.
+import type { Route } from "../types.ts";
+import { BadgeSysteme, TagAvantPoste, TagIllegal, IconeCommodite, PastilleFraicheur, CelluleFiabilite, ValeurEditable, PastilleStatut } from "./communs.tsx";
+
+type Fmt = (n: number) => string;
+type CelluleFrais = { attr: string; mark: string; text: string };
+
+export type ProprietesCommunes = {
+  fmt: Fmt;
+  fmtVol: (n: number | null) => string;
+  fmtFee: (n: number, fees: number) => string;
+  avecTexteFrais: (base: string, cell: CelluleFrais) => string;
+  texteCapaciteInconnue: string;
+  legendeAchat: Record<number, [string, string]>;
+  legendeVente: Record<number, [string, string]>;
+  corriger: (commodite: string, terminal: string, cote: "buy" | "sell", champ: "price" | "vol", valeur: string, releve: number) => void;
+};
+
+// ── Mode SIMPLE ────────────────────────────────────────────────────────────────────────────────
+export type LigneTrajet = Route & {
+  fiabilite: number; age: number | null; partVolume: number;
+  units: number; investment: number; profit: number; profitHour: number; minutes: number; fees: number;
+  feeInfo: unknown;
+  buy: Route["buy"] & { ovPrice: boolean; ovVol: boolean };
+  sell: Route["sell"] & { ovPrice: boolean; ovVol: boolean };
+};
+
+export type ProprietesTrajets = ProprietesCommunes & {
+  lignes: LigneTrajet[];
+  celluleFrais: (r: LigneTrajet) => CelluleFrais;
+  /** « ⚠ à vérifier » : relevé de plus de 10 jours, ou prix très éloigné de la moyenne UEX. */
+  suspect: (r: LigneTrajet) => string | null;
+  /** Le libellé des caisses, qui dépend du plafond du terminal d'ACHAT — propriété physique de la
+   *  station, lue du marché et non du contexte de frais (sans quoi elle disparaît quand
+   *  l'interrupteur d'autoload est relâché). */
+  libelleCaisses: (r: LigneTrajet) => string | null;
+};
+
+function BoutonVoyage({ i }: { i: number }) {
+  // `data-row` est un CONTRAT : une délégation posée sur `document` lit `shownRoutes[dataset.row]`.
+  return (
+    <button className="journey-pick" data-row={i} title="Faire ce trajet — compagnon de voyage" aria-label="Sélectionner ce trajet">▶</button>
+  );
+}
+
+function LigneSimple({ r, i, celluleFrais, suspect, libelleCaisses, ...c }: {
+  r: LigneTrajet; i: number;
+  celluleFrais: ProprietesTrajets["celluleFrais"];
+  suspect: ProprietesTrajets["suspect"];
+  libelleCaisses: ProprietesTrajets["libelleCaisses"];
+} & ProprietesCommunes) {
+  const fc = celluleFrais(r);
+  const titreFrais = fc.text || undefined;
+  const alerte = suspect(r);
+  const caisses = libelleCaisses(r);
+
+  const bout = (cote: "buy" | "sell") => {
+    // Le champ de volume porte un NOM différent selon le côté — `stock` à l'achat, `demand` à la
+    // vente — et ce ne sont pas la même chose : `demand: null` veut dire « capacité inconnue chez
+    // UEX », ni zéro ni illimitée. Le tuple est donc lu côté par côté.
+    const p = cote === "buy" ? r.buy : r.sell;
+    const volume = cote === "buy" ? r.buy.stock : r.sell.demand;
+    const editable = (champ: "price" | "vol", valeur: number | null | undefined, corrige: boolean) => (
+      <ValeurEditable valeur={valeur ?? null} corrige={corrige} fmtVol={c.fmtVol}
+                      commodite={r.commodity} terminal={p.terminal} cote={cote} champ={champ} releve={p.updated}
+                      texteCapaciteInconnue={c.texteCapaciteInconnue}
+                      onCorriger={(v) => c.corriger(r.commodity, p.terminal, cote, champ, v, p.updated)} />
+    );
+    return (
+      <td className="loc">
+        <div className="term-name">{p.terminal}</div>
+        <div className="loc-badges"><BadgeSysteme system={p.system} /><TagAvantPoste outpost={p.outpost} /></div>
+        <div className="loc-sub">
+          {p.planet} · {editable("price", p.price, p.ovPrice)} aUEC ·{" "}
+          <PastilleStatut code={p.status} cote={cote} legende={cote === "buy" ? c.legendeAchat : c.legendeVente} />
+          <span className="stock" title={cote === "buy"
+            ? "Stock disponible à l'achat (relevé UEX)"
+            : "Demande à la vente = capacité restante du terminal (relevé UEX)"}>
+            {cote === "buy" ? "stock " : "demande "}{editable("vol", volume, p.ovVol)} SCU
+          </span>
+        </div>
+        <div className="loc-fresh"><PastilleFraicheur updated={p.updated} /></div>
+      </td>
+    );
+  };
+
+  return (
+    <tr data-row={i}>
+      <td className="loc">
+        <div className="commodity-cell">
+          <BoutonVoyage i={i} />
+          <IconeCommodite kind={r.kind} />
+          <span className="cname">{r.commodity}</span>
+        </div>
+        <div className="loc-badges">
+          <TagIllegal illegal={r.illegal} />
+          {alerte ? <> <span className="suspect" title={`À vérifier en jeu : ${alerte}`}>⚠ à vérifier</span></> : null}
+          {r.same_system ? null : <span className="cross">⚡ saut inter-système</span>}
+        </div>
+      </td>
+      {bout("buy")}
+      {bout("sell")}
+      <td><CelluleFiabilite f={r.fiabilite} age={r.age} part={r.partVolume} /></td>
+      <td className="num" title={titreFrais}>{c.fmtFee(r.margin, r.fees)}</td>
+      <td className="num roi-badge" title={titreFrais}>{r.fees > 0 ? "≈ " : ""}{r.roi}%</td>
+      <td className="num" title={caisses ? `Caisses : ${caisses}` : undefined}>{c.fmt(r.units)}</td>
+      <td className="num">{c.fmt(r.investment)}</td>
+      <td className="num profit" title={titreFrais}>
+        {c.fmtFee(r.profit, r.fees)}
+        {fc.mark ? <> <span className="nofee">⊘</span></> : null}
+      </td>
+      <td className="num profit" title={c.avecTexteFrais(`Estimation ${Math.round(r.minutes)} min/voyage`, fc)}>
+        {c.fmtFee(r.profitHour, r.fees)}
+      </td>
+    </tr>
+  );
+}
+
+export function VueTrajets({ lignes, celluleFrais, suspect, libelleCaisses, ...c }: ProprietesTrajets) {
+  return (
+    <>
+      {lignes.map((r, i) => (
+        <LigneSimple key={i} r={r} i={i} celluleFrais={celluleFrais} suspect={suspect} libelleCaisses={libelleCaisses} {...c} />
+      ))}
+    </>
+  );
+}
+
+// ── Mode MULTI-COMMODITÉ ───────────────────────────────────────────────────────────────────────
+export type LigneMulti = {
+  origin: { name: string; system: string; planet: string; outpost: boolean; maxBox?: number };
+  dest: { name: string; system: string; planet: string; outpost: boolean };
+  lines: { name: string; kind: string; units: number; illegal: boolean }[];
+  cross: boolean;
+  fiabilite: number; age: number | null; partVolume: number;
+  margin: number; roi: number; units: number; investment: number;
+  profit: number; profitHour: number; minutes: number; fees: number;
+  feeInfo: unknown;
+};
+
+export type ProprietesMulti = ProprietesCommunes & {
+  lignes: LigneMulti[];
+  celluleFrais: (t: LigneMulti) => CelluleFrais;
+  libelleCaisses: (t: LigneMulti) => string | null;
+  /** Le relevé le plus ANCIEN du chargement : un trajet ne vaut pas mieux que sa ligne la moins sûre. */
+  releveLePlusAncien: (t: LigneMulti) => number;
+};
+
+const MAX_ICONES = 6;
+
+function LigneComposee({ t, i, celluleFrais, libelleCaisses, releveLePlusAncien, ...c }: {
+  t: LigneMulti; i: number;
+  celluleFrais: ProprietesMulti["celluleFrais"];
+  libelleCaisses: ProprietesMulti["libelleCaisses"];
+  releveLePlusAncien: ProprietesMulti["releveLePlusAncien"];
+} & ProprietesCommunes) {
+  const n = t.lines.length;
+  const fc = celluleFrais(t);
+  const titreFrais = fc.text || undefined;
+  const caisses = libelleCaisses(t);
+  const noms = t.lines.map((l) => `${l.name} (${c.fmt(l.units)} SCU)`).join(" · ");
+
+  const bout = (p: LigneMulti["origin"] | LigneMulti["dest"], fraicheur: number | null) => (
+    <td className="loc">
+      <div className="term-name">{p.name}</div>
+      <div className="loc-badges"><BadgeSysteme system={p.system} /><TagAvantPoste outpost={p.outpost} /></div>
+      <div className="loc-sub">{p.planet}</div>
+      {fraicheur != null ? <div className="loc-fresh"><PastilleFraicheur updated={fraicheur} /></div> : null}
+    </td>
+  );
+
+  return (
+    <tr data-row={i}>
+      <td className="loc">
+        <div className="commodity-cell">
+          <BoutonVoyage i={i} />
+          {/* `.route-toggle` déplie le chargement. Sa délégation lit `shownMulti[dataset.row]` :
+              l'index doit correspondre au rang, comme pour `.journey-pick`. */}
+          <button className="route-toggle" data-row={i} title="Voir le chargement" aria-label="Voir le chargement">📦</button>
+          <span className="multi-icons" title={noms}>
+            {t.lines.slice(0, MAX_ICONES).map((l, k) => <IconeCommodite key={k} kind={l.kind} />)}
+            {n > MAX_ICONES ? <span className="muted">+{n - MAX_ICONES}</span> : null}
+          </span>
+          {/* UNE seule expression, et non `{n} commodité{n > 1 ? "s" : ""}` : cette forme-là produit
+              TROIS nœuds de texte (« 3 », «  commodité », « s ») là où le gabarit n'en produisait
+              qu'un. Le crénage ne traverse pas une frontière de nœud, et la largeur du span y perdait
+              1/32 px — mesuré sur les 300 lignes du mode multi, contre zéro écart partout ailleurs. */}
+          <span className="cname">{`${n} commodité${n > 1 ? "s" : ""}`}</span>
+        </div>
+        <div className="loc-badges">
+          {t.lines.some((l) => l.illegal) ? <TagIllegal illegal={true} /> : null}
+          {t.cross ? <span className="cross">⚡ saut inter-système</span> : null}
+        </div>
+      </td>
+      {bout(t.origin, releveLePlusAncien(t))}
+      {bout(t.dest, null)}
+      <td><CelluleFiabilite f={t.fiabilite} age={t.age} part={t.partVolume} /></td>
+      <td className="num" title={c.avecTexteFrais("Marge moyenne pondérée par SCU chargé", fc)}>{c.fmtFee(t.margin, t.fees)}</td>
+      <td className="num roi-badge" title={titreFrais}>{t.fees > 0 ? "≈ " : ""}{t.roi}%</td>
+      <td className="num" title={caisses ? `Caisses : ${caisses}` : undefined}>{c.fmt(t.units)}</td>
+      <td className="num">{c.fmt(t.investment)}</td>
+      <td className="num profit" title={titreFrais}>
+        {c.fmtFee(t.profit, t.fees)}
+        {fc.mark ? <> <span className="nofee">⊘</span></> : null}
+      </td>
+      <td className="num profit" title={c.avecTexteFrais(`Estimation ${Math.round(t.minutes)} min/voyage`, fc)}>
+        {c.fmtFee(t.profitHour, t.fees)}
+      </td>
+    </tr>
+  );
+}
+
+export function VueTrajetsMulti({ lignes, celluleFrais, libelleCaisses, releveLePlusAncien, ...c }: ProprietesMulti) {
+  return (
+    <>
+      {lignes.map((t, i) => (
+        <LigneComposee key={i} t={t} i={i} celluleFrais={celluleFrais} libelleCaisses={libelleCaisses}
+                       releveLePlusAncien={releveLePlusAncien} {...c} />
+      ))}
+    </>
+  );
+}
+
+export const vueTrajets = (p: ProprietesTrajets) => <VueTrajets {...p} />;
+export const vueTrajetsMulti = (p: ProprietesMulti) => <VueTrajetsMulti {...p} />;


### PR DESCRIPTION
## Ce que ça change

Les deux dernières tables à lignes simples — **Trajets** (`#rows`, modes simple et multi) et
**En route** (`#enrouteRows`) — sont rendues par React. Rien ne bouge à l'écran : 23 887 formes
comparées en styles calculés, **zéro écart**.

Au passage, cliquer une valeur corrigeable ouvre son champ **synchronement**, comme avant.

## Pourquoi

Septième lot de la refonte v2 (#96, ADR-008). Deux points ont demandé une correction, tous deux
mesurés :

1. **`routeRowHTML` avait DEUX appelants.** `render()` (`app.js:498`) et `renderEnRoute()`
   (`app.js:1241`) partageaient le même rendu de ligne depuis toujours. Ne migrer que Trajets
   supprimait la fonction sous les pieds d'« En route » : 13 tests tombaient, groupés sur la Soute,
   le Manifeste et le compagnon de voyage — tout ce qui passe par le `▶` d'une ligne. D'où
   `propsLignesSimples()`, et l'îlot peint les deux tables.

2. **L'ouverture de l'édition était devenue asynchrone.** `startEdit` faisait
   `span.replaceChildren(inp)` : le champ existait dès le retour du gestionnaire. React groupe les
   états et rend au tour suivant. Quatorze tests dispatchent un clic programmatique puis lisent
   `span.querySelector("input")` dans la foulée — ils lisaient `null`. `flushSync` autour du
   `setEnEdition(true)` (`vues/communs.tsx`) rend le contrat d'origine, plutôt que d'adapter les
   tests à la régression.

**Piège JSX mesuré, à ne pas réintroduire** : `{n} commodité{n > 1 ? "s" : ""}` produit **trois**
nœuds de texte là où le gabarit n'en produisait qu'un. Le crénage ne traverse pas une frontière de
nœud, et `span.cname` y perdait 1/32 px — 300 écarts au relevé, contre zéro partout ailleurs.
Corrigé par une expression unique. Aucun test d'apparence ne l'aurait vu.

## Vérification

```
$ npm test
ℹ tests 483
ℹ pass 483
ℹ fail 0

$ npx playwright test
  207 passed (1.5m)
  2 skipped

$ npx tsc --noEmit
(0 erreur)
```

Les 207 e2e passent **sans qu'aucun n'ait été adapté**, à une exception assumée :
`e2e/edition.pw.mjs:95` affirmait que `#rows .editv` n'est PAS possédé par React — vrai quand
Trajets était vanilla, faux par construction maintenant. Sa seconde moitié vise désormais le
**manifeste**, dernier `.editv` écrit en HTML par `app.js` (`editv()`, `app.js:424`), donc le seul
endroit où les deux chemins se distinguent encore.

Avant le correctif de `routeRowHTML` : **13 échecs**. Avant `flushSync` : **14**.

**Relevé des styles calculés** (clé par rang, scopé, animations figées), `v2/main` contre cette
branche, les deux mesures prises coup sur coup :

```
== trajets-simple == comparées 13180 / identiques 13180 / différentes 0 / DISPARUES 0 / APPARUES 0
== trajets-multi  == comparées 10574 / identiques 10574 / différentes 0 / DISPARUES 0 / APPARUES 0
== enroute        == comparées   133 / identiques   133 / différentes 0 / DISPARUES 0 / APPARUES 0
== TOTAL          == comparées 23887 / identiques 23887 / différentes 0 / DISPARUES 0 / APPARUES 0
```

Contrôle : le même build mesuré deux fois donne 0 écart — la mesure est déterministe. Un score de
fiabilité franchit un palier d'âge en cours de session (40 → 39, `s-ok` → `s-low`) ; les 300
infobulles de score sont identiques ligne pour ligne entre les deux builds (`diff` vide).

## Ce qui n'est pas couvert

- **« En route » n'est migrée que pour sa TABLE.** Le compagnon de voyage, le manifeste et ses
  6 globales (dont `JOURNEY`, 33 références) restent impératifs — c'est le lot suivant, et le
  dernier.
- Le **manifeste** garde ses `.editv` vanilla, donc `startEdit` et ses deux délégations restent
  nécessaires.
- Les tableaux indexés par rang (`shownRoutes`, `shownEnroute`, `shownMulti`) que les délégations
  `document` lisent via `data-row` restent dans `app.js` : les sortir est le préalable à sa
  suppression, pas ce lot-ci.
- Le piège des nœuds de texte scindés n'a **pas** de garde permanent : il se voit au relevé, qui
  est un outil de PR et non un test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
