### PR TITLE
fix(manifeste): après un message d'invite, la carte revient

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,7 +34,7 @@ import { vueGrilleCommodites, aideBoard, vueDetailCommodite, inviteDetail } from
 import { vueStation, vueBandeCorrections, inviteStation } from "./vues/corrections.tsx";
 import { enTetePlan, corpsPlan } from "./vues/plan.tsx";
 import { vueTrajets, vueTrajetsMulti } from "./vues/trajets.tsx";
-import { carteManifeste, indiceManifeste, suggestions as vueSuggestions } from "./vues/manifeste.tsx";
+import { carteManifeste, indiceSouteInactive, indiceSoutePleine, indiceAucunChargement, suggestions as vueSuggestions } from "./vues/manifeste.tsx";
 import { KIND_ICON } from "./vues/communs.tsx";
 
 // Libellé compact des caisses SCU standard, ex. « 8×32 · 1×16 · 1×4 · 1×2 · 1×1 ».
@@ -1086,10 +1086,14 @@ let manifestGen = 0; // cf. l'affectation de `currentManifest`, plus bas
 function renderManifest(origin, destSystem, f, destTerminal) {
   const card = $("manifest");
   currentManifest = null;
-  if (enrouteOrigin == null) { card.hidden = true; return; }
+  // Les trois messages ci-dessous passent par React, comme la carte. `#manifest` lui appartient
+  // depuis #96 : un `innerHTML` y détacherait les nœuds qu'il a créés sans qu'il le sache, et la
+  // racine mémorisée dans pont.js appliquerait ensuite ses différences hors du document — le
+  // message resterait à l'écran pour de bon, sans lever (#120).
+  if (enrouteOrigin == null) { card.hidden = true; peindre(card, null); return; }
   if (!f.useCargo || !(f.cargo > 0)) {
     card.hidden = false;
-    card.innerHTML = `<div class="manifest-hint">Active la <b>soute (SCU)</b> pour calculer un manifeste de remplissage.</div>`;
+    peindre(card, indiceSouteInactive());
     return;
   }
   // La soute n'est pas vide : on ne peut charger QUE la place qui reste. C'est la question du
@@ -1100,7 +1104,7 @@ function renderManifest(origin, destSystem, f, destTerminal) {
   const libre = freeCargo(SOUTE, f.cargo);
   if (aBord > 0 && libre <= 0) {
     card.hidden = false;
-    card.innerHTML = `<div class="manifest-hint">Soute pleine : <b>${fmt(aBord)} SCU</b> déjà à bord. Vends ou dépose du fret pour charger autre chose.</div>`;
+    peindre(card, indiceSoutePleine(fmt(aBord)));
     return;
   }
   const fLibre = aBord > 0 ? { ...f, cargo: libre } : f;
@@ -1113,7 +1117,7 @@ function renderManifest(origin, destSystem, f, destTerminal) {
     || (compo ? manifesteSansOptimal(origin, cible, fLibre) : null);
   if (!man) {
     card.hidden = false;
-    card.innerHTML = `<div class="manifest-hint">Aucun chargement rentable depuis ce terminal vers cette destination${aBord > 0 ? ` dans les <b>${fmt(libre)} SCU</b> qui restent libres` : ""}.</div>`;
+    peindre(card, indiceAucunChargement(aBord > 0 ? fmt(libre) : null));
     return;
   }
   if (compo) man.lines = lignesComposees(compo.edit, origin, cible);

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -1352,6 +1352,29 @@ const memeStation = (nom) => new RegExp(nom.replace(/[.*+?^${}()|[\]\\]/g, "\\$&
 // Parcours encodé dans le lien partageable (paramètre `j` du hash), ou null.
 const lienVoyage = (page) => page.evaluate(() => new URLSearchParams(location.hash.slice(1)).get("j"));
 
+test("Manifeste : après un message d'invite, la carte REVIENT (#120)", async ({ page }) => {
+  // `#manifest` est possédé par React depuis #96. Les trois messages d'invite y écrivaient encore
+  // en `innerHTML`, ce qui détache les nœuds de React sans que React le sache : la racine mémorisée
+  // dans pont.js appliquait ensuite ses différences sur des nœuds hors du document. Le message
+  // restait à l'écran pour de bon, et rien ne levait.
+  //
+  // Aucun test ne faisait l'aller-RETOUR : c'est le seul chemin où ça se voit.
+  await manifesteDepuis(page, "Megumi — Pyro");
+  const lignes = await page.locator("#manifest .mline").count();
+  expect(lignes).toBeGreaterThan(0);
+
+  await page.uncheck("#useCargo");
+  await expect(page.locator("#manifest .manifest-hint")).toContainText("Active la");
+  await expect(page.locator("#manifest .mline")).toHaveCount(0);
+
+  await page.check("#useCargo");
+  await expect(
+    page.locator("#manifest .mline").first(),
+    "la carte n'est pas revenue — un innerHTML a détaché l'arbre React de #manifest",
+  ).toBeVisible({ timeout: 8000 });
+  await expect(page.locator("#manifest .manifest-hint")).toHaveCount(0);
+});
+
 test("Manifeste -> voyage : sans voyage, le bouton en démarre un", async ({ page }) => {
   await manifesteDepuis(page, "Megumi — Pyro");
   await expect(page.locator("#manifestToJourney")).toHaveText(/Démarrer un voyage/);

--- a/vues/manifeste.tsx
+++ b/vues/manifeste.tsx
@@ -360,8 +360,49 @@ export function CarteManifeste(p: ProprietesManifeste) {
   );
 }
 
-/** Les trois messages qui remplacent la carte quand il n'y a rien à charger. */
-export const indiceManifeste = (noeud: React.ReactNode) => <div className="manifest-hint">{noeud}</div>;
+// ---------------------------------------------------------------------------------------------
+// LES TROIS MESSAGES qui remplacent la carte quand il n'y a rien à charger.
+//
+// Ils passent par React, comme elle, et ce n'est pas une question d'uniformité : `#manifest`
+// appartient à React, et un `innerHTML` y détacherait les nœuds qu'il a créés sans qu'il le sache.
+// La racine étant mémorisée dans la WeakMap de `pont.js`, le rendu suivant appliquerait ses
+// différences sur des nœuds hors du document — le message resterait à l'écran pour de bon, et rien
+// ne lèverait. C'est ce qui est arrivé (#120), et le seul chemin qui le montre est l'aller-RETOUR
+// message → carte, qu'aucun test ne faisait.
+//
+// Ils sont exportés en FABRIQUES et non en composants JSX à composer côté appelant : `app.js`
+// reste du `.js` sans JSX — le renommer déplacerait le fichier que nomment le déploiement, `sw.js`
+// et `csp.test.mjs`.
+// ---------------------------------------------------------------------------------------------
+const Indice = ({ children }: { children: React.ReactNode }) => <div className="manifest-hint">{children}</div>;
+
+export const indiceSouteInactive = () => (
+  <Indice>
+    {"Active la "}
+    <b>soute (SCU)</b>
+    {" pour calculer un manifeste de remplissage."}
+  </Indice>
+);
+
+export const indiceSoutePleine = (scuABord: string) => (
+  <Indice>
+    {"Soute pleine : "}
+    <b>{`${scuABord} SCU`}</b>
+    {" déjà à bord. Vends ou dépose du fret pour charger autre chose."}
+  </Indice>
+);
+
+/** `scuLibres` non nul quand la soute n'était pas vide : la phrase dit alors dans quoi on cherchait. */
+export const indiceAucunChargement = (scuLibres: string | null) =>
+  scuLibres == null ? (
+    <Indice>Aucun chargement rentable depuis ce terminal vers cette destination.</Indice>
+  ) : (
+    <Indice>
+      {"Aucun chargement rentable depuis ce terminal vers cette destination dans les "}
+      <b>{`${scuLibres} SCU`}</b>
+      {" qui restent libres."}
+    </Indice>
+  );
 
 export const carteManifeste = (p: ProprietesManifeste) => <CarteManifeste {...p} />;
 export const suggestions = (p: ProprietesSuggestions) => <Suggestions {...p} />;


### PR DESCRIPTION
## Ce que ça change

Vue **En route** : quand la carte Manifeste est remplacée par un message d'invite (soute inactive,
soute pleine, aucun chargement rentable), **elle revient** dès que la condition disparaît. Elle
restait bloquée sur le message.

Closes #120

## Pourquoi

`#manifest` appartient à React depuis la migration de la carte (#96, PR #117). Les trois messages
de `renderManifest` y écrivaient encore en `card.innerHTML` (`app.js:1092`, `:1104`, `:1117`).

`innerHTML` détache les nœuds que React a créés **sans que React le sache**. La racine, elle, est
mémorisée dans la WeakMap de `pont.js` — c'est exprès, la rappeler remonterait l'arbre et reperdrait
focus et saisie (#24/#28/#38/#55). Au rendu suivant, `peindre` réutilise donc cette racine et
applique ses différences sur des nœuds **hors du document** : rien ne réapparaît, et rien ne lève.

C'est très exactement le piège que la migration s'était fixé d'éviter — *une branche restée en
`innerHTML` sur un conteneur possédé par React se fait écraser au rendu suivant, en silence*. Le
composant existait déjà dans `vues/manifeste.tsx` ; il n'avait pas été branché.

Les messages sont exportés en **fabriques** (`indiceSouteInactive`, `indiceSoutePleine`,
`indiceAucunChargement`) et non composés côté appelant : `app.js` reste du `.js` sans JSX — le
renommer déplacerait le fichier que nomment le déploiement, `sw.js` et `csp.test.mjs`.

## Vérification

Le test a été vu **rouge** avant le correctif, sur cette branche :

```
$ npx playwright test e2e/smoke.pw.mjs -g "après un message d'invite"
    Error: la carte n'est pas revenue — un innerHTML a détaché l'arbre React de #manifest
    expect(locator).toBeVisible() failed
    Expected: visible
    Error: element(s) not found
  1 failed
```

et vert après :

```
$ npx playwright test e2e/smoke.pw.mjs -g "après un message d'invite"
  1 passed (2.2s)

$ npm test
ℹ tests 483
ℹ pass 483
ℹ fail 0

$ npx playwright test
  208 passed (1.4m)
  2 skipped

$ npx tsc --noEmit
(0 erreur)
```

Sonde manuelle, avant / après :

```
AVANT   3. retour à la carte : 0 lignes | texte: "Active la soute (SCU) pour calculer un manifeste…"
APRÈS   3. retour à la carte : 3 lignes | texte: "◈ Manifeste — The Golden RivieraPYRO → Devlin Scrap…"
```

Et le message lui-même est inchangé **au caractère près** — `innerHTML` comparé entre `v2/main`
(9923998) et cette branche, pour les deux invites atteignables :

```
souteInactive : <div class="manifest-hint">Active la <b>soute (SCU)</b> pour calculer un manifeste de remplissage.</div>
soutePleine   : <div class="manifest-hint">Soute pleine : <b>50 SCU</b> déjà à bord. Vends ou dépose du fret pour charger autre chose.</div>
```

identiques des deux côtés.

## Ce qui n'est pas couvert

- Le troisième message (**« aucun chargement rentable »**) n'a pas été comparé : le déclencher
  demande un couple départ/arrivée sans aucune ligne rentable, que l'instantané courant n'offre pas
  facilement. Il emprunte la même fabrique et le même chemin que les deux autres.
- Le test couvre **un** aller-retour, celui de la soute inactive — le mécanisme est le même pour les
  trois, c'est la racine React qui est en cause, pas le message.
- Les autres `innerHTML` restants d'`app.js` ont été vérifiés un par un : ils visent `#holdDeclare`,
  `#journeyCard`, `#journeyRecap`, `#correctionsFees` et les `<datalist>`, dont **aucun** n'est
  possédé par React. `#correctionsFees` est un frère de `#correctionsStation`, pas un enfant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
