### PR TITLE
feat(voyage): le compagnon de voyage et son récap passent en React

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,8 +34,9 @@ import { vueGrilleCommodites, aideBoard, vueDetailCommodite, inviteDetail } from
 import { vueStation, vueBandeCorrections, inviteStation } from "./vues/corrections.tsx";
 import { enTetePlan, corpsPlan } from "./vues/plan.tsx";
 import { vueTrajets, vueTrajetsMulti } from "./vues/trajets.tsx";
-import { carteManifeste, indiceManifeste, suggestions as vueSuggestions } from "./vues/manifeste.tsx";
+import { carteManifeste, indiceManifeste } from "./vues/manifeste.tsx";
 import { carteSoute, carteEntrepots } from "./vues/soute.tsx";
+import { carteVoyage, recapVoyage, inviteVoyage } from "./vues/voyage.tsx";
 import { KIND_ICON } from "./vues/communs.tsx";
 
 // Libellé compact des caisses SCU standard, ex. « 8×32 · 1×16 · 1×4 · 1×2 · 1×1 ».
@@ -1437,7 +1438,7 @@ function reprendreIci(station, nom, units) {
 // l'app ne rappelait — c'était tout le sujet.
 // Les clés de DEPOTS viennent du localStorage : elles sont échappées comme n'importe quelle donnée
 // tierce (cf. e2e/injection.pw.mjs).
-function renderEntrepots() {
+function renderEntrepots(synchrone = false) {
   const box = $("depotsCard");
   if (!box) return;
   const stations = Object.entries(DEPOTS).filter(([, lots]) => Array.isArray(lots) && lots.length);
@@ -1451,7 +1452,7 @@ function renderEntrepots() {
     scuTotal: holdScu(tous),
     invest: holdByCommodity(tous).reduce((s, g) => s + g.invest, 0),
     fmt,
-  }));
+  }), { synchrone });
 }
 
 // La liste de ce qui dort en entrepôt, en texte, dans le presse-papiers : elle ne quittait jamais
@@ -1944,41 +1945,23 @@ function editLegQty(i, li, val) {
   // voyage ou de replier une jambe du premier coup). On laisse le tour d'événement se terminer.
   setTimeout(renderJourney, 0);
 }
-// Saisie en direct : met à jour l'intention + repeint profit/caisses/suggestions SANS re-render
-// global (un renderJourney() à chaque frappe ferait perdre le focus de l'input).
+// Saisie en direct : met à jour l'intention, puis repeint la carte AVEC LA GÉNÉRATION FIGÉE.
+//
+// L'ancienne version s'interdisait tout re-rendu — « un renderJourney() à chaque frappe ferait
+// perdre le focus de l'input » — et mettait donc à jour `.jman-profit`, `over-stock` et la boîte de
+// suggestions à la main. C'était vrai d'un `innerHTML`, qui détruit le champ ; ça ne l'est plus
+// d'un rendu React, qui garde le nœud et n'écrit pas dans un champ non contrôlé. Le seul risque
+// serait que la valeur CALCULÉE reprenne la main sous les doigts : `frappe: true` l'empêche en ne
+// bougeant pas la génération (cf. `renderJourney`).
 function liveLegQty(i, li, inp) {
-  if (!JOURNEY || !JOURNEY.legs[i]) return; // idem : le parcours a pu disparaître sous la saisie
-  const leg = JOURNEY.legs[i];
-  const f = readFilters();
-  const intent = legIntent(leg, i, f);
+  if (!JOURNEY || !JOURNEY.legs[i]) return; // le parcours a pu disparaître sous la saisie
+  const intent = legIntent(JOURNEY.legs[i], i, readFilters());
   if (!intent[li]) return;
-  let u = Math.floor(Number(inp.value));
-  if (!Number.isFinite(u) || u < 0) u = 0;
-  intent[li].units = u;
-  const lines = legEffectiveLines(leg, i, f); // relues au marché COURANT, jamais figées
-  const l = lines[li];
-  if (!l) return;
-  inp.classList.toggle("over-stock", isFinite(l.cap) && u > l.cap);
-  const ctx = legFeeCtx(leg, f);
-  const pair = ctx && ctx.pair;
-  const row = inp.closest(".jman-line");
-  const prof = row && row.querySelector(".jman-profit");
-  if (prof) prof.textContent = lineProfitText(u, l, pair);
-  renderLegSuggestions(i, lines);
+  const u = Math.floor(Number(inp.value));
+  intent[li].units = Number.isFinite(u) && u > 0 ? u : 0;
+  renderJourney({ frappe: true });
 }
