### PR TITLE
feat(soute): les cartes Soute et Entrepôts passent en React

### DIFF
--- a/app.js
+++ b/app.js
@@ -35,6 +35,7 @@ import { vueStation, vueBandeCorrections, inviteStation } from "./vues/correctio
 import { enTetePlan, corpsPlan } from "./vues/plan.tsx";
 import { vueTrajets, vueTrajetsMulti } from "./vues/trajets.tsx";
 import { carteManifeste, indiceManifeste, suggestions as vueSuggestions } from "./vues/manifeste.tsx";
+import { carteSoute, carteEntrepots } from "./vues/soute.tsx";
 import { KIND_ICON } from "./vues/communs.tsx";
 
 // Libellé compact des caisses SCU standard, ex. « 8×32 · 1×16 · 1×4 · 1×2 · 1×1 ».
@@ -1440,28 +1441,17 @@ function renderEntrepots() {
   const box = $("depotsCard");
   if (!box) return;
   const stations = Object.entries(DEPOTS).filter(([, lots]) => Array.isArray(lots) && lots.length);
-  if (!stations.length) { box.hidden = true; return; }
+  if (!stations.length) { box.hidden = true; peindre(box, null); return; }
   box.hidden = false;
   const tous = stations.flatMap(([, lots]) => lots);
-  const invest = holdByCommodity(tous).reduce((s, g) => s + g.invest, 0);
-  const blocs = stations.map(([label, lots]) => {
-    const { name, system } = parseStationLabel(label);
-    const lignes = holdByCommodity(lots).map((g) => `<div class="hold-line">
-        <span class="hold-name">${esc(g.name)}</span>
-        <span class="hold-scu"><b>${fmt(g.units)}</b> SCU</span>
-        <span class="hold-paid" title="Prix payé au SCU${g.lots.length > 1 ? " (moyenne des lots)" : ""}">@ ${fmt(Math.round(g.paidMoyen))}</span>
-        <button class="depot-take" data-station="${esc(label)}" data-name="${esc(g.name)}" data-units="${g.units}" title="Remettre ces ${fmt(g.units)} SCU en soute, à leur prix payé">↑ reprendre</button>
-      </div>`).join("");
-    return `<div class="depot-station"><div class="depot-lieu">${esc(name)}${sysBadge(system)} <span class="muted">${fmt(holdScu(lots))} SCU</span></div>${lignes}</div>`;
-  }).join("");
-  // Le bouton de sortie vit dans l'en-tête, sur le modèle exact du `⧉ Copier` du manifeste. Il
-  // n'existe donc que quand la carte est visible — inutile de le masquer à part : la carte entière
-  // sort dès qu'il ne dort plus rien nulle part.
-  box.innerHTML =
-    `<div class="hold-head"><span class="hold-title">⬓ Entrepôts</span>
-       <button id="copyDepots" class="copy-btn" title="Copier la liste du fret déposé, dates comprises">⧉ Copier</button></div>
-     <div class="depot-stations">${blocs}</div>
-     <div class="hold-meta"><b>${fmt(holdScu(tous))}</b> SCU déposés · capital immobilisé <b>${fmt(invest)}</b> aUEC</div>`;
+  peindre(box, carteEntrepots({
+    stations: stations.map(([label, lots]) => ({
+      label, lieu: parseStationLabel(label), scu: holdScu(lots), groupes: holdByCommodity(lots),
+    })),
+    scuTotal: holdScu(tous),
+    invest: holdByCommodity(tous).reduce((s, g) => s + g.invest, 0),
+    fmt,
+  }));
 }
 
 // La liste de ce qui dort en entrepôt, en texte, dans le presse-papiers : elle ne quittait jamais
