### PR TITLE
feat(manifeste): la carte passe en React, et la dernière édition impérative disparaît

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,6 +34,7 @@ import { vueGrilleCommodites, aideBoard, vueDetailCommodite, inviteDetail } from
 import { vueStation, vueBandeCorrections, inviteStation } from "./vues/corrections.tsx";
 import { enTetePlan, corpsPlan } from "./vues/plan.tsx";
 import { vueTrajets, vueTrajetsMulti } from "./vues/trajets.tsx";
+import { carteManifeste, indiceManifeste, suggestions as vueSuggestions } from "./vues/manifeste.tsx";
 import { KIND_ICON } from "./vues/communs.tsx";
 
 // Libellé compact des caisses SCU standard, ex. « 8×32 · 1×16 · 1×4 · 1×2 · 1×1 ».
@@ -419,22 +420,10 @@ function fiabiliteCell(f, age, part) {
   return `<div class="score-cell" title="${esc(titre)}"><span class="scorebar ${tier}"><i style="width:${scoreBarWidth(f)}%"></i></span><b>${f}</b></div>`;
 }
 
-// Valeur éditable (clic pour corriger localement). side = "buy"|"sell", field = "price"|"vol".
-// updated = date UEX du point (mémorisée comme base de fraîcheur de la correction).
-function editv(commodity, terminal, side, field, value, ov, updated) {
-  // `data-v` et `data-u` étaient les deux seules interpolations du rendu à ne pas passer par esc().
-  // Elles reçoivent des champs UEX, que le pipeline coerce désormais en nombre (numField) — mais un
-  // instantané déjà déployé, ou un data/ servi depuis le cache du service worker, peut encore
-  // contenir n'importe quoi. Une valeur non numérique n'a de toute façon aucun sens ici : le champ
-  // number de l'éditeur la rejetterait. On la ramène donc à « inconnu » plutôt que de l'écrire.
-  const v = Number.isFinite(Number(value)) ? Number(value) : null;
-  const u = Number.isFinite(Number(updated)) ? Number(updated) : 0;
-  // value null = capacité inconnue chez UEX, affichée « n.c. » (cf. fmtVol). On n'injecte pas la
-  // chaîne "null" dans data-v, sinon le champ number la rejette à l'ouverture de l'édition.
-  const unknown = value == null || v == null;
-  const hint = unknown ? `${VOL_UNKNOWN_HINT}. Clic pour le corriger localement` : "Clic pour corriger localement ce chiffre";
-  return `<span class="editv${unknown ? " nc" : ""}${ov ? " ov" : ""}" data-c="${esc(commodity)}" data-t="${esc(terminal)}" data-s="${side}" data-f="${field}" data-v="${unknown ? "" : esc(v)}" data-u="${esc(u)}" role="button" tabindex="0" title="${hint}">${fmtVol(value)}${ov ? '<span class="ovmark" title="Corrigé localement">✎</span>' : ""}</span>`;
-}
+// La valeur éditable est rendue par `ValeurEditable` (vues/communs.tsx). `editv()` fabriquait le
+// même span en chaîne pour les vues restées impératives ; la dernière — le manifeste — est passée
+// à React, donc plus personne ne l'appelait. `e2e/edition.pw.mjs` vérifie qu'aucun `.editv` de
+// l'application n'échappe à React, ce qui est la condition de cette suppression.
 
 // Lit l'état de tous les contrôles de filtre (partagé par les deux vues).
 function readFilters() {
@@ -876,14 +865,9 @@ function resetManifeste() { oublierManifeste(); refresh(); }
 // de la carte ET à leur pose en direct à la première frappe dans un champ SCU : celle-là ne repeint
 // pas la carte (elle arracherait le champ qu'on remplit), et sans ces deux-là rien à l'écran ne
 // dirait que la carte est désormais la tienne, ni comment la rendre au calcul.
-const MANIFEST_MARQUE = '<span class="manifest-edited" title="Chargement composé à la main : ses lignes, ses SCU et cette destination sont les tiens. Les prix, eux, continuent de suivre le marché. « ↺ optimal » rend la main au calcul.">✎</span>';
-const MANIFEST_BOUTON_OPTIMAL = '<button id="manifestReset" type="button" class="manifest-reset" title="Revenir au chargement optimal calculé pour ce départ">↺ optimal</button>';
-function marquerManifesteCompose() {
-  const titre = $("manifest").querySelector(".manifest-title");
-  if (titre && !titre.querySelector(".manifest-edited")) titre.insertAdjacentHTML("beforeend", " " + MANIFEST_MARQUE);
-  const ajout = $("manifest").querySelector(".manifest-add");
-  if (ajout && !$("manifestReset")) ajout.insertAdjacentHTML("beforeend", MANIFEST_BOUTON_OPTIMAL);
-}
+// Le ✎ et le bouton « ↺ optimal » sont rendus par vues/manifeste.tsx d'après `MANIFEST_EDIT`.
+// Ils étaient injectés par `insertAdjacentHTML` DANS une carte déjà rendue, faute de pouvoir la
+// repeindre sans arracher le champ en cours de frappe — la contrainte a disparu avec l'îlot.
 
 // La composition vaut-elle pour la carte demandée ? Sinon elle est abandonnée SUR PLACE : la garder
 // en réserve la ferait ressurgir au retour sur cette route, longtemps après le geste qui l'a écrite.
@@ -937,17 +921,7 @@ const isOv = (commodity, terminal, side, field) => {
 };
 
 // `m` = manifeste courant (il porte `fee`, le contexte de frais qui l'a produit) ; `t` = ses totaux.
-function manifestTotalsHTML(m, t) {
-  const empty = m.cargo - t.scu;
-  const profitHour = (t.profit * 60) / tripMinutes(0, m.cross);
-  // Les frais sont exposés à part plutôt que fondus dans le profit : c'est le seul moyen de voir
-  // ce que coûte la manutention d'un chargement à plusieurs commodités (une base par ligne).
-  const fees = t.fees > 0 ? ` · <span class="fee-chip" title="${m.feeInfo ? esc(`${feeEndText(m.feeInfo.a)} · ${feeEndText(m.feeInfo.b)} · une transaction par commodité · estimation ±3 %`) : ""}">frais ≈ ${fmt(t.fees)}</span>` : "";
-  // `m.aBord` : la soute n'était pas vide, le manifeste ne remplit donc que la place restante.
-  // Le dire ici évite de lire « 47/47 SCU » sur un vaisseau de 96 sans comprendre pourquoi.
-  const bord = m.aBord > 0 ? ` · <span class="mbord" title="Déjà en soute, payé — cf. panneau Soute">${fmt(m.aBord)} SCU à bord</span>` : "";
-  return `Profit <b class="profit">${fmtFee(t.profit, t.fees)}</b> aUEC${fees} · <b>${fmt(t.scu)}</b>/${fmt(m.cargo)} SCU${bord}${empty > 0 ? ` · ${fmt(empty)} SCU vides` : ""} · invest. ${fmt(t.invest)} · ~${fmtFee(profitHour, t.fees)}/h`;
-}
+// Les totaux du manifeste sont rendus par vues/manifeste.tsx (`<Totaux>`).
 
 // Espace/budget restants d'après les SCU actuellement affectés.
 // m = contexte de manifeste { lines, cargo, f, originIdx, destIdx, origin, dest } ; par défaut
@@ -967,31 +941,9 @@ const suggestionsFor = (m = currentManifest) => suggestionsFrom(MARKET, m, effVa
 
 // HTML des suggestions de remplissage pour un contexte de manifeste (En route ou jambe de voyage).
 // `addAttrs` = attributs data-* posés sur le bouton d'ajout, propres à l'appelant.
-function suggestionsHTML(m, addAttrs = "") {
-  const rem = manifestRemaining(m);
-  if (rem.cargoLeft <= 0) return "";
-  const sugg = suggestionsFor(m).map((it) => ({ it, u: addableUnits(it, rem) })).filter((x) => x.u >= 1)
-    // Frais actifs : une commodité dont la manutention mange la marge fait PERDRE de l'argent, et
-    // le manifeste optimal l'écarte déjà (manifestsFrom). La proposer en tête, juste sous le
-    // manifeste qui vient de la refuser, serait une contradiction à l'écran.
-    .filter((x) => !m.fee || lineNet(x.u, x.it, m.fee) > 0)
-    .slice(0, 6);
-  if (!sugg.length) return `<div class="suggest-head">${fmt(rem.cargoLeft)} SCU libres — aucune autre commodité rentable vers cette destination.</div>`;
-  return `<div class="suggest-head">Remplir les ${fmt(rem.cargoLeft)} SCU libres — suggestions :</div>` +
-    sugg.map(({ it, u }) =>
-      `<div class="sline">${commodityIcon(it.kind)}` +
-      `<span class="mname">${esc(it.name)}${illegalTag(it.illegal)}</span>` +
-      `<span class="mstock">stock ${fmt(it.stock)} · dem. ${fmtVol(it.demand)}</span>` +
-      `<span class="mprice">${fmt(it.buyPrice)} → ${fmt(it.sellPrice)} · marge ${fmt(it.margin)}</span>` +
-      `<button class="suggest-add" data-name="${esc(it.name)}"${addAttrs} title="Ajouter au manifeste">+ ${fmt(u)} SCU</button></div>`
-    ).join("");
-}
-
-function renderSuggestions() {
-  const box = $("manifestSuggest");
-  if (!box || !currentManifest) return;
-  box.innerHTML = suggestionsHTML(currentManifest);
-}
+// Les suggestions de remplissage sont rendues par vues/manifeste.tsx (`<Suggestions>`), pour la
+// carte comme pour une jambe du compagnon. `suggestionsHTML` produisait le MÊME balisage en chaîne
+// et n'a plus lieu d'être : deux fabriques du même bloc auraient fini par diverger.
 
 function addSuggestion(name) {
   const it = suggestionsFor().find((x) => x.name === name);
@@ -1032,99 +984,59 @@ function removeManifestLine(name) {
 // L'état vient de manifestJourneyState (pur, testé) — le rendu ne décide de rien.
 // Le bouton n'existe QUE dans l'état « ajouter », donc la branche REMPLACER d'addToJourney, qui
 // efface un voyage sans prévenir, est inatteignable depuis cette carte.
-function manifestJourneyHTML(m) {
-  if (!m.lines.length) return `<span class="journey-hint">Manifeste vide — ajoute une commodité pour l'engager.</span>`;
-  const st = manifestJourneyState(JOURNEY, m.origin, m.dest);
-  if (st.etat === "ajouter") {
-    const neuf = !JOURNEY;
-    return `<button id="manifestToJourney" class="chain-pick" title="${neuf ? "Démarrer un voyage avec ce chargement" : "Ajouter ce chargement à la suite du voyage"}">▶ ${neuf ? "Démarrer un voyage" : "Ajouter au voyage"}</button>`;
-  }
-  // « Déjà » est l'état NORMAL après tout ▶ (En route est pré-rempli avec la jambe courante) et
-  // celui où l'on retombe après un ajout réussi : la phrase fait donc office de confirmation, à
-  // l'endroit exact du clic. Un bouton y serait un clic mort.
-  if (st.etat === "deja") return `<span class="journey-hint">✓ C'est déjà la jambe ${st.leg + 1} de ton voyage.</span>`;
-  if (!st.fin) return "";
-  return `<span class="journey-hint">Ce chargement part de <b>${esc(m.origin.name)}</b>, mais le voyage se termine à <b>${esc(st.fin)}</b> — seul un chargement au départ de <b>${esc(st.fin)}</b> s'y ajoute.</span>`;
-}
+// Le bouton « ▶ Ajouter au voyage » et ses phrases sont rendus par vues/manifeste.tsx.
 
 // Dessine le manifeste courant : totaux + lignes (SCU/prix/stock éditables) + suggestions.
+// Tout ce qui suit dépend de l'ÉTAT GLOBAL (le marché, les corrections, le parcours, la
+// composition à la main) ; la mise en forme, elle, vit dans l'îlot.
 function paintManifest() {
   const m = currentManifest;
-  const card = $("manifest");
-  const totals = manifestTotals(m.lines, m.fee);
-  card.hidden = false;
-  card.innerHTML =
-    `<div class="manifest-head">
-      <span class="manifest-title">◈ Manifeste — ${esc(m.origin.name)}${sysBadge(m.origin.system)} → ${esc(m.dest.name)}${sysBadge(m.dest.system)}${m.cross ? ' <span class="cross">⚡ inter-système</span>' : ""}${MANIFEST_EDIT ? " " + MANIFEST_MARQUE : ""}</span>
-      <span class="manifest-tot" id="manifestTot">${manifestTotalsHTML(m, totals)}</span>
-      ${manifestJourneyHTML(m)}
-      <button id="copyManifest" class="copy-btn" title="Copier le plan de chargement">⧉ Copier</button>
-    </div>
-    <div class="manifest-lines">` +
-    m.lines.map((l, i) => {
-      const carry = l.sellPrice == null; // pas vendable à cette destination -> à écouler ailleurs
-      // Symétrique : aucun point d'achat au départ -> le fret est DÉJÀ en soute (butin, minage,
-      // salvage). Afficher un prix « 0 » éditable le ferait passer pour un achat gratuit sur place.
-      const acq = !!l.acquired;
-      const demCell = carry ? '<span class="muted">—</span>' : editv(l.name, m.dest.name, "sell", "vol", l.demand, isOv(l.name, m.dest.name, "sell", "vol"), l.sellUpdated);
-      const sellCell = carry ? '<span class="carry-tag" title="Pas vendable à cette destination — à écouler ailleurs">vend ailleurs</span>' : editv(l.name, m.dest.name, "sell", "price", l.sellPrice, isOv(l.name, m.dest.name, "sell", "price"), l.sellUpdated);
-      const stockCell = acq ? '<span class="muted">—</span>' : editv(l.name, m.origin.name, "buy", "vol", l.stock, isOv(l.name, m.origin.name, "buy", "vol"), l.buyUpdated);
-      const buyCell = acq ? '<span class="carry-tag" title="Introuvable à l\'achat ici — fret déjà en soute (butin, minage, salvage). Ajuste les SCU à ce que tu transportes.">acquis ailleurs</span>' : editv(l.name, m.origin.name, "buy", "price", l.buyPrice, isOv(l.name, m.origin.name, "buy", "price"), l.buyUpdated);
-      const lineFees = lineHaulFee(l.units, l, m.fee);
-      // Une ligne « vend ailleurs » n'a pas de profit ICI (elle sera écoulée plus loin), mais elle
-      // a bien été CHARGÉE ici : ses frais sont retranchés du total. Les taire laissait le total
-      // baisser sans qu'aucune ligne à l'écran ne l'explique.
-      const profitCell = carry
-        ? `<span class="mprofit muted"${lineFees > 0 ? ' title="Chargée ici, vendue ailleurs : seul le chargement est facturé sur ce trajet"' : ""}>${lineProfitText(l.units, l, m.fee)}</span>`
-        : `<span class="mprofit profit">${lineProfitText(l.units, l, m.fee)}</span>`;
-      return `<div class="mline${carry ? " carry" : ""}${acq ? " acquired" : ""}">${commodityIcon(l.kind)}` +
-        `<span class="mqtywrap"><input type="number" class="mqty-input" min="0" value="${l.units}" data-i="${i}" data-cap="${l.cap}" title="Ajuste librement — tu peux dépasser le stock UEX (vol de fret, relevé périmé…)" aria-label="SCU ${esc(l.name)}"><span class="munit">SCU</span></span>` +
-        `<span class="mname">${esc(l.name)}${illegalTag(l.illegal)}<button class="mline-del" data-name="${esc(l.name)}" title="Retirer du manifeste" aria-label="Retirer">✕</button></span>` +
-        `<span class="mstock">stock ${stockCell} · dem. ${demCell}</span>` +
-        `<span class="mprice">${buyCell} → ${sellCell}</span>` +
-        profitCell +
-        `<span class="mboxes" title="Caisses SCU standard à charger">📦 ${scuBoxesLabel(l.units, m.origin.maxBox)}</span></div>`;
-    }).join("") +
-    `</div>
-    <div class="manifest-add">
-      <input id="manifestAddInput" list="commodityList" placeholder="Ajouter n'importe quelle commodité (même non vendable ici)…" autocomplete="off" aria-label="Ajouter une commodité" />
-      <button id="manifestAddBtn" type="button" class="copy-btn">+ Ajouter</button>
-      ${MANIFEST_EDIT ? MANIFEST_BOUTON_OPTIMAL : ""}
-    </div>
-    <div id="manifestSuggest" class="manifest-suggest"></div>`;
-  renderSuggestions();
+  $("manifest").hidden = false;
+  peindre($("manifest"), carteManifeste({
+    m,
+    generation: manifestGen,
+    compose: !!MANIFEST_EDIT,
+    parcours: JOURNEY,
+    suggestions: suggestionsFor(m),
+    restant: manifestRemaining(m),
+    fmt, fmtVol, fmtFee, signe,
+    libelleCaisses: (units) => scuBoxesLabel(units, m.origin.maxBox),
+    texteBoutFrais: feeEndText,
+    minutesTrajet: tripMinutes(0, m.cross),
+    estCorrige: isOv,
+    texteCapaciteInconnue: VOL_UNKNOWN_HINT,
+    corriger: (commodite, terminal, cote, champ, valeur, releve) => {
+      if (champ === "vol") pinLegsForVolume(commodite, terminal, cote);
+      setOverride(commodite, terminal, cote, champ, valeur === "" ? null : valeur, Number(releve) || 0);
+      updateOvBadge();
+      refresh();
+    },
+  }));
 }
 
 // Recalcule totaux + profit par ligne d'après les SCU saisis, et rafraîchit les suggestions.
+//
+// Elle REPEINT la carte, ce que la version impérative s'interdisait (« elle arracherait le champ
+// qu'on remplit »). Ce n'est plus vrai : le champ SCU est NON CONTRÔLÉ dans l'îlot, donc React
+// garde le même nœud DOM au re-rendu et ne touche ni à sa valeur ni à son curseur. C'est ce qui
+// permet de supprimer les trois écritures en place (`.mprofit`, `.mboxes`, `#manifestTot`) — un
+// nœud possédé par React et muté hors de React, c'est précisément ce que le garde de #113 interdit.
 function updateManifestTotals() {
   if (!currentManifest) return;
-  const pair = currentManifest.fee;
   document.querySelectorAll("#manifest .mqty-input").forEach((inp) => {
     const i = Number(inp.dataset.i);
-    const cap = Number(inp.dataset.cap);
     let u = Math.floor(Number(inp.value));
     if (!Number.isFinite(u) || u < 0) u = 0;
     // Le dépassement du stock UEX est autorisé (vol de fret, relevé périmé…) : on ne plafonne
-    // plus à `cap`, on le signale visuellement pour que ce soit un choix conscient.
-    inp.classList.toggle("over-stock", u > cap);
-    // La LIGNE, pas ses attributs data-* : elle seule porte `carry`/`acquired`, donc le nombre
-    // d'opérations réellement facturées. Recalculer à partir de la seule marge affichait un profit
-    // qui contredisait le total juste au-dessus.
+    // plus à `cap`, on le signale visuellement — la classe `over-stock` est posée au rendu.
     const l = currentManifest.lines[i];
-    if (!l) return;
-    l.units = u;
-    const line = inp.closest(".mline");
-    line.querySelector(".mprofit").textContent = lineProfitText(u, l, pair);
-    line.querySelector(".mboxes").textContent = "📦 " + scuBoxesLabel(u, currentManifest.origin.maxBox);
+    if (l) l.units = u;
   });
-  const totals = manifestTotals(currentManifest.lines, pair); // unités déjà synchronisées ci-dessus
-  $("manifestTot").innerHTML = manifestTotalsHTML(currentManifest, totals);
   // À la FRAPPE, pas au blur : le champ ne porte aucun `change`, et le premier refresh venu — un
   // prix corrigé ailleurs, une recherche tapée — repeindrait la carte avant qu'on ait quitté le
   // champ. Ce que ça écrit tient en deux nombres par ligne.
   retenirManifeste();
-  marquerManifesteCompose();
-  renderSuggestions();
+  paintManifest();
 }
 
 // Copie le plan de chargement en texte (pour un 2e écran / des notes).
@@ -1170,6 +1082,7 @@ function copierTexte(texte, btn, libelle) {
   }).catch(() => showToast("⚠ Presse-papiers refusé — la copie n'a pas eu lieu"));
 }
 
+let manifestGen = 0; // cf. l'affectation de `currentManifest`, plus bas
 function renderManifest(origin, destSystem, f, destTerminal) {
   const card = $("manifest");
   currentManifest = null;
@@ -1211,6 +1124,15 @@ function renderManifest(origin, destSystem, f, destTerminal) {
   // risque donc pas de le reconstruire AUTREMENT que ce qui a servi à choisir la destination.
   man.feeInfo = feeCtx(f, man.origin.name, man.dest.name, man.origin, man.dest);
   currentManifest = man;
+  // La GÉNÉRATION distingue les deux façons de repeindre la carte, et c'est tout ce qui reste du
+  // comportement de l'ancien `card.innerHTML` :
+  //   - ici, le manifeste vient d'être RECALCULÉ (départ changé, « ↺ optimal », correction de
+  //     prix…) : les champs SCU doivent adopter les nouvelles valeurs, donc ils se remontent ;
+  //   - depuis `updateManifestTotals`, on est EN TRAIN de taper : la génération ne bouge pas, le
+  //     champ garde son nœud, sa valeur et son curseur.
+  // Sans elle, un champ non contrôlé garderait à jamais ce que l'utilisateur y a tapé — « ↺
+  // optimal » remettait `value="96"` dans l'attribut pendant que le champ affichait encore 30.
+  manifestGen++;
   paintManifest();
 }
 
@@ -2119,7 +2041,13 @@ function renderLegSuggestions(i, lines) {
   const box = document.querySelector(`.jman-suggest[data-leg="${i}"]`);
   if (!box) return;
   const ctx = legSuggestCtx(JOURNEY.legs[i], lines, readFilters());
-  box.innerHTML = ctx ? suggestionsHTML(ctx, ` data-leg="${i}"`) : "";
+  // Même composant que la carte : `data-leg` part sur le bouton d'ajout, la délégation qui le lit
+  // ne bouge pas. La carte du compagnon est encore écrite en innerHTML, donc ce conteneur est
+  // recréé à chaque rendu — la WeakMap de pont.js lui redonne simplement une racine neuve.
+  peindre(box, ctx ? vueSuggestions({
+    suggestions: suggestionsFor(ctx), restant: manifestRemaining(ctx), frais: ctx.fee,
+    fmt, fmtVol, attributsAjout: { "data-leg": i },
+  }) : null);
 }
 // Ajoute une commodité suggérée à une jambe, remplie au max possible.
 function addLegSuggestion(i, name) {
@@ -2321,10 +2249,12 @@ function renderJourney() {
         `<span class="jman-profit profit">${lineProfitText(l.units, l, pair)}</span>` +
         `<button class="jman-del" data-leg="${i}" data-name="${esc(l.name)}" title="Retirer">✕</button></div>`
       ).join("") || '<div class="muted jman-empty">Aucune commodité.</div>';
-      const sctx = legSuggestCtx(leg, lines, f);
+      // Le conteneur part VIDE : `renderLegSuggestions` le peint juste après l'écriture de la
+      // carte, avec le même composant React que le manifeste d'« En route ». L'incruster ici
+      // demanderait une seconde fabrique du même bloc, en chaîne — c'est ce qu'on vient de retirer.
       editor = `<div class="jman">${rows}
         <div class="jman-add"><input class="jman-add-input" list="commodityList" data-leg="${i}" placeholder="+ commodité (même non vendable)…" autocomplete="off"><button class="jman-add-btn" data-leg="${i}">+</button>${edited ? `<button class="jman-reset" data-leg="${i}" title="Revenir au manifeste optimal">↺ optimal</button>` : ""}</div>
-        <div class="jman-suggest manifest-suggest" data-leg="${i}">${sctx ? suggestionsHTML(sctx, ` data-leg="${i}"`) : ""}</div>
+        <div class="jman-suggest manifest-suggest" data-leg="${i}"></div>
       </div>`;
     }
     return `<div class="jleg${i === JOURNEY.current ? " current" : ""}${expanded ? " expanded" : ""}">
@@ -2355,6 +2285,10 @@ function renderJourney() {
      ${suggestBlock}
      <div class="journey-meta">${n} saut${n > 1 ? "s" : ""} · marge cumulée <b class="profit">${fmt(journeyMargin(JOURNEY))}</b> aUEC/SCU</div>`;
 
+  // Après `card.innerHTML` : le conteneur des suggestions vient d'être (re)créé, il faut le peindre.
+  // Une seule jambe est dépliée à la fois, donc une seule en porte un.
+  if (MARKET && journeyExpandedLeg != null && JOURNEY.legs[journeyExpandedLeg])
+    renderLegSuggestions(journeyExpandedLeg, legEffectiveLines(JOURNEY.legs[journeyExpandedLeg], journeyExpandedLeg, f));
   renderJourneyRecap({ n, totalProfit, totalScu, totalFees, systems: new Set(stations.map((s) => s.system)).size });
   renderJourneyMap();
   renderSoute();
@@ -3008,45 +2942,12 @@ async function copyShareLink() {
   }
 }
 
-// ---------- Édition inline d'une valeur corrigeable ----------
-// Remplace le span par un champ ; à la validation, enregistre la correction et rafraîchit.
-function startEdit(span) {
-  if (span.querySelector("input")) return;
-  const { c, t, s, f: field, v, u } = span.dataset;
-  // Contenu d'origine (chiffre formaté + éventuel ✎), conservé pour pouvoir annuler l'édition
-  // sans re-render global. `replaceChildren` détache ces nœuds mais ne les détruit pas.
-  const original = [...span.childNodes];
-  const inp = document.createElement("input");
-  inp.type = "number"; inp.min = "0"; inp.value = v; inp.className = "editv-input";
-  span.replaceChildren(inp);
-  inp.focus(); inp.select();
-  let done = false;
-  const commit = (save) => {
-    if (done) return; done = true;
-    // CONSULTER un chiffre ne doit rien écrire. Sans cette comparaison, cliquer une valeur puis
-    // cliquer ailleurs créait une correction locale IDENTIQUE au relevé UEX : compteur « ✎
-    // Corrections (n) », marqueur « corrigé localement » sur la cellule, et plus tard un toast
-    // « correction périmée par une mise à jour UEX » à propos d'une correction fantôme.
-    if (save && inp.value !== v) {
-      // Un VOLUME rebat les quantités de tout chargement qui touche ce point : on fige d'abord les
-      // jambes déjà planifiées (avant d'écrire, pour capturer les SCU encore en vigueur). Un PRIX
-      // ne change aucune quantité — il ne fige rien, il met juste les bénéfices à jour.
-      if (field === "vol") pinLegsForVolume(c, t, s);
-      setOverride(c, t, s, field, inp.value === "" ? null : inp.value, Number(u));
-      updateOvBadge();
-      refresh(); // re-render la vue courante ET le voyage avec la valeur corrigée
-      return;
-    }
-    // Rien n'a changé : on remet l'affichage tel quel. Un refresh() global détruirait le nœud
-    // entre le mousedown et le mouseup, ce qui avalait le clic suivant sur une autre cellule.
-    span.replaceChildren(...original);
-  };
-  inp.addEventListener("keydown", (e) => {
-    if (e.key === "Enter") { e.preventDefault(); commit(true); }
-    else if (e.key === "Escape") { e.preventDefault(); commit(false); }
-  });
-  inp.addEventListener("blur", () => commit(true));
-}
+// L'édition en place vit désormais dans `ValeurEditable` (vues/communs.tsx), qui la gère PAR SON
+// ÉTAT. `startEdit` la faisait en mutant le span (`replaceChildren`) depuis une délégation posée
+// sur `document` : c'est la seule situation où les deux modèles se contredisaient vraiment. Les
+// trois comportements qu'elle avait durement acquis — consulter n'écrit rien, Échap ne re-rend
+// pas la vue, le ✎ reste DANS le span — sont portés par le composant, et couverts par
+// `e2e/edition.pw.mjs`.
 
 // Met à jour le libellé du bouton de vue « Corrections » (compteur).
 function updateOvBadge() {
@@ -3745,21 +3646,10 @@ async function init() {
   document.addEventListener("change", (e) => {
     if (e.target.classList && e.target.classList.contains("jman-qty")) editLegQty(Number(e.target.dataset.leg), Number(e.target.dataset.i), e.target.value);
   });
-  // Corrections locales : clic (ou Entrée/Espace) sur une valeur éditable ; bouton reset.
-  // `data-react` : le nœud est rendu par un îlot React, qui gère son édition PAR SON ÉTAT. Sans ce
-  // garde, `startEdit` viendrait le muter (`replaceChildren`) et React écraserait la saisie au
-  // rendu suivant, sans savoir qu'elle avait eu lieu — la classe de bug de #24, #28, #38 et #55.
-  document.addEventListener("click", (e) => {
-    const span = e.target.closest(".editv");
-    if (span && !span.dataset.react && !span.querySelector("input")) startEdit(span);
-  });
-  document.addEventListener("keydown", (e) => {
-    if ((e.key === "Enter" || e.key === " ") && e.target.classList && e.target.classList.contains("editv")) {
-      if (e.target.dataset.react) return;
-      e.preventDefault();
-      startEdit(e.target);
-    }
-  });
+  // Les deux délégations qui ouvraient l'édition (clic, Entrée/Espace) ont disparu avec
+  // `startEdit` : `ValeurEditable` porte ses propres `onClick`/`onKeyDown`. Le garde `data-react`
+  // qu'elles consultaient n'a plus rien à garder — mais l'attribut RESTE sur le composant, c'est
+  // lui que `e2e/edition.pw.mjs` interroge pour vérifier qu'aucun `.editv` n'échappe à React.
   // Raccourcis clavier : / (recherche), 1 à 8 (vues). Ignorés pendant la saisie.
   document.addEventListener("keydown", (e) => {
     if (e.ctrlKey || e.metaKey || e.altKey) return;

--- a/e2e/edition.pw.mjs
+++ b/e2e/edition.pw.mjs
@@ -103,17 +103,21 @@ test("Édition React : app.js ne vient PAS muter un nœud possédé par React (#
   await cellule.click();
   await expect(cellule.locator("input.editv-input"), "deux champs : startEdit est venu muter le nœud React").toHaveCount(1);
 
-  // Et le garde n'a pas rendu `startEdit` inerte pour autant : les valeurs éditables du MANIFESTE
-  // sont encore écrites en HTML par app.js (`editv()`, app.js:424) et s'ouvrent par la délégation.
-  // C'était la vue Trajets qui tenait ce rôle ici ; elle est passée à React avec « En route »
-  // (elles partageaient leur rendu de ligne), et le manifeste est désormais le dernier `.editv`
-  // vanilla — donc le seul endroit où les deux chemins se distinguent encore vraiment.
+  // Et il n'y a plus AUCUN `.editv` en dehors de React : le manifeste était le dernier écrit en
+  // HTML par app.js, il est passé à l'îlot avec la carte. `editv()` et `startEdit()` ont donc été
+  // supprimés — ce test est ce qui autorise leur suppression, et ce qui la rattraperait si un
+  // rendu impératif revenait par la bande.
+  const vues = ["#viewRoutes", "#viewLoops", "#viewChain", "#viewCommodities", "#viewCorrections", "#viewTour", "#viewPlan"];
+  for (const v of vues) {
+    await page.click(v);
+    await page.waitForTimeout(150);
+  }
   await page.click("#viewRoutes");
   await page.locator("#rows tr").first().locator(".journey-pick").click();
   await page.click("#viewEnroute");
-  const vanilla = page.locator("#manifest .editv").first();
-  await expect(vanilla).toBeVisible({ timeout: 8000 });
-  await expect(vanilla).not.toHaveAttribute("data-react", "1");
-  await vanilla.click();
-  await expect(vanilla.locator("input")).toBeVisible();
+  await expect(page.locator("#manifest .editv").first()).toBeVisible({ timeout: 8000 });
+
+  const orphelins = await page.evaluate(() =>
+    [...document.querySelectorAll(".editv")].filter((e) => !e.dataset.react).length);
+  expect(orphelins, "un `.editv` n'est pas possédé par React — startEdit a été supprimé, il ne s'ouvrira pas").toBe(0);
 });

--- a/vues/manifeste.tsx
+++ b/vues/manifeste.tsx
@@ -1,0 +1,367 @@
+// La carte « Manifeste » de la vue « En route », neuvième îlot React (ADR-008 #96).
+//
+// C'est la carte la plus IMPÉRATIVE du dépôt, et c'est pour ça qu'elle passe en dernier avant le
+// compagnon de voyage. Trois mécanismes y écrivaient dans le DOM à la main :
+//
+//   1. `updateManifestTotals()` réécrivait `.mprofit`, `.mboxes` et `#manifestTot` À CHAQUE FRAPPE
+//      dans un champ SCU — c'est-à-dire exactement le « app.js mute un nœud possédé par React »
+//      que le garde `data-react` interdit depuis #113.
+//   2. `marquerManifesteCompose()` injectait le ✎ et le bouton « ↺ optimal » par
+//      `insertAdjacentHTML` DANS une carte déjà rendue.
+//   3. `renderSuggestions()` réécrivait `#manifestSuggest`, un conteneur enfant de la carte.
+//
+// Tous les trois deviennent de l'ÉTAT : l'îlot lit `MANIFEST_EDIT` et `currentManifest.lines`, et
+// un re-rendu suffit. Ce qui reste à app.js, c'est ce qui dépend de l'état global (le marché, les
+// corrections, le parcours) et la persistance.
+//
+// LE CHAMP SCU RESTE NON CONTRÔLÉ (`defaultValue`), et c'est délibéré : React ne touche pas au
+// `value` d'un champ non contrôlé au re-rendu, donc la frappe survit pendant que le profit, les
+// caisses et les totaux se recalculent — le comportement exact de l'ancienne mise à jour en place.
+// Le passer en contrôlé rendrait la valeur au rendu et déplacerait le curseur en fin de champ.
+import { Fragment } from "react";
+import { manifestTotals, lineHaulFee, lineNet, addableUnits, manifestJourneyState } from "../logic.ts";
+import type {
+  LigneManifeste, CandidatChargement, RestantManifeste, PaireFrais, Parcours,
+} from "../types.ts";
+import { BadgeSysteme, IconeCommodite, TagIllegal, ValeurEditable } from "./communs.tsx";
+
+type Fmt = (n: number) => string;
+
+/** Le contexte de manifeste tel qu'app.js le tient dans `currentManifest`. */
+export type ContexteCarte = {
+  lines: LigneManifeste[];
+  cargo: number;
+  aBord: number;
+  cross: boolean;
+  origin: { name: string; system: string; maxBox?: number };
+  dest: { name: string; system: string };
+  fee: PaireFrais | null;
+  feeInfo: { a: unknown; b: unknown } | null;
+};
+
+export type ProprietesManifeste = {
+  m: ContexteCarte;
+  /** Bougée à chaque RECALCUL du manifeste, jamais à la frappe : elle remonte les champs SCU. */
+  generation: number;
+  /** `MANIFEST_EDIT != null` : le chargement a été composé à la main. */
+  compose: boolean;
+  /** Le parcours courant, pour savoir si ce chargement y est déjà. */
+  parcours: Parcours | null;
+  /** Les suggestions de remplissage, calculées par app.js (elles ont besoin du MARCHÉ). */
+  suggestions: CandidatChargement[];
+  /** L'espace et le budget qu'il reste — `manifestRemaining`, qui lit les filtres. */
+  restant: RestantManifeste;
+  fmt: Fmt;
+  fmtVol: Fmt;
+  fmtFee: (n: number, fees: number) => string;
+  signe: (n: number, texte: string) => string;
+  libelleCaisses: (units: number) => string;
+  texteBoutFrais: (bout: unknown) => string;
+  minutesTrajet: number;
+  estCorrige: (commodite: string, terminal: string, cote: string, champ: string) => boolean;
+  texteCapaciteInconnue: string;
+  corriger: (commodite: string, terminal: string, cote: string, champ: string, valeur: string, releve: number) => void;
+};
+
+// ---------------------------------------------------------------------------------------------
+// Les suggestions de remplissage. Partagées entre la carte et les jambes du compagnon de voyage :
+// c'était `suggestionsHTML(m, addAttrs)`, dont le second argument posait un `data-leg` sur le
+// bouton. Ici, `attributsAjout` joue le même rôle — la délégation qui lit `data-leg` ne bouge pas.
+// ---------------------------------------------------------------------------------------------
+export type ProprietesSuggestions = {
+  suggestions: CandidatChargement[];
+  restant: RestantManifeste;
+  frais: PaireFrais | null;
+  fmt: Fmt;
+  fmtVol: Fmt;
+  attributsAjout?: Record<string, string | number>;
+};
+
+export function Suggestions({ suggestions, restant, frais, fmt, fmtVol, attributsAjout = {} }: ProprietesSuggestions) {
+  if (restant.cargoLeft <= 0) return null;
+  const retenues = suggestions
+    .map((it) => ({ it, u: addableUnits(it, restant) }))
+    .filter((x) => x.u >= 1)
+    // Frais actifs : une commodité dont la manutention mange la marge fait PERDRE de l'argent, et
+    // le manifeste optimal l'écarte déjà (manifestsFrom). La proposer en tête, juste sous le
+    // manifeste qui vient de la refuser, serait une contradiction à l'écran.
+    .filter((x) => !frais || lineNet(x.u, x.it, frais) > 0)
+    .slice(0, 6);
+
+  if (!retenues.length)
+    return (
+      <div className="suggest-head">
+        {fmt(restant.cargoLeft)} SCU libres — aucune autre commodité rentable vers cette destination.
+      </div>
+    );
+
+  return (
+    <>
+      <div className="suggest-head">{`Remplir les ${fmt(restant.cargoLeft)} SCU libres — suggestions :`}</div>
+      {retenues.map(({ it, u }) => (
+        <div className="sline" key={it.name}>
+          <IconeCommodite kind={it.kind} />
+          <span className="mname">
+            {it.name}
+            <TagIllegal illegal={it.illegal} />
+          </span>
+          <span className="mstock">{`stock ${fmt(it.stock ?? 0)} · dem. ${fmtVol(it.demand ?? 0)}`}</span>
+          <span className="mprice">{`${fmt(it.buyPrice)} → ${fmt(it.sellPrice ?? 0)} · marge ${fmt(it.margin)}`}</span>
+          <button className="suggest-add" data-name={it.name} {...attributsAjout} title="Ajouter au manifeste">
+            {`+ ${fmt(u)} SCU`}
+          </button>
+        </div>
+      ))}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Les totaux, en une phrase.
+// ---------------------------------------------------------------------------------------------
+function Totaux({ p, totaux }: { p: ProprietesManifeste; totaux: { profit: number; invest: number; scu: number; fees: number } }) {
+  const { m, fmt, fmtFee } = p;
+  const vides = m.cargo - totaux.scu;
+  const profitHeure = (totaux.profit * 60) / p.minutesTrajet;
+  // Les frais sont exposés à part plutôt que fondus dans le profit : c'est le seul moyen de voir
+  // ce que coûte la manutention d'un chargement à plusieurs commodités (une base par ligne).
+  const avecFrais = totaux.fees > 0;
+  // `m.aBord` : la soute n'était pas vide, le manifeste ne remplit donc que la place restante. Le
+  // dire ici évite de lire « 47/47 SCU » sur un vaisseau de 96 sans comprendre pourquoi.
+  const avecBord = m.aBord > 0;
+
+  // LES SÉPARATEURS SONT COLLÉS AU TEXTE QUI LES PRÉCÈDE, et ce n'est pas une coquetterie : le
+  // gabarit produisait UN seul nœud de texte entre deux éléments, et le crénage ne traverse pas
+  // une frontière de nœud. Écrire {" aUEC"}{" · "} au lieu de {" aUEC · "} coûtait 1/64 px sur la
+  // largeur de la phrase — mesuré au relevé, et invisible pour toute autre vérification.
+  const restant = (vides > 0 ? ` · ${fmt(vides)} SCU vides` : "")
+    + ` · invest. ${fmt(totaux.invest)} · ~${fmtFee(profitHeure, totaux.fees)}/h`;
+
+  return (
+    <span className="manifest-tot" id="manifestTot">
+      {"Profit "}
+      <b className="profit">{fmtFee(totaux.profit, totaux.fees)}</b>
+      {" aUEC · "}
+      {avecFrais ? (
+        <>
+          <span
+            className="fee-chip"
+            title={m.feeInfo ? `${p.texteBoutFrais(m.feeInfo.a)} · ${p.texteBoutFrais(m.feeInfo.b)} · une transaction par commodité · estimation ±3 %` : ""}
+          >
+            {`frais ≈ ${fmt(totaux.fees)}`}
+          </span>
+          {" · "}
+        </>
+      ) : null}
+      <b>{fmt(totaux.scu)}</b>
+      {avecBord ? (
+        <>
+          {`/${fmt(m.cargo)} SCU · `}
+          <span className="mbord" title="Déjà en soute, payé — cf. panneau Soute">{`${fmt(m.aBord)} SCU à bord`}</span>
+          {restant}
+        </>
+      ) : (
+        // Sans badge « à bord », rien ne s'intercale : la queue de phrase doit rester UN nœud.
+        `/${fmt(m.cargo)} SCU${restant}`
+      )}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Le bouton d'engagement dans le voyage, ou la phrase qui dit pourquoi il n'y est pas.
+// L'état vient de `manifestJourneyState` (pur, testé) — le rendu ne décide de rien.
+// ---------------------------------------------------------------------------------------------
+function Engagement({ m, parcours }: { m: ContexteCarte; parcours: Parcours | null }) {
+  if (!m.lines.length) return <span className="journey-hint">Manifeste vide — ajoute une commodité pour l'engager.</span>;
+  const st = manifestJourneyState(parcours, m.origin, m.dest);
+  if (st.etat === "ajouter") {
+    const neuf = !parcours;
+    return (
+      <button
+        id="manifestToJourney"
+        className="chain-pick"
+        title={neuf ? "Démarrer un voyage avec ce chargement" : "Ajouter ce chargement à la suite du voyage"}
+      >
+        {neuf ? "▶ Démarrer un voyage" : "▶ Ajouter au voyage"}
+      </button>
+    );
+  }
+  // « Déjà » est l'état NORMAL après tout ▶ (En route est pré-rempli avec la jambe courante) et
+  // celui où l'on retombe après un ajout réussi : la phrase fait donc office de confirmation, à
+  // l'endroit exact du clic. Un bouton y serait un clic mort.
+  if (st.etat === "deja") return <span className="journey-hint">{`✓ C'est déjà la jambe ${st.leg + 1} de ton voyage.`}</span>;
+  if (!st.fin) return null;
+  return (
+    <span className="journey-hint">
+      {"Ce chargement part de "}
+      <b>{m.origin.name}</b>
+      {", mais le voyage se termine à "}
+      <b>{st.fin}</b>
+      {" — seul un chargement au départ de "}
+      <b>{st.fin}</b>
+      {" s'y ajoute."}
+    </span>
+  );
+}
+
+const MARQUE_TITRE =
+  "Chargement composé à la main : ses lignes, ses SCU et cette destination sont les tiens. " +
+  "Les prix, eux, continuent de suivre le marché. « ↺ optimal » rend la main au calcul.";
+
+// ---------------------------------------------------------------------------------------------
+// Une ligne du manifeste.
+// ---------------------------------------------------------------------------------------------
+function Ligne({ p, l, i }: { p: ProprietesManifeste; l: LigneManifeste; i: number }) {
+  const { m } = p;
+  const carry = l.sellPrice == null; // pas vendable à cette destination -> à écouler ailleurs
+  // Symétrique : aucun point d'achat au départ -> le fret est DÉJÀ en soute (butin, minage,
+  // salvage). Afficher un prix « 0 » éditable le ferait passer pour un achat gratuit sur place.
+  const acq = !!l.acquired;
+  const fraisLigne = lineHaulFee(l.units, l, m.fee);
+
+  const editable = (terminal: string, cote: "buy" | "sell", champ: "price" | "vol", valeur: number | null, releve: number) => (
+    <ValeurEditable
+      valeur={valeur}
+      commodite={l.name}
+      terminal={terminal}
+      cote={cote}
+      champ={champ}
+      releve={releve}
+      corrige={p.estCorrige(l.name, terminal, cote, champ)}
+      fmtVol={p.fmtVol}
+      onCorriger={(v) => p.corriger(l.name, terminal, cote, champ, v, releve)}
+      texteCapaciteInconnue={p.texteCapaciteInconnue}
+    />
+  );
+
+  // Une ligne « vend ailleurs » n'a pas de profit ICI (elle sera écoulée plus loin), mais elle a
+  // bien été CHARGÉE ici : ses frais sont retranchés du total. Les taire laissait le total baisser
+  // sans qu'aucune ligne à l'écran ne l'explique.
+  const texteProfit = carry
+    ? fraisLigne > 0
+      ? p.fmtFee(-fraisLigne, fraisLigne)
+      : "—"
+    : p.signe(lineNet(l.units, l, m.fee), p.fmtFee(lineNet(l.units, l, m.fee), fraisLigne));
+
+  return (
+    <div className={"mline" + (carry ? " carry" : "") + (acq ? " acquired" : "")}>
+      <IconeCommodite kind={l.kind} />
+      <span className="mqtywrap">
+        {/* NON CONTRÔLÉ, et c'est ce qui fait tenir la frappe : React ne rend pas sa valeur au
+            re-rendu, donc le profit et les totaux se recalculent sous les doigts sans déplacer le
+            curseur. La contrepartie, c'est qu'un champ déjà tapé n'adopterait JAMAIS une nouvelle
+            valeur calculée — d'où la `key` portant la génération, qui le remonte quand le
+            manifeste est recalculé (« ↺ optimal », changement de départ) et seulement là. */}
+        <input
+          key={`${l.name}@${p.generation}`}
+          type="number"
+          className={"mqty-input" + (l.units > l.cap ? " over-stock" : "")}
+          min="0"
+          defaultValue={l.units}
+          data-i={i}
+          data-cap={l.cap}
+          title="Ajuste librement — tu peux dépasser le stock UEX (vol de fret, relevé périmé…)"
+          aria-label={`SCU ${l.name}`}
+        />
+        <span className="munit">SCU</span>
+      </span>
+      <span className="mname">
+        {l.name}
+        <TagIllegal illegal={l.illegal} />
+        <button className="mline-del" data-name={l.name} title="Retirer du manifeste" aria-label="Retirer">✕</button>
+      </span>
+      <span className="mstock">
+        {"stock "}
+        {acq ? <span className="muted">—</span> : editable(m.origin.name, "buy", "vol", l.stock, l.buyUpdated)}
+        {" · dem. "}
+        {carry ? <span className="muted">—</span> : editable(m.dest.name, "sell", "vol", l.demand, l.sellUpdated)}
+      </span>
+      <span className="mprice">
+        {acq ? (
+          <span className="carry-tag" title="Introuvable à l'achat ici — fret déjà en soute (butin, minage, salvage). Ajuste les SCU à ce que tu transportes.">
+            acquis ailleurs
+          </span>
+        ) : (
+          editable(m.origin.name, "buy", "price", l.buyPrice, l.buyUpdated)
+        )}
+        {" → "}
+        {carry ? (
+          <span className="carry-tag" title="Pas vendable à cette destination — à écouler ailleurs">vend ailleurs</span>
+        ) : (
+          editable(m.dest.name, "sell", "price", l.sellPrice, l.sellUpdated)
+        )}
+      </span>
+      <span
+        className={"mprofit " + (carry ? "muted" : "profit")}
+        title={carry && fraisLigne > 0 ? "Chargée ici, vendue ailleurs : seul le chargement est facturé sur ce trajet" : undefined}
+      >
+        {texteProfit}
+      </span>
+      <span className="mboxes" title="Caisses SCU standard à charger">{`📦 ${p.libelleCaisses(l.units)}`}</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------------------------
+// La carte entière.
+// ---------------------------------------------------------------------------------------------
+export function CarteManifeste(p: ProprietesManifeste) {
+  const { m } = p;
+  const totaux = manifestTotals(m.lines, m.fee);
+  return (
+    <>
+      <div className="manifest-head">
+        <span className="manifest-title">
+          {"◈ Manifeste — "}
+          {m.origin.name}
+          <BadgeSysteme system={m.origin.system} />
+          {" → "}
+          {m.dest.name}
+          <BadgeSysteme system={m.dest.system} />
+          {/* L'espace AVANT le badge est significative : le gabarit écrivait `' <span class="cross">'`
+              et sans elle le titre perd 5 px — mesuré au relevé, seul écart des 127 formes de la
+              carte. JSX ne restitue pas une espace de fin de ligne, il faut l'écrire. */}
+          {m.cross ? <>{" "}<span className="cross">⚡ inter-système</span></> : null}
+          {/* Le ✎ était injecté APRÈS coup par `marquerManifesteCompose` (insertAdjacentHTML dans
+              une carte déjà rendue). Il est ici de l'état : `MANIFEST_EDIT != null`. */}
+          {p.compose ? <>{" "}<span className="manifest-edited" title={MARQUE_TITRE}>✎</span></> : null}
+        </span>
+        <Totaux p={p} totaux={totaux} />
+        <Engagement m={m} parcours={p.parcours} />
+        <button id="copyManifest" className="copy-btn" title="Copier le plan de chargement">⧉ Copier</button>
+      </div>
+      <div className="manifest-lines">
+        {m.lines.map((l, i) => (
+          <Fragment key={l.name}>
+            <Ligne p={p} l={l} i={i} />
+          </Fragment>
+        ))}
+      </div>
+      <div className="manifest-add">
+        <input
+          id="manifestAddInput"
+          list="commodityList"
+          placeholder="Ajouter n'importe quelle commodité (même non vendable ici)…"
+          autoComplete="off"
+          aria-label="Ajouter une commodité"
+        />
+        <button id="manifestAddBtn" type="button" className="copy-btn">+ Ajouter</button>
+        {p.compose ? (
+          <button id="manifestReset" type="button" className="manifest-reset" title="Revenir au chargement optimal calculé pour ce départ">
+            ↺ optimal
+          </button>
+        ) : null}
+      </div>
+      <div id="manifestSuggest" className="manifest-suggest">
+        <Suggestions suggestions={p.suggestions} restant={p.restant} frais={m.fee} fmt={p.fmt} fmtVol={p.fmtVol} />
+      </div>
+    </>
+  );
+}
+
+/** Les trois messages qui remplacent la carte quand il n'y a rien à charger. */
+export const indiceManifeste = (noeud: React.ReactNode) => <div className="manifest-hint">{noeud}</div>;
+
+export const carteManifeste = (p: ProprietesManifeste) => <CarteManifeste {...p} />;
+export const suggestions = (p: ProprietesSuggestions) => <Suggestions {...p} />;


### PR DESCRIPTION
## Ce que ça change

La carte **Manifeste** (vue « En route ») est rendue par React, ainsi que les suggestions de
remplissage — celles de la carte comme celles d'une jambe du compagnon de voyage. Rien ne bouge à
l'écran : 194 formes comparées en styles calculés, **zéro écart**.

Conséquence : **`editv()` et `startEdit()` sont supprimés**, avec les deux délégations qui les
ouvraient. Plus aucune valeur corrigeable n'est éditée hors de React.

## Pourquoi

Neuvième lot de #96 (ADR-008). C'est la carte la plus impérative du dépôt — trois mécanismes y
écrivaient dans le DOM à la main, et chacun était exactement le « app.js mute un nœud possédé par
React » que le garde `data-react` interdit depuis #113 :

1. `updateManifestTotals()` réécrivait `.mprofit`, `.mboxes` et `#manifestTot` **à chaque frappe**
   dans un champ SCU (`app.js`, ancien l.1099-1130).
2. `marquerManifesteCompose()` injectait le ✎ et « ↺ optimal » par `insertAdjacentHTML` **dans une
   carte déjà rendue** — faute de pouvoir la repeindre sans arracher le champ en cours de saisie.
3. `renderSuggestions()` réécrivait `#manifestSuggest`, un conteneur enfant de la carte.

Les trois deviennent de l'état. La contrainte de (2) tombe parce que **le champ SCU reste non
contrôlé** : React ne rend pas sa valeur au re-rendu, donc le nœud, la saisie et le curseur
survivent pendant que profit, caisses et totaux se recalculent.

**Le piège que ça ouvre, et sa réponse.** Un champ non contrôlé n'adopte plus JAMAIS une valeur
calculée : `↺ optimal` remettait `value="96"` dans l'attribut pendant que le champ affichait encore
`30` — `smoke.pw.mjs:1471` l'a attrapé. D'où une **génération**, incrémentée au seul endroit où le
manifeste est *recalculé* (`currentManifest = man`) et jamais à la frappe ; elle sert de `key` au
champ, qui se remonte alors. C'est exactement ce que faisait l'ancien `card.innerHTML`.

`suggestionsHTML` avait trois appelants (la carte, la jambe dépliée, et son rafraîchissement) : le
composant les sert tous les trois, et le second argument `addAttrs` — qui posait `data-leg` sur le
bouton — devient la propriété `attributsAjout`. La délégation qui lit `data-leg` ne bouge pas.

**Piège JSX, deuxième occurrence mesurée** (cf. #116) : deux nœuds de texte adjacents ne se crènent
pas comme un seul. Deux écarts au relevé, tous deux invisibles autrement — l'espace avant
`⚡ inter-système` (5 px, le gabarit écrivait `' <span class="cross">'`) et la queue de la phrase de
totaux coupée en deux (1/64 px). Les séparateurs sont désormais collés au texte qui les précède.

## Vérification

```
$ npm test
ℹ tests 483
ℹ pass 483
ℹ fail 0

$ npx playwright test
  207 passed (1.4m)
  2 skipped

$ npx tsc --noEmit
(0 erreur)
```

Aucun test n'a été ajouté ni adapté, sauf `e2e/edition.pw.mjs:95`, dont la seconde moitié visait le
dernier `.editv` vanilla. Elle **devient le garde qui autorise la suppression** de `startEdit` :
elle parcourt les huit vues puis compte les `.editv` sans `data-react` — attendu `0`. Elle a été
écrite et vue verte AVANT la suppression.

Deux échecs rencontrés en route, tous deux corrigés : `smoke.pw.mjs:1471` (« ↺ optimal », cause
ci-dessus) et `edition.pw.mjs:95`.

**Relevé des styles calculés**, `v2/main` (291f435) contre cette branche, mesures prises coup sur
coup, animations figées :

```
== manifeste          == comparées  65 / identiques  65 / différentes 0 / DISPARUES 0 / APPARUES 0
== manifeste-compose  == comparées  67 / identiques  67 / différentes 0 / DISPARUES 0 / APPARUES 0
== jambe-depliee      == comparées  62 / identiques  62 / différentes 0 / DISPARUES 0 / APPARUES 0
== TOTAL              == comparées 194 / identiques 194 / différentes 0 / DISPARUES 0 / APPARUES 0
```

## Ce qui n'est pas couvert

- Le relevé porte sur trois états : carte optimale, carte composée à la main, jambe dépliée. Les
  états **« soute non vide » (`aBord > 0`), « vend ailleurs » et « acquis ailleurs »** ne sont pas
  mesurés — ils restent couverts par la suite e2e, pas par le relevé.
- **Le compagnon de voyage reste impératif** : `renderJourney`, son récap, sa carte SVG, la soute
  et les entrepôts. C'est le dernier lot, et le plus couplé (6 globales, dont `JOURNEY`).
- L'éditeur de manifeste **par jambe** (`.jman-line`, `.jman-qty`) est encore écrit en chaîne dans
  `renderJourney` ; seules ses suggestions passent par l'îlot.
- Le piège des nœuds de texte adjacents n'a toujours pas de garde permanent : il se voit au relevé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