-// Repeint la boîte de suggestions d'une jambe dépliée.
-function renderLegSuggestions(i, lines) {
-  const box = document.querySelector(`.jman-suggest[data-leg="${i}"]`);
-  if (!box) return;
-  const ctx = legSuggestCtx(JOURNEY.legs[i], lines, readFilters());
-  // Même composant que la carte : `data-leg` part sur le bouton d'ajout, la délégation qui le lit
-  // ne bouge pas. La carte du compagnon est encore écrite en innerHTML, donc ce conteneur est
-  // recréé à chaque rendu — la WeakMap de pont.js lui redonne simplement une racine neuve.
-  peindre(box, ctx ? vueSuggestions({
-    suggestions: suggestionsFor(ctx), restant: manifestRemaining(ctx), frais: ctx.fee,
-    fmt, fmtVol, attributsAjout: { "data-leg": i },
-  }) : null);
-}
+
 // Ajoute une commodité suggérée à une jambe, remplie au max possible.
 function addLegSuggestion(i, name) {
   const leg = JOURNEY.legs[i];
@@ -2114,24 +2097,24 @@ function removeJourneyStop(stopIndex) {
   refresh();
 }
 
-function renderJourney() {
+// `frappe` : on est EN TRAIN de taper dans un champ SCU de jambe. La génération ne bouge alors pas,
+// donc les champs non contrôlés gardent leur valeur et leur curseur pendant que profits, totaux et
+// suggestions se recalculent — même mécanique que le manifeste (#117). Tout autre appel la bouge,
+// ce qui remonte les champs : c'est ce que faisait l'ancien `card.innerHTML`.
+let journeyGen = 0;
+function renderJourney({ frappe = false } = {}) {
   const card = $("journeyCard");
   if (!card) return;
+  if (!frappe) journeyGen++;
   // Aucun voyage -> invite à en démarrer un : depuis un trajet (▶) OU « de zéro » (point de départ).
   if (!JOURNEY) {
     card.hidden = false;
-    const recap0 = $("journeyRecap"); if (recap0) recap0.hidden = true; // pas de récap sans voyage
+    const recap0 = $("journeyRecap"); if (recap0) { recap0.hidden = true; peindre(recap0, null); } // pas de récap sans voyage
     const row0 = $("shipJourneyRow"); if (row0) row0.classList.remove("stacked");
     renderJourneyMap();
     renderSoute();
     renderEntrepots();
-    card.innerHTML =
-      `<div class="journey-head"><span class="journey-title">◈ Nouveau voyage</span></div>
-       <p class="journey-hint">Choisis un trajet (▶) dans une vue, ou démarre de zéro :</p>
-       <div class="journey-add">
-         <input id="journeyStart" list="stationList" placeholder="Point de départ (terminal)…" autocomplete="off" aria-label="Point de départ du voyage" />
-         <button id="journeyStartBtn" type="button" class="chain-pick">Commencer</button>
-       </div>`;
+    peindre(card, inviteVoyage(), { synchrone: true });
     return;
   }
   card.hidden = false;
@@ -2140,89 +2123,71 @@ function renderJourney() {
   else if (!enrouteReady) setupEnRoute();
 
   const stations = journeyStations(JOURNEY);
-  const path = stations
-    .map((s, i) => `<span class="jstep-wrap"><button class="jstep${i === JOURNEY.current ? " here" : ""}" data-i="${i}" title="Je suis ici"><span class="sys ${esc(s.system.toLowerCase())}">${esc(s.name)}</span></button><button class="jstep-del" data-i="${i}" title="Retirer cet arrêt" aria-label="Retirer">✕</button></span>`)
-    .join('<span class="jsep">→</span>');
   const n = JOURNEY.legs.length;
   const f = readFilters();
   let totalProfit = 0, totalScu = 0, totalFees = 0; // récap : profit réel, SCU et frais du voyage
   // Manifeste (cargaison) de chaque jambe — optimal ou édité ; jambe dépliable pour l'éditer.
-  const legsHtml = JOURNEY.legs.map((leg, i) => {
+  const jambes = JOURNEY.legs.map((leg, i) => {
     const lines = MARKET ? legEffectiveLines(leg, i, f) : null;
     const pair = MARKET ? (legFeeCtx(leg, f) || {}).pair : null;
     const edited = MARKET && !!JOURNEY_EDITS[legKey(leg, i)];
-    const pinned = edited && !!JOURNEY_PINS[legKey(leg, i)]; // figée par une correction, pas par toi
-    const charge = MARKET && jambeChargee(leg, i); // ce manifeste est-il déjà en soute ?
     const expanded = i === journeyExpandedLeg;
-    let cargo, total;
-    // `totalJambe` porte le NOMBRE quand `total` n'en est que le rendu : c'est lui qui décide du
-    // signe et de la couleur. Une jambe dont les frais dépassent la marge est une vraie réponse,
+    // `nombreTotal` porte le NOMBRE quand `texteTotal` n'en est que le rendu : c'est lui qui décide
+    // du signe et de la couleur. Une jambe dont les frais dépassent la marge est une vraie réponse,
     // pas un cas limite — elle s'affichait « +-1 234 », en vert.
-    let totalJambe = 0;
-    if (!MARKET) { cargo = '<span class="muted">calcul…</span>'; total = "—"; }
-    else if (!lines.length) { cargo = '<span class="muted">aucun fret rentable</span>'; total = "0"; }
-    else {
-      cargo = lines.map((l) => `<span class="jcargo-item">${freshDot(lineFreshUpdated(l))}${commodityIcon(l.kind)}<span>${esc(l.name)}${illegalTag(l.illegal)}</span> <b>${fmt(l.units)} SCU</b></span>`).join("");
+    let texteTotal = "—", nombreTotal = 0;
+    if (MARKET && lines.length) {
       const t = manifestTotals(lines, pair);
-      total = fmtFee(t.profit, t.fees);
-      totalJambe = t.profit;
+      texteTotal = fmtFee(t.profit, t.fees);
+      nombreTotal = t.profit;
       totalProfit += t.profit;
       totalFees += t.fees;
       totalScu += lines.reduce((s, l) => s + l.units, 0);
-    }
-    let editor = "";
-    if (expanded && MARKET) {
-      const rows = lines.map((l, li) =>
-        `<div class="jman-line">${commodityIcon(l.kind)}` +
-        `<span class="mqtywrap"><input type="number" class="jman-qty" min="0" value="${l.units}" data-leg="${i}" data-i="${li}" aria-label="SCU ${esc(l.name)}"><span class="munit">SCU</span></span>` +
-        `<span class="jman-name">${freshDot(lineFreshUpdated(l))}${esc(l.name)}${illegalTag(l.illegal)}${l.acquired ? ' <span class="carry-tag" title="Introuvable à l\'achat ici — fret déjà en soute">acquis ailleurs</span>' : ""}${l.sellPrice == null ? ' <span class="carry-tag">vend ailleurs</span>' : ""}</span>` +
-        `<span class="jman-profit profit">${lineProfitText(l.units, l, pair)}</span>` +
-        `<button class="jman-del" data-leg="${i}" data-name="${esc(l.name)}" title="Retirer">✕</button></div>`
-      ).join("") || '<div class="muted jman-empty">Aucune commodité.</div>';
-      // Le conteneur part VIDE : `renderLegSuggestions` le peint juste après l'écriture de la
-      // carte, avec le même composant React que le manifeste d'« En route ». L'incruster ici
-      // demanderait une seconde fabrique du même bloc, en chaîne — c'est ce qu'on vient de retirer.
-      editor = `<div class="jman">${rows}
-        <div class="jman-add"><input class="jman-add-input" list="commodityList" data-leg="${i}" placeholder="+ commodité (même non vendable)…" autocomplete="off"><button class="jman-add-btn" data-leg="${i}">+</button>${edited ? `<button class="jman-reset" data-leg="${i}" title="Revenir au manifeste optimal">↺ optimal</button>` : ""}</div>
-        <div class="jman-suggest manifest-suggest" data-leg="${i}"></div>
-      </div>`;
-    }
-    return `<div class="jleg${i === JOURNEY.current ? " current" : ""}${expanded ? " expanded" : ""}">
-        <div class="jleg-head" data-leg="${i}" role="button" tabindex="0" aria-expanded="${expanded}" title="Éditer le manifeste de cette jambe"><span class="jleg-n">${i + 1}</span><span class="jleg-route">${esc(leg.from)} → ${esc(leg.to)}</span>${edited ? (pinned
-          ? '<span class="jleg-pinned" title="Quantités figées : le stock ou la demande de ce chargement a été corrigé depuis. Le trajet reste tel que tu l\'as décidé — les prix, eux, continuent de suivre le marché. « ↺ optimal » recalcule tout.">🔒</span>'
-          : '<span class="jleg-edited" title="Manifeste personnalisé">✎</span>') : ""}${MARKET && lines && lines.length ? `<button class="jleg-load${charge ? " charge" : ""}" data-leg="${i}" title="${charge ? "Annuler : ce chargement n'est plus à bord" : "J'ai payé et chargé ce manifeste — il entre en soute à ce prix"}">${charge ? "⬢ à bord" : "✓ chargé"}</button>` : ""}<span class="jleg-profit ${classeProfit(totalJambe)}">${signe(totalJambe, total)}</span><span class="jleg-caret">${expanded ? "▾" : "▸"}</span></div>
-        <div class="jleg-cargo">${cargo}</div>
-        ${editor}
-      </div>`;
-  }).join("");
+    } else if (MARKET) texteTotal = "0";
+    // Les suggestions de la jambe DÉPLIÉE sont calculées ici et rendues dans l'arbre : elles
+    // vivaient dans un conteneur peint à part, détour qui n'existait que parce que la carte était
+    // réécrite en innerHTML à chaque rendu.
+    const sctx = expanded && MARKET ? legSuggestCtx(leg, lines, f) : null;
+    return {
+      i, from: leg.from, to: leg.to,
+      courante: i === JOURNEY.current,
+      depliee: expanded,
+      editee: !!edited,
+      figee: !!(edited && JOURNEY_PINS[legKey(leg, i)]), // figée par une correction, pas par toi
+      chargee: !!(MARKET && jambeChargee(leg, i)),       // ce manifeste est-il déjà en soute ?
+      lignes: lines && lines.map((l) => ({
+        name: l.name, kind: l.kind, illegal: !!l.illegal, units: l.units,
+        acquired: !!l.acquired, vendable: l.sellPrice != null,
+        releve: lineFreshUpdated(l),
+        texteProfit: lineProfitText(l.units, l, pair),
+        auDela: Number.isFinite(l.cap) && l.units > l.cap,
+      })),
+      texteTotal, nombreTotal,
+      suggestions: sctx ? {
+        suggestions: suggestionsFor(sctx), restant: manifestRemaining(sctx), frais: sctx.fee,
+        fmt, fmtVol, attributsAjout: { "data-leg": i },
+      } : null,
+    };
+  });
 
-  // Ajout d'arrêt : champ libre (tous terminaux) + suggestions rentables depuis la fin.
-  const sugList = MARKET ? journeyStopSuggestions() : [];
-  const suggestBlock = !MARKET ? ""
-    : sugList.length
-      ? `<div class="journey-suggest"><span class="suggest-lbl">Suggestions :</span>${sugList.map((s) => `<button class="jstop-suggest" data-label="${esc(s.label)}" title="Ajouter ${esc(s.terminal)} — via ${esc(s.commodity)}, +${fmt(s.margin)} marge/SCU">+ ${esc(s.terminal)} <span class="muted">+${fmt(s.margin)}</span></button>`).join("")}</div>`
-      : '<div class="journey-suggest-empty muted">Aucune destination rentable depuis ici — ajoute quand même un arrêt au champ ci-dessus (il aura un manifeste vide, à remplir à la main).</div>';
-  const startHint = n === 0 ? '<p class="journey-hint">Départ posé — ajoute un arrêt pour construire ton parcours.</p>' : "";
-  card.innerHTML =
-    `<div class="journey-head"><span class="journey-title">◈ ${n === 0 ? "Voyage" : "Voyage en cours"}</span><button id="journeyClear" class="journey-clear" title="Effacer le parcours" aria-label="Effacer">✕</button></div>
-     <div class="journey-path">${path}</div>
-     ${startHint}
-     <div class="journey-legs">${legsHtml}</div>
-     <div class="journey-add">
-       <input id="journeyAddStop" list="stationList" placeholder="+ Ajouter un arrêt (terminal)…" autocomplete="off" aria-label="Ajouter un arrêt" />
-       <button id="journeyAddBtn" type="button" class="chain-pick">+ Arrêt</button>
-     </div>
-     ${suggestBlock}
-     <div class="journey-meta">${n} saut${n > 1 ? "s" : ""} · marge cumulée <b class="profit">${fmt(journeyMargin(JOURNEY))}</b> aUEC/SCU</div>`;
+  peindre(card, carteVoyage({
+    stations, courante: JOURNEY.current, nbSauts: n,
+    margeCumulee: journeyMargin(JOURNEY),
+    marchePret: !!MARKET,
+    jambes,
+    suggestionsArret: MARKET ? journeyStopSuggestions() : null,
+    generation: journeyGen,
+    fmt, signe,
+  }), { synchrone: true });
 
-  // Après `card.innerHTML` : le conteneur des suggestions vient d'être (re)créé, il faut le peindre.
-  // Une seule jambe est dépliée à la fois, donc une seule en porte un.
-  if (MARKET && journeyExpandedLeg != null && JOURNEY.legs[journeyExpandedLeg])
-    renderLegSuggestions(journeyExpandedLeg, legEffectiveLines(JOURNEY.legs[journeyExpandedLeg], journeyExpandedLeg, f));
   renderJourneyRecap({ n, totalProfit, totalScu, totalFees, systems: new Set(stations.map((s) => s.system)).size });
   renderJourneyMap();
-  renderSoute();
-  renderEntrepots();
+  // SYNCHRONES, les quatre : `ajusterRangeeVoyage` MESURE les hauteurs juste en dessous
+  // (`getBoundingClientRect`) pour décider d'empiler les colonnes. Un rendu React groupé les lui
+  // ferait lire AVANT peinture — la carte basculait de 1172 px à 640 px de large selon l'état,
+  // et la bascule s'inversait à l'état suivant. L'ancien `innerHTML` était synchrone ; on le reste.
+  renderSoute(true);
+  renderEntrepots(true);
   ajusterRangeeVoyage(); // après la carte ET la soute : les deux pèsent sur l'équilibre des colonnes
 }
 
@@ -2231,17 +2196,12 @@ function renderJourneyRecap({ n, totalProfit, totalScu, totalFees, systems }) {
   const recap = $("journeyRecap");
   if (!recap) return;
   recap.hidden = false;
-  const materials = MARKET ? journeyCarriedCommodities().size : 0;
-  const kpi = (v, lbl) => `<div class="recap-kpi"><b>${v}</b><span>${lbl}</span></div>`;
-  recap.innerHTML =
-    `<div class="recap-head">◈ Résumé du voyage</div>
-     <div class="recap-profit ${classeProfit(totalProfit)}"${totalFees > 0 ? ` title="Frais d'autoload ≈ ${fmt(totalFees)} aUEC déjà déduits — estimation (±3 %)"` : ""}>${MARKET ? signe(totalProfit, (totalFees > 0 ? "≈ " : "") + fmt(totalProfit)) : "…"} <span>aUEC</span></div>
-     <div class="recap-kpis">
-       ${kpi(n, "saut" + (n > 1 ? "s" : ""))}
-       ${kpi(MARKET ? fmt(totalScu) : "…", "SCU")}
-       ${kpi(systems, "système" + (systems > 1 ? "s" : ""))}
-       ${kpi(MARKET ? materials : "…", "matériau" + (materials > 1 ? "x" : ""))}
-     </div>`;
+  peindre(recap, recapVoyage({
+    n, totalProfit, totalScu, totalFees, systems,
+    materials: MARKET ? journeyCarriedCommodities().size : 0,
+    marchePret: !!MARKET,
+    fmt, signe,
+  }), { synchrone: true });
 }
 
 // ---------- La tournée d'écoulement : la huitième vue (ADR-007, #57) ----------

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -1717,6 +1717,25 @@ async function ouvrirUneJambeEditable(page, essais = 10, convient = null) {
   throw new Error("aucune des premières lignes ne mène à une jambe qui convienne");
 }
 
+test("Dépassement du stock : le marqueur SURVIT à un rafraîchissement (#122)", async ({ page }) => {
+  // `over-stock` n'était posée que par le gestionnaire de saisie, jamais au rendu : la première
+  // réécriture de la carte — un filtre changé, l'arrivée du marché, un prix corrigé ailleurs —
+  // l'effaçait en laissant la quantité. Le dépassement cessait d'être signalé, ce qui est
+  // exactement ce que le marqueur existe pour éviter.
+  await ouvrirUneJambeEditable(page);
+  const champ = page.locator("#journeyCard .jman-qty").first();
+  await champ.fill("99999");
+  await expect(champ, "le marqueur n'apparaît même pas à la frappe").toHaveClass(/over-stock/);
+
+  // Un rendu venu d'AILLEURS : on ne touche pas au champ, on change un filtre.
+  await page.fill("#cargo", "95");
+  await expect(champ).toHaveValue("99999");
+  await expect(
+    champ,
+    "le marqueur a disparu au rafraîchissement — la quantité absurde n'est plus signalée",
+  ).toHaveClass(/over-stock/);
+});
+
 test("Compagnon de voyage : éditer le manifeste d'une jambe (SCU) persiste hors lien", async ({ page }) => {
   await ouvrirUneJambeEditable(page);
   await page.locator("#journeyCard .jman-qty").first().fill("7");

--- a/vues/communs.tsx
+++ b/vues/communs.tsx
@@ -55,6 +55,18 @@ export function PastilleFraicheur({ updated }: { updated: number }) {
   return <span className={"fresh " + cls} title={"Relevé UEX il y a " + label}>{label}</span>;
 }
 
+// Le POINT de fraîcheur — à ne pas confondre avec la pastille ci-dessus. Celle-ci porte son
+// libellé et sert les tableaux ; celui-là est un simple rond coloré, sans texte, posé devant un nom
+// de commodité dans le compagnon de voyage, où la place manque. Deux classes, deux rendus, et les
+// seuils diffèrent aussi : le point n'a pas de cas « moins d'un jour » séparé.
+export function PointFraicheur({ updated }: { updated: number }) {
+  const d = ageDays(updated);
+  if (d == null) return <span className="fresh-dot f-old" title="Fraîcheur des données inconnue" />;
+  const label = d < 1 ? (d < 1 / 24 ? "moins d'1 h" : Math.round(d * 24) + " h") : Math.round(d) + " j";
+  const cls = d < 3 ? "f-good" : d < 7 ? "f-ok" : "f-old";
+  return <span className={"fresh-dot " + cls} title={"Relevé UEX il y a " + label} />;
+}
+
 // La cellule de fiabilité. Elle N'ENTRE PAS DANS LE TRI, et son title le dit — c'est une décision
 // de l'ADR-005 : la fiabilité informe, elle ne classe pas.
 export function CelluleFiabilite({ f, age, part }: { f: number; age: number | null; part: number }) {

--- a/vues/voyage.tsx
+++ b/vues/voyage.tsx
@@ -1,0 +1,336 @@
+// Le compagnon de voyage — `#journeyCard` et son récap —, onzième et DERNIER îlot de vue (#96).
+//
+// C'est le plus couplé du dépôt, et c'est pour ça qu'il passe en dernier : il lit six globales
+// (dont `JOURNEY`, 33 références), et son rendu déclenchait celui de trois autres cartes. Rien de
+// tout ça ne bouge — app.js garde l'orchestration, l'îlot ne reçoit que le résultat.
+//
+// DEUX CHOSES À NE PAS DÉFAIRE :
+//
+//  1. Le champ SCU d'une jambe (`.jman-qty`) est NON CONTRÔLÉ, et une `generation` le remonte.
+//     Même mécanique que le manifeste (#117) : la frappe doit survivre au re-rendu qu'elle
+//     provoque, mais un manifeste RECALCULÉ doit reprendre la main. `renderJourney({frappe:true})`
+//     ne bouge pas la génération ; tout autre appel la bouge.
+//  2. Les suggestions d'une jambe sont rendues ICI, dans l'arbre. Elles vivaient dans un conteneur
+//     peint à part (`renderLegSuggestions`) parce que la carte, elle, était écrite en `innerHTML`
+//     et le détruisait à chaque rendu. La carte étant passée à React, ce détour n'a plus de raison
+//     d'être — et un conteneur peint à part DANS une carte possédée par React est précisément le
+//     piège de #120.
+import { Fragment } from "react";
+import { PointFraicheur, IconeCommodite, TagIllegal } from "./communs.tsx";
+import { Suggestions, type ProprietesSuggestions } from "./manifeste.tsx";
+
+type Fmt = (n: number) => string;
+
+export type LigneJambe = {
+  name: string;
+  kind: string;
+  illegal: boolean;
+  units: number;
+  /** Introuvable à l'achat ici : le fret est déjà en soute (butin, minage, salvage). */
+  acquired: boolean;
+  /** `null` quand la commodité n'est pas vendable à l'arrivée — à écouler ailleurs. */
+  vendable: boolean;
+  /** Le plus ancien des relevés achat/vente de la ligne. */
+  releve: number;
+  /** Rendu par app.js (`lineProfitText`), qui seul connaît le contexte de frais de la jambe. */
+  texteProfit: string;
+  /** Le stock UEX est dépassé — signalé, jamais empêché (vol de fret, relevé périmé…). */
+  auDela: boolean;
+};
+
+export type Jambe = {
+  i: number;
+  from: string;
+  to: string;
+  courante: boolean;
+  depliee: boolean;
+  /** Manifeste personnalisé (✎), et figé par une correction (🔒) plutôt que par toi. */
+  editee: boolean;
+  figee: boolean;
+  /** Ce manifeste est-il déjà en soute ? */
+  chargee: boolean;
+  /** `null` tant que le marché n'est pas là : la jambe affiche « calcul… ». */
+  lignes: LigneJambe[] | null;
+  /** Le rendu du total (`fmtFee`) et le NOMBRE qui décide de son signe et de sa couleur. Les
+   *  séparer n'est pas un luxe : une jambe dont les frais dépassent la marge s'affichait
+   *  « +-1 234 », en vert. */
+  texteTotal: string;
+  nombreTotal: number;
+  /** Les suggestions de remplissage de CETTE jambe, quand elle est dépliée. */
+  suggestions: ProprietesSuggestions | null;
+};
+
+export type SuggestionArret = { label: string; terminal: string; commodity: string; margin: number };
+
+export type ProprietesVoyage = {
+  stations: { name: string; system: string }[];
+  courante: number;
+  nbSauts: number;
+  margeCumulee: number;
+  /** Sans marché, ni manifeste par jambe, ni suggestion d'arrêt : la carte le dit au lieu de mentir. */
+  marchePret: boolean;
+  jambes: Jambe[];
+  /** `null` quand le marché manque ; une liste vide est une réponse, pas une absence. */
+  suggestionsArret: SuggestionArret[] | null;
+  /** Bougée à chaque rendu SAUF pendant la frappe — elle remonte les champs SCU des jambes. */
+  generation: number;
+  fmt: Fmt;
+  signe: (n: number, texte: string) => string;
+};
+
+const classeProfit = (n: number) => (n < 0 ? "perte" : "profit");
+
+// ---------------------------------------------------------------------------------------------
+// Aucun voyage : l'invite à en démarrer un, depuis un trajet (▶) ou de zéro.
+// ---------------------------------------------------------------------------------------------
+export const inviteVoyage = () => (
+  <>
+    <div className="journey-head">
+      <span className="journey-title">◈ Nouveau voyage</span>
+    </div>
+    <p className="journey-hint">Choisis un trajet (▶) dans une vue, ou démarre de zéro :</p>
+    <div className="journey-add">
+      <input id="journeyStart" list="stationList" placeholder="Point de départ (terminal)…" autoComplete="off" aria-label="Point de départ du voyage" />
+      <button id="journeyStartBtn" type="button" className="chain-pick">Commencer</button>
+    </div>
+  </>
+);
+
+// ---------------------------------------------------------------------------------------------
+// L'éditeur de manifeste d'une jambe dépliée.
+// ---------------------------------------------------------------------------------------------
+function EditeurJambe({ j, generation }: { j: Jambe; generation: number }) {
+  const lignes = j.lignes || [];
+  return (
+    <div className="jman">
+      {lignes.length ? (
+        lignes.map((l, li) => (
+          <div className="jman-line" key={l.name}>
+            <IconeCommodite kind={l.kind} />
+            <span className="mqtywrap">
+              {/* Non contrôlé + `key` portant la génération : cf. l'en-tête du fichier. */}
+              <input
+                key={`${l.name}@${generation}`}
+                type="number"
+                className={"jman-qty" + (l.auDela ? " over-stock" : "")}
+                min="0"
+                defaultValue={l.units}
+                data-leg={j.i}
+                data-i={li}
+                aria-label={`SCU ${l.name}`}
+              />
+              <span className="munit">SCU</span>
+            </span>
+            <span className="jman-name">
+              <PointFraicheur updated={l.releve} />
+              {l.name}
+              <TagIllegal illegal={l.illegal} />
+              {l.acquired ? (
+                <>
+                  {" "}
+                  <span className="carry-tag" title="Introuvable à l'achat ici — fret déjà en soute">acquis ailleurs</span>
+                </>
+              ) : null}
+              {!l.vendable ? (
+                <>
+                  {" "}
+                  <span className="carry-tag">vend ailleurs</span>
+                </>
+              ) : null}
+            </span>
+            <span className="jman-profit profit">{l.texteProfit}</span>
+            <button className="jman-del" data-leg={j.i} data-name={l.name} title="Retirer">✕</button>
+          </div>
+        ))
+      ) : (
+        <div className="muted jman-empty">Aucune commodité.</div>
+      )}
+      <div className="jman-add">
+        <input className="jman-add-input" list="commodityList" data-leg={j.i} placeholder="+ commodité (même non vendable)…" autoComplete="off" />
+        <button className="jman-add-btn" data-leg={j.i}>+</button>
+        {j.editee ? (
+          <button className="jman-reset" data-leg={j.i} title="Revenir au manifeste optimal">↺ optimal</button>
+        ) : null}
+      </div>
+      <div className="jman-suggest manifest-suggest" data-leg={j.i}>
+        {j.suggestions ? <Suggestions {...j.suggestions} /> : null}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Une jambe : son en-tête cliquable, sa cargaison, et son éditeur si elle est dépliée.
+// ---------------------------------------------------------------------------------------------
+function JambeVoyage({ p, j }: { p: ProprietesVoyage; j: Jambe }) {
+  const lignes = j.lignes;
+  return (
+    <div className={"jleg" + (j.courante ? " current" : "") + (j.depliee ? " expanded" : "")}>
+      <div className="jleg-head" data-leg={j.i} role="button" tabIndex={0} aria-expanded={j.depliee} title="Éditer le manifeste de cette jambe">
+        <span className="jleg-n">{j.i + 1}</span>
+        <span className="jleg-route">{`${j.from} → ${j.to}`}</span>
+        {j.editee ? (
+          j.figee ? (
+            <span
+              className="jleg-pinned"
+              title="Quantités figées : le stock ou la demande de ce chargement a été corrigé depuis. Le trajet reste tel que tu l'as décidé — les prix, eux, continuent de suivre le marché. « ↺ optimal » recalcule tout."
+            >
+              🔒
+            </span>
+          ) : (
+            <span className="jleg-edited" title="Manifeste personnalisé">✎</span>
+          )
+        ) : null}
+        {p.marchePret && lignes && lignes.length ? (
+          <button
+            className={"jleg-load" + (j.chargee ? " charge" : "")}
+            data-leg={j.i}
+            title={j.chargee ? "Annuler : ce chargement n'est plus à bord" : "J'ai payé et chargé ce manifeste — il entre en soute à ce prix"}
+          >
+            {j.chargee ? "⬢ à bord" : "✓ chargé"}
+          </button>
+        ) : null}
+        <span className={"jleg-profit " + classeProfit(j.nombreTotal)}>{p.signe(j.nombreTotal, j.texteTotal)}</span>
+        <span className="jleg-caret">{j.depliee ? "▾" : "▸"}</span>
+      </div>
+      <div className="jleg-cargo">
+        {!p.marchePret ? (
+          <span className="muted">calcul…</span>
+        ) : !lignes || !lignes.length ? (
+          <span className="muted">aucun fret rentable</span>
+        ) : (
+          lignes.map((l) => (
+            <span className="jcargo-item" key={l.name}>
+              <PointFraicheur updated={l.releve} />
+              <IconeCommodite kind={l.kind} />
+              <span>
+                {l.name}
+                <TagIllegal illegal={l.illegal} />
+              </span>
+              {" "}
+              <b>{`${p.fmt(l.units)} SCU`}</b>
+            </span>
+          ))
+        )}
+      </div>
+      {j.depliee && p.marchePret ? <EditeurJambe j={j} generation={p.generation} /> : null}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------------------------
+// La carte entière.
+// ---------------------------------------------------------------------------------------------
+export function CarteVoyage(p: ProprietesVoyage) {
+  const n = p.nbSauts;
+  return (
+    <>
+      <div className="journey-head">
+        <span className="journey-title">{n === 0 ? "◈ Voyage" : "◈ Voyage en cours"}</span>
+        <button id="journeyClear" className="journey-clear" title="Effacer le parcours" aria-label="Effacer">✕</button>
+      </div>
+      <div className="journey-path">
+        {p.stations.map((s, i) => (
+          // `Fragment` et non un <span> englobant : `.journey-path` est un conteneur flex, et
+          // envelopper ses enfants les en sortirait (mesuré sur `.chain-path`, PR #111).
+          <Fragment key={i}>
+            {i > 0 ? <span className="jsep">→</span> : null}
+            <span className="jstep-wrap">
+              <button className={"jstep" + (i === p.courante ? " here" : "")} data-i={i} title="Je suis ici">
+                <span className={"sys " + s.system.toLowerCase()}>{s.name}</span>
+              </button>
+              <button className="jstep-del" data-i={i} title="Retirer cet arrêt" aria-label="Retirer">✕</button>
+            </span>
+          </Fragment>
+        ))}
+      </div>
+      {n === 0 ? <p className="journey-hint">Départ posé — ajoute un arrêt pour construire ton parcours.</p> : null}
+      <div className="journey-legs">
+        {p.jambes.map((j) => (
+          <Fragment key={j.i}>
+            <JambeVoyage p={p} j={j} />
+          </Fragment>
+        ))}
+      </div>
+      <div className="journey-add">
+        <input id="journeyAddStop" list="stationList" placeholder="+ Ajouter un arrêt (terminal)…" autoComplete="off" aria-label="Ajouter un arrêt" />
+        <button id="journeyAddBtn" type="button" className="chain-pick">+ Arrêt</button>
+      </div>
+      {/* Ajout d'arrêt : champ libre (tous terminaux) + suggestions rentables depuis la fin.
+          Une liste VIDE est une réponse — « rien ne rapporte d'ici » — et se dit. `null`, lui, veut
+          dire que le marché n'est pas encore là, et ne se dit pas du tout. */}
+      {p.suggestionsArret == null ? null : p.suggestionsArret.length ? (
+        <div className="journey-suggest">
+          <span className="suggest-lbl">Suggestions :</span>
+          {p.suggestionsArret.map((s) => (
+            <button
+              className="jstop-suggest"
+              data-label={s.label}
+              title={`Ajouter ${s.terminal} — via ${s.commodity}, +${p.fmt(s.margin)} marge/SCU`}
+              key={s.label}
+            >
+              {`+ ${s.terminal} `}
+              <span className="muted">{`+${p.fmt(s.margin)}`}</span>
+            </button>
+          ))}
+        </div>
+      ) : (
+        <div className="journey-suggest-empty muted">
+          Aucune destination rentable depuis ici — ajoute quand même un arrêt au champ ci-dessus (il aura un manifeste vide, à remplir à la main).
+        </div>
+      )}
+      <div className="journey-meta">
+        {`${n} saut${n > 1 ? "s" : ""} · marge cumulée `}
+        <b className="profit">{p.fmt(p.margeCumulee)}</b>
+        {" aUEC/SCU"}
+      </div>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Le récap (colonne de gauche, sous le vaisseau) : remplit l'espace avec des KPIs utiles.
+// ---------------------------------------------------------------------------------------------
+export type ProprietesRecap = {
+  n: number;
+  totalProfit: number;
+  totalScu: number;
+  totalFees: number;
+  systems: number;
+  materials: number;
+  marchePret: boolean;
+  fmt: Fmt;
+  signe: (n: number, texte: string) => string;
+};
+
+const Kpi = ({ v, lbl }: { v: string | number; lbl: string }) => (
+  <div className="recap-kpi">
+    <b>{v}</b>
+    <span>{lbl}</span>
+  </div>
+);
+
+export function RecapVoyage(p: ProprietesRecap) {
+  return (
+    <>
+      <div className="recap-head">◈ Résumé du voyage</div>
+      <div
+        className={"recap-profit " + classeProfit(p.totalProfit)}
+        title={p.totalFees > 0 ? `Frais d'autoload ≈ ${p.fmt(p.totalFees)} aUEC déjà déduits — estimation (±3 %)` : undefined}
+      >
+        {p.marchePret ? p.signe(p.totalProfit, (p.totalFees > 0 ? "≈ " : "") + p.fmt(p.totalProfit)) : "…"}
+        {" "}
+        <span>aUEC</span>
+      </div>
+      <div className="recap-kpis">
+        <Kpi v={p.n} lbl={"saut" + (p.n > 1 ? "s" : "")} />
+        <Kpi v={p.marchePret ? p.fmt(p.totalScu) : "…"} lbl="SCU" />
+        <Kpi v={p.systems} lbl={"système" + (p.systems > 1 ? "s" : "")} />
+        <Kpi v={p.marchePret ? p.materials : "…"} lbl={"matériau" + (p.materials > 1 ? "x" : "")} />
+      </div>
+    </>
+  );
+}
+
+export const carteVoyage = (p: ProprietesVoyage) => <CarteVoyage {...p} />;
+export const recapVoyage = (p: ProprietesRecap) => <RecapVoyage {...p} />;


### PR DESCRIPTION
## Ce que ça change

Le **compagnon de voyage** (`#journeyCard`) et son **récap** (`#journeyRecap`) sont rendus par
React. C'est la dernière vue de la migration. Rien ne bouge à l'écran, à une exception voulue :

**Correctif** — le marqueur de dépassement du stock UEX (`over-stock`) sur un champ SCU de jambe
survit désormais à un rafraîchissement. Il disparaissait au premier rendu venu d'ailleurs, en
laissant la quantité absurde **non signalée**.

Closes #122

## Pourquoi

Onzième et dernier lot de vue de #96 (ADR-008). C'était le plus couplé du dépôt : six globales
(dont `JOURNEY`, 33 références) et un rendu qui déclenche celui de trois autres cartes. Rien de tout
ça ne bouge — `renderJourney` calcule et orchestre, l'îlot ne reçoit que le résultat.

**Trois choses valent d'être dites, toutes trouvées en mesurant :**

1. **Les quatre rendus de ce chemin sont SYNCHRONES.** `ajusterRangeeVoyage()` *mesure* les hauteurs
   (`getBoundingClientRect`) juste après, pour décider d'empiler les colonnes. Avec un rendu React
   groupé, elle lisait le DOM **avant peinture** : la carte passait de 1172 px à 640 px de large, et
   la bascule s'inversait à l'état suivant. L'ancien `innerHTML` était synchrone, on le reste.
2. **Les suggestions d'une jambe sont rendues dans l'arbre**, et `renderLegSuggestions` disparaît.
   Ce conteneur peint à part n'existait que parce que la carte, écrite en `innerHTML`, le détruisait
   à chaque rendu. Un conteneur peint à part **dans** une carte possédée par React, c'est
   exactement le piège de #120.
3. **`liveLegQty` ne mute plus le DOM.** Elle s'interdisait tout re-rendu — « un `renderJourney()` à
   chaque frappe ferait perdre le focus » — et écrivait donc `.jman-profit` et `over-stock` à la
   main. Vrai d'un `innerHTML`, faux d'un rendu React, qui garde le nœud et n'écrit pas dans un
   champ non contrôlé. Une `generation` figée (`renderJourney({frappe: true})`) empêche la valeur
   calculée de reprendre la main sous les doigts — même mécanique qu'au manifeste (#117).

**Cause racine du correctif** : `over-stock` n'était posée que par les gestionnaires de saisie
(`liveLegQty`, et `updateManifestTotals` avant #117), jamais au rendu — la ligne s'écrivait
`class="jman-qty"` sans condition. Le commentaire du code disait pourtant l'intention : « on ne
plafonne plus à `cap`, on le signale visuellement **pour que ce soit un choix conscient** ». Dérivée
de l'état, la classe tient.

## Vérification

Le test de #122 a été vu **rouge** contre le build de `v2/main` (68f5daa), dans un worktree séparé :

```
$ npx playwright test e2e/smoke.pw.mjs -g "marqueur SURVIT"     # sur v2/main
    Error: le marqueur a disparu au rafraîchissement — la quantité absurde n'est plus signalée
    expect(locator).toHaveClass(expected) failed
    Expected pattern: /over-stock/
    Received string:  "jman-qty"
  1 failed
```

et vert ici :

```
$ npx playwright test e2e/smoke.pw.mjs -g "marqueur SURVIT"
  1 passed (2.2s)

$ npm test
ℹ tests 483
ℹ pass 483
ℹ fail 0

$ npx playwright test
  209 passed (1.4m)
  2 skipped

$ npx tsc --noEmit
(0 erreur)
```

Sonde manuelle, avant / après :

```
AVANT   après frappe : [{"v":"99999","over":true}]   après refresh : [{"v":"99999","over":false}]
APRÈS   après frappe : [{"v":"99999","over":true}]   après refresh : [{"v":"99999","over":true}]
```

**Relevé des styles calculés**, `v2/main` contre cette branche, cinq états, mesures coup sur coup :

```
== invite         == comparées   7 / identiques   7 / différentes 0 / DISPARUES 0 / APPARUES 0
== voyage         == comparées  47 / identiques  47 / différentes 0 / DISPARUES 0 / APPARUES 0
== recap          == comparées  17 / identiques  17 / différentes 0 / DISPARUES 0 / APPARUES 0
== jambe-depliee  == comparées  83 / identiques  83 / différentes 0 / DISPARUES 0 / APPARUES 0
== jambe-chargee  == comparées  84 / identiques  82 / différentes 2 / DISPARUES 1 / APPARUES 1
```

Les 4 formes de `jambe-chargee` sont **le correctif de #122 et lui seul** : un champ gagne
`over-stock`, ce qui décale les rangs des trois `input.jman-qty` — d'où deux « valeurs différentes »
et le couple disparue/apparue. Avant le passage aux rendus synchrones, ce même relevé donnait
**48 écarts** ; ils ont tous disparu avec le point 1.

## Ce qui n'est pas couvert

- **La carte SVG du parcours** (`#journeyMap`, `journeyMapHTML`) reste impérative. Elle est
  autonome et n'émet que du SVG ; c'est un lot à part.
- **`renderDeclaration` (`#holdDeclare`)** reste impérative, avec son garde
  `if (!force && box.contains(document.activeElement)) return`. Même raisonnement que les champs non
  contrôlés, sa propre PR.
- Les tableaux indexés par rang (`shownRoutes`, `shownEnroute`, `shownLoops`, `shownMulti`) que les
  délégations `document` lisent via `data-row` restent dans `app.js` : c'est le préalable à sa
  suppression, pas ce lot-ci.
- Le relevé porte sur cinq états. Un voyage à **plusieurs jambes**, une jambe **figée** (🔒) et le
  cas **« aucun fret rentable »** ne sont pas mesurés — ils restent couverts par la suite e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