@@ -1472,39 +1462,9 @@ function copierEntrepots() {
 
 // « Où écouler ce qui reste ? » — le détour manuel par la vue Commodités, en un panneau.
 let ecoulerOuvert = false;
-function ecoulerHTML() {
-  if (!ecoulerOuvert || !MARKET) return "";
-  const idx = stationCourante();
-  // Une soute DÉCLARÉE peut exister sans le moindre voyage : le panneau n'a alors pas de point de
-  // départ. Rendre "" laissait le clic sans effet visible — on dit ce qui manque, et où le saisir.
-  if (idx == null) {
-    return `<div class="hold-ecouler"><p class="muted">Dis d'abord <b>où tu es</b> : le classement part d'un terminal.
-      Le champ <b>◈ Je suis à</b>, juste dessous, l'attend.</p></div>`;
-  }
-  const f = readFilters();
-  const dest = offloadPlan(MARKET, SOUTE, idx, f, effVals, feeResolver(f), 5);
-  if (!dest.length) {
-    return `<div class="hold-ecouler"><p class="muted">Aucune destination ne reprend ce fret avec ces filtres.
-      Tu peux le <b>déposer</b> à une station : il n'est alors ni vendu ni perdu.</p></div>`;
-  }
-  const lignes = dest.map((d) => {
-    const cert = d.certitude === "connue"
-      ? `<span class="ec-sur" title="Capacité publiée par UEX">${fmt(d.garanti)} SCU garantis</span>`
-      : d.certitude === "inconnue"
-        ? `<span class="ec-flou" title="UEX ne publie pas la capacité de ce point : ni zéro, ni illimitée">capacité inconnue</span>`
-        : `<span class="ec-flou" title="Capacité publiée pour une partie seulement">${fmt(d.garanti)} SCU garantis, reste inconnu</span>`;
-    const detail = d.lignes.map((l) => `${esc(l.name)} ${fmt(l.absorbe)}${l.reste > 0 ? `/${fmt(l.absorbe + l.reste)}` : ""}`).join(" · ");
-    // Vendre sous le prix payé peut rester le bon choix — libérer la soute vaut parfois une perte —
-    // mais ça ne doit jamais passer inaperçu derrière un chiffre positif.
-    const perte = d.aPerte ? ` · <span class="ec-perte" title="Le prix ici est inférieur à ce que tu as payé">sous le prix payé</span>` : "";
-    return `<div class="ec-dest">
-        <span class="ec-nom">${esc(d.terminal)}${sysBadge(d.system)}${d.cross ? ' <span class="cross">⚡</span>' : ""}${outpostTag(d.outpost)}</span>
-        <span class="ec-profit ${d.profit < 0 ? "perte" : "profit"}" title="Ce que ça rapporte, prix d'achat déduit${d.profit < 0 ? " — négatif : tu vendrais à perte ici" : ""}. Encaissement brut : ${fmt(Math.round(d.encaisse))} aUEC.">${d.profit >= 0 ? "+" : ""}${fmt(Math.round(d.profit))}</span>
-        <span class="ec-detail">${esc(detail)} · ${cert}${perte}${d.reste > 0 ? ` · <b>${fmt(d.reste)}</b> SCU resteraient à bord` : " · <b>soute vidée</b>"}</span>
-      </div>`;
-  }).join("");
-  return `<div class="hold-ecouler"><div class="ec-head">Où écouler — classé par ce que ça rapporte, prix d'achat déduit</div>${lignes}</div>`;
-}
+// Le panneau « où écouler » est rendu par vues/soute.tsx (`<OuEcouler>`). Le CALCUL, lui, reste
+// ici : `offloadPlan` a besoin du marché, des filtres et du résolveur de corrections — et il n'est
+// appelé que si le panneau est ouvert, parce qu'il parcourt tous les terminaux à chaque rendu.
 
 // ---------- Déclarer « j'ai ça à bord » : la deuxième entrée de la soute (#55) ----------
 // Le repli que l'ADR-002 réservait (option D) et n'avait jamais câblé. Jusqu'ici rien n'entrait en
@@ -1608,76 +1568,46 @@ function poserPosition(v) {
 function viderSoute() { SOUTE = []; saveSoute(); renderSoute(); refresh(); }
 function retirerLot(i) { SOUTE = SOUTE.filter((_, j) => j !== i); saveSoute(); renderSoute(); refresh(); }
 
-function renderSoute() {
+// `synchrone` : la délégation du bouton « vendu » sélectionne le champ de quantité JUSTE APRÈS ce
+// rendu (`…querySelector(".hold-sell-qty")?.select()`). Un rendu React groupé n'aurait pas encore
+// créé le champ, le `?.` court-circuiterait, et le champ s'ouvrirait sans le focus — visible au
+// relevé : sa bordure passait de l'ambre pleine à l'ambre à 30 %.
+function renderSoute(synchrone = false) {
   const box = $("holdCard");
   if (!box) return;
   // AVANT le retour anticipé : le point d'entrée « déclarer », lui, doit exister précisément quand
   // la carte n'existe pas. C'est le seul rendu appelé depuis tous les chemins qui repeignent la soute.
   renderDeclaration();
-  if (!SOUTE.length) { box.hidden = true; return; }
+  if (!SOUTE.length) { box.hidden = true; peindre(box, null); return; }
   box.hidden = false;
   // Du fret à bord et pas de graphe : la vue par défaut ne lit que routes.json, et sans marché la
   // carte ne sait ni nommer une icône, ni proposer une vente, ni classer « où écouler ». Ça se
   // voyait peu tant qu'on ne pouvait charger que depuis « En route » — qui le charge ; une soute
   // déclarée, elle, peut naître sur Trajets et y rester.
   if (!MARKET) withMarket(renderSoute);
-  const groupes = holdByCommodity(SOUTE);
   const ici = stationCourante();
-  const scu = holdScu(SOUTE);
   const f = readFilters();
-  const libre = f.useCargo && f.cargo > 0 ? freeCargo(SOUTE, f.cargo) : null;
-  const invest = groupes.reduce((s, g) => s + g.invest, 0);
-  // Le `kind` n'est pas persisté dans le lot : c'est une propriété de la commodité, pas de la
-  // transaction. On le relit au marché quand il est là, et on s'en passe sinon.
-  const icone = (nom) => {
-    const c = MARKET && findCommodity(nom);
-    return c ? commodityIcon(c.kind) : "";
-  };
-  const lignes = groupes.map((g) => {
-    // Un lot DÉCLARÉ n'a pas de terminal d'achat (`from` vide) : le dire, plutôt qu'afficher « ? »
-    // qui laisse croire à une donnée perdue. C'est un fait, pas un trou.
-    const ouCharge = (l) => (l.from ? `Chargé à ${esc(l.from)}` : "Déclaré à la main — aucun terminal d'achat");
-    // Le détail des lots n'apparaît que s'il y en a plusieurs : sinon c'est du bruit.
-    const lots = g.lots.length > 1
-      ? `<div class="hold-lots">${g.lots.map((l) => `<span class="hold-lot" title="${ouCharge(l)}">${fmt(l.units)} SCU @ ${fmt(l.paid)}<button class="hold-del" data-i="${l.i}" title="Retirer ce lot" aria-label="Retirer">✕</button></span>`).join("")}</div>`
-      : `<button class="hold-del solo" data-i="${g.lots[0].i}" title="Retirer ce lot" aria-label="Retirer">✕</button>`;
-    // Coût nul : « où écouler » comptera tout l'encaissement comme profit. C'est juste — du butin
-    // n'a rien coûté — mais ça change le sens du chiffre, et ça ne doit pas se deviner.
-    const butin = g.invest === 0
-      ? ` <span class="hold-butin" title="Rien payé pour ce fret : « où écouler » compte donc tout l'encaissement comme profit">butin</span>`
-      : "";
-    const sansAchat = g.lots.every((l) => !l.from) ? " — déclaré à la main, aucun terminal d'achat" : "";
-    // Vendre suppose de savoir OÙ l'on est, et que le comptoir reprenne la commodité.
-    const pt = ici != null && MARKET ? sellableAt(MARKET, ici, g.name, effVals) : null;
-    // Vendre suppose que le comptoir reprenne la commodité ; DÉPOSER, non — c'est justement la
-    // sortie quand il n'en veut pas. Les deux ouvrent le même champ de quantité.
-    // `data-idx` fige la station telle qu'elle a été résolue POUR CE RENDU : c'est elle qui a fixé
-    // le prix annoncé juste à côté. Sans lui, `vendreIci` relisait `stationCourante()` au clic et
-    // pouvait encaisser ailleurs qu'à l'endroit dont l'utilisateur venait de lire le chiffre.
-    const vente = venteEnCours === g.name
-      ? `<span class="hold-sell open" data-idx="${ici}"><input class="hold-sell-qty" type="number" min="0" max="${g.units}" value="${g.units}" aria-label="SCU de ${esc(g.name)}" />
-           ${pt ? `<button class="hold-sell-ok" data-name="${esc(g.name)}" title="Vendre ici à ${fmt(pt.price)} aUEC/SCU">✓ vendre</button>` : ""}
-           <button class="hold-store" data-name="${esc(g.name)}" title="Déposer à la station : ni vendu, ni perdu">⬓ déposer</button>
-           <button class="hold-sell-no" title="Annuler">✕</button></span>`
-      : ici != null
-        ? `<button class="hold-sell-btn" data-name="${esc(g.name)}" title="${pt
-            ? `Vendre ou déposer ici — ${fmt(pt.price)} aUEC/SCU${pt.demand == null ? ", capacité inconnue chez UEX" : `, capacité annoncée ${fmt(pt.demand)} SCU`}`
-            : "Ce comptoir ne reprend pas cette commodité — tu peux quand même l'y déposer"}">${pt ? "vendu" : "déposer"}</button>`
-        : "";
-    return `<div class="hold-line">
-        <span class="hold-name">${icone(g.name)}${esc(g.name)}</span>
-        <span class="hold-scu"><b>${fmt(g.units)}</b> SCU</span>
-        <span class="hold-paid" title="Prix payé au SCU${g.lots.length > 1 ? " (moyenne des lots)" : ""}${sansAchat}">@ ${fmt(Math.round(g.paidMoyen))}</span>${butin}
-        ${vente}
-        ${lots}
-      </div>`;
-  }).join("");
-  box.innerHTML =
-    `<div class="hold-head"><span class="hold-title">◈ Soute</span><button id="holdClear" class="journey-clear" title="Vider la soute (le fret est débarqué)" aria-label="Vider la soute">✕</button></div>
-     <div class="hold-lines">${lignes}</div>
-     <div class="hold-meta"><b>${fmt(scu)}</b> SCU à bord${libre != null ? ` · <b>${fmt(libre)}</b> libres` : ""} · capital engagé <b>${fmt(invest)}</b> aUEC
-       <button id="holdOffload" class="hold-offload">${ecoulerOuvert ? "▾" : "▸"} où écouler ?</button></div>
-     ${ecoulerHTML()}`;
+  peindre(box, carteSoute({
+    groupes: holdByCommodity(SOUTE),
+    ici,
+    scu: holdScu(SOUTE),
+    libre: f.useCargo && f.cargo > 0 ? freeCargo(SOUTE, f.cargo) : null,
+    invest: holdByCommodity(SOUTE).reduce((s, g) => s + g.invest, 0),
+    venteEnCours,
+    ecoulerOuvert,
+    positionConnue: ici != null,
+    marchePret: !!MARKET,
+    // Le classement n'est calculé QUE si le panneau est ouvert : `offloadPlan` parcourt tous les
+    // terminaux, et cette carte se repeint à chaque rafraîchissement de l'application.
+    ecoulement: ecoulerOuvert && MARKET && ici != null
+      ? offloadPlan(MARKET, SOUTE, ici, f, effVals, feeResolver(f), 5)
+      : null,
+    pointVente: (nom) => (ici != null && MARKET ? sellableAt(MARKET, ici, nom, effVals) : null),
+    // Le `kind` n'est pas persisté dans le lot : c'est une propriété de la commodité, pas de la
+    // transaction. On le relit au marché quand il est là, et on s'en passe sinon.
+    kindDe: (nom) => { const c = MARKET && findCommodity(nom); return c ? c.kind : null; },
+    fmt,
+  }), { synchrone });
 }
 
 // ---------- Carte 2D du parcours (ADR-001) ----------
@@ -3526,7 +3456,7 @@ async function init() {
     const deposer = e.target.closest(".hold-store");
     if (deposer) { const b = deposer.closest(".hold-sell"); deposerIci(deposer.dataset.name, Number(b.querySelector(".hold-sell-qty").value), Number(b.dataset.idx)); return; }
     const ouvrir = e.target.closest(".hold-sell-btn");
-    if (ouvrir) { venteEnCours = ouvrir.dataset.name; renderSoute(); $("holdCard").querySelector(".hold-sell-qty")?.select(); return; }
+    if (ouvrir) { venteEnCours = ouvrir.dataset.name; renderSoute(true); $("holdCard").querySelector(".hold-sell-qty")?.select(); return; }
     if (e.target.closest(".hold-sell-no")) { venteEnCours = null; renderSoute(); return; }
     const ok = e.target.closest(".hold-sell-ok");
     if (ok) { const b = ok.closest(".hold-sell"); vendreIci(ok.dataset.name, Number(b.querySelector(".hold-sell-qty").value), Number(b.dataset.idx)); return; }

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -952,6 +952,39 @@ test("Soute : « où écouler » classe les destinations et affiche la certitude
   await expect(page.locator("#holdCard .ec-dest")).toHaveCount(0);
 });
 
+test("« où écouler » : une apostrophe dans un nom n'est pas échappée deux fois (#118)", async ({ page }) => {
+  // `ecoulerHTML` échappait chaque nom dans `detail`, PUIS le détail entier à l'insertion : `E'tam`
+  // s'affichait `E&#39;tam`, et la ligne prenait deux hauteurs au lieu d'une.
+  //
+  // La commodité est choisie DANS LES DONNÉES, pas écrite en dur : le test doit porter sur le cas
+  // visé tant qu'un nom à apostrophe existe, et se taire franchement si l'instantané n'en offre
+  // plus — pas passer au vert en ayant mesuré autre chose.
+  await ouvrirDeclaration(page);
+  const aApostrophe = (await commodites(page)).filter((n) => /['\u2019]/.test(n));
+  test.skip(!aApostrophe.length, "aucune commodité à apostrophe dans cet instantané");
+  await page.locator("#holdAddNo").click();
+
+  let trouve = null;
+  for (const nom of aApostrophe.slice(0, 6)) {
+    await declarer(page, nom, 2200, 1000);
+    await positionner(page, "Megumi — Pyro");
+    if (!(await page.locator("#holdCard .ec-head").count())) await page.locator("#holdOffload").click();
+    await expect(page.locator("#holdCard .hold-ecouler")).toBeVisible();
+    if ((await page.locator("#holdCard .ec-dest").count()) > 0) { trouve = nom; break; }
+    await page.locator("#holdClear").click();
+  }
+  expect(trouve, "aucune commodité à apostrophe n'a de débouché depuis ce quai").not.toBeNull();
+
+  const details = await page.locator("#holdCard .ec-detail").allTextContents();
+  expect(details.length).toBeGreaterThan(0);
+  // Le nom apparaît TEL QUEL dans le détail…
+  expect(details.some((t) => t.includes(trouve))).toBe(true);
+  // …et aucune entité HTML ne s'y affiche en clair.
+  for (const t of details) {
+    expect(t, "une entité HTML s'affiche telle quelle — le détail est échappé deux fois").not.toMatch(/&(#\d+|amp|quot|lt|gt);/);
+  }
+});
+
 test("Soute : déposer à la station libère la place sans vendre", async ({ page }) => {
   await jambeChargeable(page);
   await page.locator("#journeyCard .jleg-load").first().click();

--- a/vues/soute.tsx
+++ b/vues/soute.tsx
@@ -1,0 +1,324 @@
+// La carte « Soute » et la carte « Entrepôts », dixième îlot React (ADR-008 #96).
+//
+// Les deux vivent dans `#voyageLeft`, que `switchView` ne touche jamais : les huit vues les
+// portent, y compris Trajets et Commodités qui n'ont aucun rapport avec un voyage. Ce ne sont donc
+// pas des vues — ce sont deux cartes d'ÉTAT, visibles partout, et c'est pour ça qu'elles migrent
+// ensemble : elles répondent à la même question, « qu'est-ce que je transporte, et où ? ».
+//
+// Tout ce qui décide vit ailleurs : `holdByCommodity`, `offloadPlan` et `sellableAt` sont dans
+// logic.ts et déjà testés. app.js ne passe ici que ce qui dépend de l'état global — la station
+// courante, le point de vente résolu, l'icône d'une commodité (qui se relit au MARCHÉ), et les
+// deux interrupteurs d'affichage (`venteEnCours`, `ecoulerOuvert`).
+import { Fragment } from "react";
+import type { GroupeSoute, Destination, VenteAuTerminal, Lot, Station } from "../types.ts";
+import { BadgeSysteme, TagAvantPoste, IconeCommodite } from "./communs.tsx";
+
+type Fmt = (n: number) => string;
+
+export type ProprietesSoute = {
+  groupes: GroupeSoute[];
+  /** Le terminal où l'on se trouve, ou `null` : vendre suppose de savoir où l'on est. */
+  ici: number | null;
+  scu: number;
+  /** La place libre, ou `null` quand la soute n'est pas bornée dans les filtres. */
+  libre: number | null;
+  invest: number;
+  /** La commodité dont le champ de quantité est ouvert, ou `null`. */
+  venteEnCours: string | null;
+  /** Le panneau « où écouler » est-il déplié ? */
+  ecoulerOuvert: boolean;
+  /** Les destinations d'écoulement, ou `null` quand il n'y a pas de quoi les calculer. */
+  ecoulement: Destination[] | null;
+  /** `null` quand la position manque : le panneau dit alors ce qui lui manque. */
+  positionConnue: boolean;
+  /** Le marché est-il là ? Sans lui, ni icône, ni vente, ni classement. */
+  marchePret: boolean;
+  /** Le point de vente de cette commodité ICI, ou `null` si le comptoir n'en veut pas. */
+  pointVente: (nom: string) => VenteAuTerminal | null;
+  /** Le `kind` d'une commodité — relu au marché, absent du lot (c'est une propriété de la
+   *  commodité, pas de la transaction). */
+  kindDe: (nom: string) => string | null;
+  fmt: Fmt;
+};
+
+// ---------------------------------------------------------------------------------------------
+// « Où écouler ce qui reste ? » — le détour manuel par la vue Commodités, en un panneau.
+// ---------------------------------------------------------------------------------------------
+function OuEcouler({ p }: { p: ProprietesSoute }) {
+  if (!p.ecoulerOuvert || !p.marchePret) return null;
+  // Une soute DÉCLARÉE peut exister sans le moindre voyage : le panneau n'a alors pas de point de
+  // départ. Ne rien rendre laissait le clic sans effet visible — on dit ce qui manque, et où le saisir.
+  if (!p.positionConnue)
+    return (
+      <div className="hold-ecouler">
+        <p className="muted">
+          {"Dis d'abord "}
+          <b>où tu es</b>
+          {" : le classement part d'un terminal.\n      Le champ "}
+          <b>◈ Je suis à</b>
+          {", juste dessous, l'attend."}
+        </p>
+      </div>
+    );
+  const dest = p.ecoulement || [];
+  if (!dest.length)
+    return (
+      <div className="hold-ecouler">
+        <p className="muted">
+          {"Aucune destination ne reprend ce fret avec ces filtres.\n      Tu peux le "}
+          <b>déposer</b>
+          {" à une station : il n'est alors ni vendu ni perdu."}
+        </p>
+      </div>
+    );
+  return (
+    <div className="hold-ecouler">
+      <div className="ec-head">Où écouler — classé par ce que ça rapporte, prix d'achat déduit</div>
+      {dest.map((d) => (
+        <LigneEcoulement d={d} fmt={p.fmt} key={d.idx} />
+      ))}
+    </div>
+  );
+}
+
+function LigneEcoulement({ d, fmt }: { d: Destination; fmt: Fmt }) {
+  const cert =
+    d.certitude === "connue" ? (
+      <span className="ec-sur" title="Capacité publiée par UEX">{`${fmt(d.garanti)} SCU garantis`}</span>
+    ) : d.certitude === "inconnue" ? (
+      <span className="ec-flou" title="UEX ne publie pas la capacité de ce point : ni zéro, ni illimitée">capacité inconnue</span>
+    ) : (
+      <span className="ec-flou" title="Capacité publiée pour une partie seulement">{`${fmt(d.garanti)} SCU garantis, reste inconnu`}</span>
+    );
+  const detail = d.lignes.map((l) => `${l.name} ${fmt(l.absorbe)}${l.reste > 0 ? `/${fmt(l.absorbe + l.reste)}` : ""}`).join(" · ");
+  return (
+    <div className="ec-dest">
+      <span className="ec-nom">
+        {d.terminal}
+        <BadgeSysteme system={d.system} />
+        {d.cross ? <>{" "}<span className="cross">⚡</span></> : null}
+        <TagAvantPoste outpost={!!d.outpost} />
+      </span>
+      <span
+        className={"ec-profit " + (d.profit < 0 ? "perte" : "profit")}
+        title={`Ce que ça rapporte, prix d'achat déduit${d.profit < 0 ? " — négatif : tu vendrais à perte ici" : ""}. Encaissement brut : ${fmt(Math.round(d.encaisse))} aUEC.`}
+      >
+        {`${d.profit >= 0 ? "+" : ""}${fmt(Math.round(d.profit))}`}
+      </span>
+      <span className="ec-detail">
+        {`${detail} · `}
+        {cert}
+        {/* Vendre sous le prix payé peut rester le bon choix — libérer la soute vaut parfois une
+            perte — mais ça ne doit jamais passer inaperçu derrière un chiffre positif. */}
+        {d.aPerte ? (
+          <>
+            {" · "}
+            <span className="ec-perte" title="Le prix ici est inférieur à ce que tu as payé">sous le prix payé</span>
+          </>
+        ) : null}
+        {d.reste > 0 ? (
+          <>
+            {" · "}
+            <b>{fmt(d.reste)}</b>
+            {" SCU resteraient à bord"}
+          </>
+        ) : (
+          <>
+            {" · "}
+            <b>soute vidée</b>
+          </>
+        )}
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Une commodité à bord : ce qu'elle est, ce qu'elle a coûté, et les deux sorties (vendre, déposer).
+// ---------------------------------------------------------------------------------------------
+function LigneSoute({ p, g }: { p: ProprietesSoute; g: GroupeSoute }) {
+  const { fmt } = p;
+  // Un lot DÉCLARÉ n'a pas de terminal d'achat (`from` vide) : le dire, plutôt qu'afficher « ? »
+  // qui laisse croire à une donnée perdue. C'est un fait, pas un trou.
+  const ouCharge = (l: Lot) => (l.from ? `Chargé à ${l.from}` : "Déclaré à la main — aucun terminal d'achat");
+  const sansAchat = g.lots.every((l) => !l.from) ? " — déclaré à la main, aucun terminal d'achat" : "";
+  const pt = p.ici != null && p.marchePret ? p.pointVente(g.name) : null;
+  const kind = p.kindDe(g.name);
+
+  return (
+    <div className="hold-line">
+      <span className="hold-name">
+        {kind ? <IconeCommodite kind={kind} /> : null}
+        {g.name}
+      </span>
+      <span className="hold-scu">
+        <b>{fmt(g.units)}</b>
+        {" SCU"}
+      </span>
+      <span className="hold-paid" title={`Prix payé au SCU${g.lots.length > 1 ? " (moyenne des lots)" : ""}${sansAchat}`}>
+        {`@ ${fmt(Math.round(g.paidMoyen))}`}
+      </span>
+      {/* Coût nul : « où écouler » comptera tout l'encaissement comme profit. C'est juste — du
+          butin n'a rien coûté — mais ça change le sens du chiffre, et ça ne doit pas se deviner. */}
+      {g.invest === 0 ? (
+        <>
+          {" "}
+          <span className="hold-butin" title="Rien payé pour ce fret : « où écouler » compte donc tout l'encaissement comme profit">butin</span>
+        </>
+      ) : null}
+      {/* Vendre suppose que le comptoir reprenne la commodité ; DÉPOSER, non — c'est justement la
+          sortie quand il n'en veut pas. Les deux ouvrent le même champ de quantité.
+          `data-idx` fige la station telle qu'elle a été résolue POUR CE RENDU : c'est elle qui a
+          fixé le prix annoncé juste à côté. Sans lui, `vendreIci` relisait `stationCourante()` au
+          clic et pouvait encaisser ailleurs qu'à l'endroit dont l'utilisateur venait de lire le
+          chiffre. */}
+      {p.venteEnCours === g.name ? (
+        <span className="hold-sell open" data-idx={p.ici}>
+          <input className="hold-sell-qty" type="number" min="0" max={g.units} defaultValue={g.units} aria-label={`SCU de ${g.name}`} />
+          {pt ? (
+            <button className="hold-sell-ok" data-name={g.name} title={`Vendre ici à ${fmt(pt.price ?? 0)} aUEC/SCU`}>✓ vendre</button>
+          ) : null}
+          <button className="hold-store" data-name={g.name} title="Déposer à la station : ni vendu, ni perdu">⬓ déposer</button>
+          <button className="hold-sell-no" title="Annuler">✕</button>
+        </span>
+      ) : p.ici != null ? (
+        <button
+          className="hold-sell-btn"
+          data-name={g.name}
+          title={
+            pt
+              ? `Vendre ou déposer ici — ${fmt(pt.price ?? 0)} aUEC/SCU${pt.demand == null ? ", capacité inconnue chez UEX" : `, capacité annoncée ${fmt(pt.demand)} SCU`}`
+              : "Ce comptoir ne reprend pas cette commodité — tu peux quand même l'y déposer"
+          }
+        >
+          {pt ? "vendu" : "déposer"}
+        </button>
+      ) : null}
+      {/* Le détail des lots n'apparaît que s'il y en a plusieurs : sinon c'est du bruit. */}
+      {g.lots.length > 1 ? (
+        <div className="hold-lots">
+          {g.lots.map((l) => (
+            <span className="hold-lot" title={ouCharge(l)} key={l.i}>
+              {`${fmt(l.units)} SCU @ ${fmt(l.paid)}`}
+              <button className="hold-del" data-i={l.i} title="Retirer ce lot" aria-label="Retirer">✕</button>
+            </span>
+          ))}
+        </div>
+      ) : (
+        <button className="hold-del solo" data-i={g.lots[0].i} title="Retirer ce lot" aria-label="Retirer">✕</button>
+      )}
+    </div>
+  );
+}
+
+export function CarteSoute(p: ProprietesSoute) {
+  return (
+    <>
+      <div className="hold-head">
+        <span className="hold-title">◈ Soute</span>
+        <button id="holdClear" className="journey-clear" title="Vider la soute (le fret est débarqué)" aria-label="Vider la soute">✕</button>
+      </div>
+      <div className="hold-lines">
+        {p.groupes.map((g) => (
+          <Fragment key={g.name}>
+            <LigneSoute p={p} g={g} />
+          </Fragment>
+        ))}
+      </div>
+      {/* `.hold-meta` est en `display: block` : ses espaces COMPTENT, à la différence de
+          `.hold-line` qui est flex. Le gabarit terminait par « aUEC » suivi d'un retour à la ligne
+          et de son indentation avant le bouton, ce qui rend UNE espace — 2,67 px à 11 px de police,
+          et sans elle toute la carte rétrécissait d'autant
+          (mesuré : 410,78 → 408,11 px). Les séparateurs sont donc collés au texte qui les précède,
+          et l'espace avant le bouton est explicite. */}
+      <div className="hold-meta">
+        <b>{p.fmt(p.scu)}</b>
+        {p.libre != null ? " SCU à bord · " : " SCU à bord · capital engagé "}
+        {p.libre != null ? (
+          <>
+            <b>{p.fmt(p.libre)}</b>
+            {" libres · capital engagé "}
+          </>
+        ) : null}
+        <b>{p.fmt(p.invest)}</b>
+        {" aUEC\n       "}
+        <button id="holdOffload" className="hold-offload">{p.ecoulerOuvert ? "▾ où écouler ?" : "▸ où écouler ?"}</button>
+      </div>
+      <OuEcouler p={p} />
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Les entrepôts : ce qui dort à une station, ni vendu ni perdu.
+// ---------------------------------------------------------------------------------------------
+export type StationEntrepot = {
+  /** Le libellé complet, tel que la délégation le relit dans `data-station`. */
+  label: string;
+  lieu: Station;
+  scu: number;
+  groupes: GroupeSoute[];
+};
+
+export type ProprietesEntrepots = {
+  stations: StationEntrepot[];
+  scuTotal: number;
+  invest: number;
+  fmt: Fmt;
+};
+
+export function CarteEntrepots({ stations, scuTotal, invest, fmt }: ProprietesEntrepots) {
+  return (
+    <>
+      {/* Le bouton de sortie vit dans l'en-tête, sur le modèle exact du `⧉ Copier` du manifeste. Il
+          n'existe donc que quand la carte est visible — inutile de le masquer à part : la carte
+          entière sort dès qu'il ne dort plus rien nulle part. */}
+      <div className="hold-head">
+        <span className="hold-title">⬓ Entrepôts</span>
+        <button id="copyDepots" className="copy-btn" title="Copier la liste du fret déposé, dates comprises">⧉ Copier</button>
+      </div>
+      <div className="depot-stations">
+        {stations.map((s) => (
+          <div className="depot-station" key={s.label}>
+            <div className="depot-lieu">
+              {s.lieu.name}
+              <BadgeSysteme system={s.lieu.system} />
+              {" "}
+              <span className="muted">{`${fmt(s.scu)} SCU`}</span>
+            </div>
+            {s.groupes.map((g) => (
+              <div className="hold-line" key={g.name}>
+                <span className="hold-name">{g.name}</span>
+                <span className="hold-scu">
+                  <b>{fmt(g.units)}</b>
+                  {" SCU"}
+                </span>
+                <span className="hold-paid" title={`Prix payé au SCU${g.lots.length > 1 ? " (moyenne des lots)" : ""}`}>
+                  {`@ ${fmt(Math.round(g.paidMoyen))}`}
+                </span>
+                <button
+                  className="depot-take"
+                  data-station={s.label}
+                  data-name={g.name}
+                  data-units={g.units}
+                  title={`Remettre ces ${fmt(g.units)} SCU en soute, à leur prix payé`}
+                >
+                  ↑ reprendre
+                </button>
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+      <div className="hold-meta">
+        <b>{fmt(scuTotal)}</b>
+        {" SCU déposés · capital immobilisé "}
+        <b>{fmt(invest)}</b>
+        {" aUEC"}
+      </div>
+    </>
+  );
+}
+
+export const carteSoute = (p: ProprietesSoute) => <CarteSoute {...p} />;
+export const carteEntrepots = (p: ProprietesEntrepots) => <CarteEntrepots {...p} />;


### PR DESCRIPTION
## Ce que ça change

Les cartes **Soute** (`#holdCard`, avec son panneau « où écouler ») et **Entrepôts**
(`#depotsCard`) sont rendues par React. Rien ne bouge à l'écran, à une exception voulue :

**Correctif** — dans « où écouler », une commodité dont le nom porte une apostrophe s'affichait
`E&#39;tam` au lieu de `E'tam`, et la ligne prenait deux hauteurs au lieu d'une.

Closes #118

## Pourquoi

Dixième lot de #96 (ADR-008). Les deux cartes vivent dans `#voyageLeft`, que `switchView` ne
touche jamais : ce ne sont pas des vues, ce sont deux cartes d'**état** visibles depuis les huit
vues. Elles migrent ensemble parce qu'elles répondent à la même question — « qu'est-ce que je
transporte, et où ? ».

**Cause racine du correctif** : double échappement dans `ecoulerHTML()` (`app.js`, supprimée par
cette PR). Le détail était construit en échappant déjà chaque nom
(`` `${esc(l.name)} ${fmt(l.absorbe)}…` ``) puis échappé **une seconde fois** à l'insertion
(`` `<span class="ec-detail">${esc(detail)} · …` ``). `E'tam` → `E&#39;tam` → `E&amp;#39;tam`,
affiché tel quel. JSX rend le nom une seule fois, donc correctement.

**Deux écarts d'apparence trouvés au relevé, tous deux corrigés :**

1. **La carte rétrécissait de 2,67 px** (410,78 → 408,11), et tout son contenu avec. `.hold-meta`
   est en `display: block` — à la différence de `.hold-line` qui est flex — donc ses espaces
   comptent. Le gabarit terminait par `aUEC` suivi d'un retour à la ligne avant le `<button>`, ce
   qui rend une espace ; à 11 px de police, exactement 2,67 px.
2. **Le champ « vendu » s'ouvrait sans le focus** — sa bordure passait de l'ambre pleine à l'ambre
   à 30 %. La délégation fait `renderSoute()` puis `…querySelector(".hold-sell-qty")?.select()` :
   avec un rendu React groupé, le champ n'existe pas encore et le `?.` court-circuite. `renderSoute`
   prend donc un paramètre `synchrone`, et cette délégation-là le passe.

## Vérification

```
$ npm test
ℹ tests 483
ℹ pass 483
ℹ fail 0

$ npx playwright test
  208 passed (1.4m)
  2 skipped

$ npx tsc --noEmit
(0 erreur)
```

**Le test de #118 a été vu ROUGE avant le correctif**, lancé contre le build de `v2/main`
(9923998) dans un worktree séparé :

```
$ npx playwright test e2e/smoke.pw.mjs -g "apostrophe"     # sur v2/main
    Expected: true
    Received: false
      982 |   // …et aucune entité HTML ne s'y affiche en clair.
  1 failed
```

Il choisit la commodité **dans les données** (`#commodityList`) plutôt qu'en dur, et se `skip`
franchement si l'instantané n'offre plus de nom à apostrophe — une première version, qui prenait la
cargaison telle qu'elle venait, passait au vert en ayant mesuré autre chose.

**Relevé des styles calculés**, `v2/main` contre cette branche, quatre états, mesures coup sur coup :

```
== soute          == comparées  34 / identiques  34 / différentes 0 / DISPARUES 0 / APPARUES 0
== ou-ecouler     == comparées  77 / identiques  73 / différentes 4 / DISPARUES 0 / APPARUES 0
== vente-ouverte  == comparées  80 / identiques  76 / différentes 4 / DISPARUES 0 / APPARUES 0
== entrepots      == comparées  18 / identiques  18 / différentes 0 / DISPARUES 0 / APPARUES 0
```

Les 8 écarts restants sont **le correctif de #118 et lui seul** — la même hauteur, propagée :
`.ec-detail` 31,5 → 15,75 px (une ligne au lieu de deux), donc `.ec-dest`, `.hold-ecouler` et la
carte. Aucune forme n'a disparu ni apparu.

## Ce qui n'est pas couvert

- **`renderDeclaration` (`#holdDeclare`) reste impératif.** Elle porte un garde
  `if (!force && box.contains(document.activeElement)) return` qui existe précisément parce qu'un
  `innerHTML` détruirait le champ en cours de saisie ; le résoudre demande le même raisonnement que
  le champ SCU du manifeste, et mérite sa propre PR.
- **Le compagnon de voyage reste impératif** : `renderJourney`, son récap et sa carte SVG. Dernier
  lot, et le plus couplé.
- Le relevé porte sur quatre états. La soute à **plusieurs lots pour une même commodité**
  (`.hold-lots`) et le cas **« butin »** (`invest === 0`) ne sont pas mesurés — ils restent couverts
  par la suite e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
