### PR TITLE
feat(carte): la carte du parcours passe en React

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,6 +37,7 @@ import { vueTrajets, vueTrajetsMulti } from "./vues/trajets.tsx";
 import { carteManifeste, indiceSouteInactive, indiceSoutePleine, indiceAucunChargement } from "./vues/manifeste.tsx";
 import { carteSoute, carteEntrepots } from "./vues/soute.tsx";
 import { carteVoyage, recapVoyage, inviteVoyage } from "./vues/voyage.tsx";
+import { carteParcours } from "./vues/carte.tsx";
 import { KIND_ICON } from "./vues/communs.tsx";
 
 // Libellé compact des caisses SCU standard, ex. « 8×32 · 1×16 · 1×4 · 1×2 · 1×1 ».
@@ -1616,78 +1617,18 @@ function renderSoute(synchrone = false) {
 }
 
 // ---------- Carte 2D du parcours (ADR-001) ----------
-// Le calcul est PUR (journeyMap, logic.mjs) : ici on n'émet que du SVG. Aucun asset, aucune image.
-
-// Semis d'étoiles déterministe (générateur congruentiel) : même ciel à chaque rendu, donc aucun
-// scintillement quand la carte se redessine — et statique, décision de l'ADR : rien ne doit bouger
-// en périphérie de tableaux qu'on lit.
-function etoilesHTML(n, w, h) {
-  let s = 20260812, out = "";
-  const suivant = () => ((s = (s * 1103515245 + 12345) % 2147483648) / 2147483648);
-  for (let i = 0; i < n; i++) {
-    const x = (suivant() * w).toFixed(1), y = (suivant() * h).toFixed(1), o = (0.12 + suivant() * 0.45).toFixed(2);
-    out += `<circle cx="${x}" cy="${y}" r="${suivant() > 0.9 ? 0.9 : 0.5}" fill="#dfe6f5" opacity="${o}"/>`;
-  }
-  return out;
-}
-
-const SYS_TEINTE = { Stanton: "var(--stanton)", Pyro: "var(--pyro)", Nyx: "var(--nyx)" };
-const teinte = (nom) => SYS_TEINTE[nom] || "var(--acc)";
-
-function journeyMapHTML(c) {
-  const nf = (v) => Number(v).toFixed(1);
-  let svg = `<rect width="${c.largeur}" height="${c.hauteur}" fill="#080b14"/>${etoilesHTML(70, c.largeur, c.hauteur)}`;
-
-  for (const sys of c.systemes) {
-    const t = teinte(sys.nom);
-    svg += `<g class="jm-sys"><circle cx="${nf(sys.cx)}" cy="${nf(sys.cy)}" r="${nf(sys.r * 1.1)}" fill="none" stroke="${t}" stroke-opacity="0.13" stroke-dasharray="2 5"/>`;
-    for (const b of sys.corps) {
-      svg += `<circle cx="${nf(sys.cx)}" cy="${nf(sys.cy)}" r="${nf(b.orbite)}" fill="none" stroke="${t}" stroke-opacity="0.15"/>`;
-      svg += `<circle cx="${nf(b.x)}" cy="${nf(b.y)}" r="3.2" fill="${t}" fill-opacity="0.85"/>`;
-      // Le libellé du corps s'efface quand une escale s'y pose : son nom est déjà écrit là.
-      if (!b.occupe) svg += `<text class="jm-corps" x="${nf(b.x + 6)}" y="${nf(b.y + 3)}">${esc(b.nom)}</text>`;
-    }
-    svg += `<circle cx="${nf(sys.cx)}" cy="${nf(sys.cy)}" r="6.5" fill="${t}" fill-opacity="0.18"/>`;
-    svg += `<circle cx="${nf(sys.cx)}" cy="${nf(sys.cy)}" r="3" fill="${t}"/>`;
-    svg += `<text class="jm-sysnom" x="${nf(sys.cx)}" y="${nf(Math.max(13, sys.cy - sys.r * 1.22))}" fill="${t}">${esc(sys.nom.toUpperCase())}</text></g>`;
-  }
-
-  for (const j of c.jambes) {
-    // Arc plutôt que segment : la courbure suit le sens du trajet, donc l'aller et le retour d'un
-    // même couple ne se superposent plus. Le chevron dit dans quel sens on va.
-    const d = `M${nf(j.x1)} ${nf(j.y1)} Q${nf(j.cx)} ${nf(j.cy)} ${nf(j.x2)} ${nf(j.y2)}`;
-    svg += j.saut
-      ? `<path class="jm-saut" d="${d}"/>` +
-        `<circle class="jm-saut-noeud" cx="${nf(j.fleche.x)}" cy="${nf(j.fleche.y)}" r="7"/>` +
-        `<text class="jm-saut-glyphe" x="${nf(j.fleche.x)}" y="${nf(j.fleche.y + 3)}">⚡</text>`
-      : `<path class="jm-jambe${j.faite ? " faite" : ""}" d="${d}"/>` +
-        `<path class="jm-sens${j.faite ? " faite" : ""}" d="M-3 -2.6 L2.6 0 L-3 2.6" style="transform: translate(${nf(j.fleche.x)}px, ${nf(j.fleche.y)}px) rotate(${nf(j.fleche.angle)}deg)"/>`;
-  }
-
-  // Les arrêts sont des boutons : cliquer une escale déplace « je suis ici », comme le fil
-  // d'étapes textuel juste au-dessus (décision de l'ADR — un second chemin, pas une nouveauté).
-  c.arrets.forEach((a, i) => {
-    const fait = i < c.vaisseau.arret, ici = i === c.vaisseau.arret;
-    const droite = a.x < c.largeur / 2;
-    svg += `<g class="jm-arret${fait ? " fait" : ""}${ici ? " ici" : ""}" data-i="${i}" role="button" tabindex="0" aria-label="Se placer à ${esc(a.nom)}">` +
-      `<circle class="jm-cible" cx="${nf(a.x)}" cy="${nf(a.y)}" r="11"/>` +
-      `<circle class="jm-point" cx="${nf(a.x)}" cy="${nf(a.y)}" r="4.5"/>` +
-      `<text class="jm-nom" x="${nf(a.x + (droite ? 9 : -9))}" y="${nf(a.y - 9)}" text-anchor="${droite ? "start" : "end"}">${esc(a.nom)}</text></g>`;
-  });
-
-  const v = c.vaisseau;
-  svg += `<g class="jm-vaisseau${v.enVol ? " en-vol" : ""}" style="transform: translate(${nf(v.x)}px, ${nf(v.y)}px) rotate(${nf(v.angle)}deg)">` +
-    `<circle r="10" fill="var(--acc)" fill-opacity="0.12"/><path d="M8 0 L-5 5 L-2.5 0 L-5 -5 Z" fill="var(--acc)" stroke="#140c00" stroke-width="0.5"/></g>`;
-
-  return `<svg class="jm-svg" viewBox="0 0 ${c.largeur} ${c.hauteur}" role="img" aria-label="Carte du parcours : ${esc(c.arrets.map((a) => a.nom).join(", puis "))}">${svg}</svg>`;
-}
+// Le calcul est PUR (journeyMap, logic.ts) et le dessin vit dans `vues/carte.tsx` : ici il ne reste
+// que le branchement à l'état — les globales JOURNEY / MARKET / STARMAP, qu'un îlot ne lit pas.
 
 // Dessine (ou masque) le panneau carte. Appelé par renderJourney, donc à chaque refresh.
 function renderJourneyMap() {
   const box = $("journeyMap");
   if (!box) return;
-  if (!JOURNEY || !MARKET) { box.hidden = true; return; }
-  if (!STARMAP) { ensureStarmap(renderJourneyMap); box.hidden = true; return; }
+  // Masquer NE SUFFIT PAS : le conteneur reste possédé par React, donc on le repeint à vide. Une
+  // branche qui se contenterait de poser `hidden` laisserait le dessin précédent en place, prêt à
+  // réapparaître tel quel — c'est la même règle que pour les messages vides des autres îlots.
+  if (!JOURNEY || !MARKET) { box.hidden = true; peindre(box, null); return; }
+  if (!STARMAP) { ensureStarmap(renderJourneyMap); box.hidden = true; peindre(box, null); return; }
   const info = (nom) => {
     const i = stationMap.get(stationLabel(nom, (journeyStations(JOURNEY).find((s) => s.name === nom) || {}).system || ""));
     return i == null ? null : MARKET.terminals[i];
@@ -1696,9 +1637,9 @@ function renderJourneyMap() {
   const legCourante = JOURNEY.legs[JOURNEY.current];
   const enVol = !!legCourante && jambeChargee(legCourante, JOURNEY.current);
   const c = journeyMap(journeyStations(JOURNEY), JOURNEY.current, STARMAP, info, enVol);
-  if (!c) { box.hidden = true; return; }
+  if (!c) { box.hidden = true; peindre(box, null); return; }
   box.hidden = false;
-  box.innerHTML = `<span class="jm-label">◈ <b>Carte du parcours</b> <span class="muted">schéma — rayons compressés</span></span>${journeyMapHTML(c)}`;
+  peindre(box, carteParcours(c));
 }
 
 // ---------- Compagnon de voyage : résumé du parcours (près du vaisseau) ----------

--- a/e2e/plan.pw.mjs
+++ b/e2e/plan.pw.mjs
@@ -228,6 +228,75 @@ test("Plan de vol : la carte garde ses écouteurs directs après un re-rendu (#6
   await expect(arrets.nth(1)).toHaveClass(/ici/);
 });
 
+// Les trois tests qui suivent gardent ce que la carte a de VÉRIFIABLE et que rien ne regardait :
+// son ciel, son bandeau et les libellés qu'elle efface. Ce sont les endroits par où un rendu
+// reconstruit dérive en silence — les assertions existantes comptent des formes et lisent des `d`,
+// aucune ne verrait un ciel qui bouge ni une espace perdue.
+
+test("Plan de vol : la carte se redessine à l'IDENTIQUE — le ciel ne scintille pas (#61)", async ({ page }) => {
+  // Le semis est déterministe PAR CONSTRUCTION (générateur congruentiel à graine fixe) et le code
+  // en fait une promesse explicite : « même ciel à chaque rendu, donc aucun scintillement ». La
+  // carte se redessine à CHAQUE refresh() : la promesse est tenue par la graine, et par rien
+  // d'autre. Une graine qui deviendrait dépendante du rendu ferait clignoter 70 étoiles sous les
+  // yeux du lecteur, avec toute la suite au vert.
+  await voyageSimple(page);
+  await page.click("#viewPlan");
+  await expect(page.locator("#journeyMap .jm-svg")).toBeVisible({ timeout: 10_000 });
+
+  const ciel = () =>
+    page.locator('#journeyMap .jm-svg > circle[fill="#dfe6f5"]').evaluateAll((els) =>
+      els.map((e) => ["cx", "cy", "r", "opacity"].map((a) => e.getAttribute(a)).join(",")));
+
+  const avant = await ciel();
+  expect(avant).toHaveLength(70);
+
+  // Trois occasions de redessiner : on quitte la vue, on y revient, et on déplace « je suis ici ».
+  await page.click("#viewRoutes");
+  await page.click("#viewPlan");
+  await page.locator("#journeyMap .jm-arret").nth(1).locator(".jm-cible").click();
+  await expect(page.locator("#journeyMap .jm-arret").nth(1)).toHaveClass(/ici/);
+
+  expect(await ciel()).toEqual(avant);
+});
+
+test("Plan de vol : le bandeau de la carte garde ses espaces et ses trois parties (#61)", async ({ page }) => {
+  // Les espaces y sont SIGNIFIANTES : « ◈ » puis le titre en gras, puis la glose en gris. Un
+  // gabarit redécoupé en plusieurs nœuds de texte les perd (piège mesuré en #111 et #116), et le
+  // titre se lirait « ◈Carte du parcoursschéma ». Aucune assertion de comptage ne le voit.
+  await voyageSimple(page);
+  await page.click("#viewPlan");
+  const bandeau = page.locator("#journeyMap .jm-label");
+  await expect(bandeau).toBeVisible({ timeout: 10_000 });
+  await expect(bandeau).toHaveText("◈ Carte du parcours schéma — rayons compressés");
+  await expect(bandeau.locator("b")).toHaveText("Carte du parcours");
+  await expect(bandeau.locator(".muted")).toHaveText("schéma — rayons compressés");
+});
+
+test("Plan de vol : les escales restent des boutons annoncés, et effacent le libellé du corps (#61)", async ({ page }) => {
+  await voyageSimple(page);
+  await page.click("#viewPlan");
+  const arret = page.locator("#journeyMap .jm-arret").first();
+  await expect(arret).toBeVisible({ timeout: 10_000 });
+
+  // La carte est un SECOND chemin vers « je suis ici » (ADR-001) : elle doit s'annoncer comme tel,
+  // sans quoi le clavier n'y accède plus — et c'est le genre d'attribut qu'une réécriture oublie.
+  await expect(arret).toHaveAttribute("role", "button");
+  await expect(arret).toHaveAttribute("tabindex", "0");
+  await expect(arret).toHaveAttribute("aria-label", /^Se placer à \S/);
+  await expect(arret).toHaveAttribute("data-i", "0"); // ce que lisent les écouteurs directs
+  await expect(page.locator("#journeyMap .jm-svg")).toHaveAttribute("aria-label", /^Carte du parcours : \S/);
+
+  // « Le libellé du corps s'efface quand une escale s'y pose : son nom est déjà écrit là. »
+  // Ça se COMPTE, et c'est le seul angle qui morde : un disque par corps, un libellé par corps NON
+  // occupé — et le parcours en occupe forcément au moins un, puisque ses escales s'y posent.
+  // (Comparer les NOMS ne prouve rien : une escale ne porte pas le nom de son corps — « The Golden
+  //  Riviera » se pose sur « Cellin ». Écrite ainsi, l'assertion passait la garde retirée.)
+  const disques = await page.locator('#journeyMap .jm-svg circle[r="3.2"]').count();
+  const libelles = await page.locator("#journeyMap .jm-corps").count();
+  expect(disques).toBeGreaterThan(0);
+  expect(libelles).toBeLessThan(disques);
+});
+
 test("Plan de vol : sans voyage, un état vide utile plutôt qu'une page blanche (#61)", async ({ page }) => {
   await page.click("#viewPlan");
   await expect(page.locator("#plan")).toBeVisible();

--- a/vues/carte.tsx
+++ b/vues/carte.tsx
@@ -1,0 +1,137 @@
+// La carte 2D du parcours (ADR-001), douzième îlot React de la refonte (ADR-008 #96).
+//
+// C'est le premier qui ne soit pas une VUE : `#journeyMap` est un `<aside>` frère de `#planHead` et
+// `#planBody`, pas un conteneur de vue. Il vit là parce qu'un élément à écouteurs DIRECTS se
+// déménage en frère, jamais en enfant d'un conteneur réécrit (leçon de #24, rappelée par l'ADR-004
+// et par l'en-tête de `plan.tsx`).
+//
+// Ces écouteurs — le clic et le clavier sur `.jm-arret` — restent posés par app.js sur `#journeyMap`
+// LUI-MÊME, une seule fois. React ne peint qu'à l'INTÉRIEUR du conteneur : ils survivent donc à
+// chaque rendu sans rien changer, à condition que `data-i`, `role` et `tabindex` restent sur le
+// groupe. Ce n'est pas de la décoration : sans `role="button"`, Playwright ne parvient même plus à
+// cliquer `.jm-cible` (le `.jm-point` concentrique intercepte le pointeur), et le test des
+// écouteurs directs tombe.
+//
+// Le calcul est PUR et vit ailleurs (`journeyMap`, logic.ts) : ici on n'émet que du SVG. Aucun
+// asset, aucune image — la CSP du dépôt n'en voudrait pas.
+import { Fragment } from "react";
+import type { Carte, SystemeCarte } from "../types.ts";
+
+const SYS_TEINTE: Record<string, string> = { Stanton: "var(--stanton)", Pyro: "var(--pyro)", Nyx: "var(--nyx)" };
+const teinte = (nom: string) => SYS_TEINTE[nom] || "var(--acc)";
+
+// Les coordonnées restent des CHAÎNES à une décimale. Passer les nombres bruts à React écrirait
+// `cx="510"` là où le gabarit écrivait `cx="510.0"` : même dessin, mais le relevé attribut par
+// attribut ne pourrait plus servir de preuve d'identité.
+const nf = (v: number) => Number(v).toFixed(1);
+
+// Semis d'étoiles déterministe (générateur congruentiel) : même ciel à chaque rendu, donc aucun
+// scintillement quand la carte se redessine — et statique, décision de l'ADR : rien ne doit bouger
+// en périphérie de tableaux qu'on lit.
+//
+// L'ORDRE DES TIRAGES EST LE MÉCANISME : x, y, o, puis r. Le gabarit calculait `o` avant `r`, et
+// écrire `r={…} opacity={o}` en JSX les inverserait — l'ordre d'évaluation des props est celui de
+// l'écriture. Le ciel entier changerait, silencieusement, dès la deuxième étoile.
+function etoiles(n: number, w: number, h: number) {
+  let s = 20260812;
+  const suivant = () => ((s = (s * 1103515245 + 12345) % 2147483648) / 2147483648);
+  const out = [];
+  for (let i = 0; i < n; i++) {
+    const x = (suivant() * w).toFixed(1), y = (suivant() * h).toFixed(1), o = (0.12 + suivant() * 0.45).toFixed(2);
+    const r = suivant() > 0.9 ? 0.9 : 0.5;
+    out.push(<circle key={i} cx={x} cy={y} r={r} fill="#dfe6f5" opacity={o} />);
+  }
+  return out;
+}
+
+function Systeme({ sys }: { sys: SystemeCarte }) {
+  const t = teinte(sys.nom);
+  return (
+    <g className="jm-sys">
+      <circle cx={nf(sys.cx)} cy={nf(sys.cy)} r={nf(sys.r * 1.1)} fill="none" stroke={t} strokeOpacity="0.13" strokeDasharray="2 5" />
+      {sys.corps.map((b, i) => (
+        <Fragment key={i}>
+          <circle cx={nf(sys.cx)} cy={nf(sys.cy)} r={nf(b.orbite)} fill="none" stroke={t} strokeOpacity="0.15" />
+          <circle cx={nf(b.x)} cy={nf(b.y)} r="3.2" fill={t} fillOpacity="0.85" />
+          {/* Le libellé du corps s'efface quand une escale s'y pose : son nom est déjà écrit là. */}
+          {!b.occupe && <text className="jm-corps" x={nf(b.x + 6)} y={nf(b.y + 3)}>{b.nom}</text>}
+        </Fragment>
+      ))}
+      <circle cx={nf(sys.cx)} cy={nf(sys.cy)} r="6.5" fill={t} fillOpacity="0.18" />
+      <circle cx={nf(sys.cx)} cy={nf(sys.cy)} r="3" fill={t} />
+      <text className="jm-sysnom" x={nf(sys.cx)} y={nf(Math.max(13, sys.cy - sys.r * 1.22))} fill={t}>{sys.nom.toUpperCase()}</text>
+    </g>
+  );
+}
+
+export function carteParcours(c: Carte) {
+  const v = c.vaisseau;
+  return (
+    <>
+      {/* Les espaces y sont SIGNIFIANTES et tiennent en DEUX nœuds de texte, « ◈ » et le blanc qui
+          suit le titre. Les écrire comme littéraux séparés reproduit exactement le gabarit ; les
+          laisser tomber recollerait « ◈Carte du parcoursschéma » (piège n°2, #111 et #116). */}
+      <span className="jm-label">{"◈ "}<b>Carte du parcours</b>{" "}<span className="muted">schéma — rayons compressés</span></span>
+      <svg
+        className="jm-svg"
+        viewBox={`0 0 ${c.largeur} ${c.hauteur}`}
+        role="img"
+        aria-label={`Carte du parcours : ${c.arrets.map((a) => a.nom).join(", puis ")}`}
+      >
+        <rect width={c.largeur} height={c.hauteur} fill="#080b14" />
+        {etoiles(70, c.largeur, c.hauteur)}
+
+        {c.systemes.map((sys, i) => <Systeme key={i} sys={sys} />)}
+
+        {c.jambes.map((j, i) => {
+          // Arc plutôt que segment : la courbure suit le sens du trajet, donc l'aller et le retour
+          // d'un même couple ne se superposent plus. Le chevron dit dans quel sens on va.
+          const d = `M${nf(j.x1)} ${nf(j.y1)} Q${nf(j.cx)} ${nf(j.cy)} ${nf(j.x2)} ${nf(j.y2)}`;
+          return j.saut ? (
+            <Fragment key={i}>
+              <path className="jm-saut" d={d} />
+              <circle className="jm-saut-noeud" cx={nf(j.fleche.x)} cy={nf(j.fleche.y)} r="7" />
+              <text className="jm-saut-glyphe" x={nf(j.fleche.x)} y={nf(j.fleche.y + 3)}>⚡</text>
+            </Fragment>
+          ) : (
+            <Fragment key={i}>
+              <path className={`jm-jambe${j.faite ? " faite" : ""}`} d={d} />
+              <path
+                className={`jm-sens${j.faite ? " faite" : ""}`}
+                d="M-3 -2.6 L2.6 0 L-3 2.6"
+                style={{ transform: `translate(${nf(j.fleche.x)}px, ${nf(j.fleche.y)}px) rotate(${nf(j.fleche.angle)}deg)` }}
+              />
+            </Fragment>
+          );
+        })}
+
+        {/* Les arrêts sont des boutons : cliquer une escale déplace « je suis ici », comme le fil
+            d'étapes textuel juste au-dessus (décision de l'ADR — un second chemin, pas une
+            nouveauté). `data-i` est ce que lisent les deux écouteurs directs d'app.js. */}
+        {c.arrets.map((a, i) => {
+          const fait = i < v.arret, ici = i === v.arret;
+          const droite = a.x < c.largeur / 2;
+          return (
+            <g
+              key={i}
+              className={`jm-arret${fait ? " fait" : ""}${ici ? " ici" : ""}`}
+              data-i={i}
+              role="button"
+              tabIndex={0}
+              aria-label={`Se placer à ${a.nom}`}
+            >
+              <circle className="jm-cible" cx={nf(a.x)} cy={nf(a.y)} r="11" />
+              <circle className="jm-point" cx={nf(a.x)} cy={nf(a.y)} r="4.5" />
+              <text className="jm-nom" x={nf(a.x + (droite ? 9 : -9))} y={nf(a.y - 9)} textAnchor={droite ? "start" : "end"}>{a.nom}</text>
+            </g>
+          );
+        })}
+
+        <g className={`jm-vaisseau${v.enVol ? " en-vol" : ""}`} style={{ transform: `translate(${nf(v.x)}px, ${nf(v.y)}px) rotate(${nf(v.angle)}deg)` }}>
+          <circle r="10" fill="var(--acc)" fillOpacity="0.12" />
+          <path d="M8 0 L-5 5 L-2.5 0 L-5 -5 Z" fill="var(--acc)" stroke="#140c00" strokeWidth="0.5" />
+        </g>
+      </svg>
+    </>
+  );
+}


### PR DESCRIPTION
## Ce que ça change

Rien à l'écran, et c'est le but : la carte 2D du parcours est dessinée par React au lieu d'un
gabarit `innerHTML`. Même ciel, mêmes arcs, mêmes escales cliquables.

## Pourquoi

Douzième îlot de la refonte (#96), et le premier qui ne soit pas une **vue** : `#journeyMap` est un
`<aside>` frère de `#planHead` et `#planBody`. Il le reste — un élément à écouteurs **directs** se
déménage en frère, jamais en enfant d'un conteneur réécrit (leçon de #24, rappelée par l'ADR-004).

app.js garde `hidden`, ses deux écouteurs et la résolution des globales (`JOURNEY`, `MARKET`,
`STARMAP`) ; le dessin part dans `vues/carte.tsx`. Bilan : **-69 lignes pour +10** dans app.js, et
un `innerHTML` de moins (11 → 10).

Trois endroits où la réécriture pouvait dériver **en silence**, et ce qui les tient :

- **L'ordre des tirages** du semis d'étoiles (`x, y, o` puis `r`) est le mécanisme. Écrire
  `r={…} opacity={o}` en JSX l'inverserait — l'ordre d'évaluation des props est celui de l'écriture
  — et le ciel entier changerait dès la deuxième étoile. `r` est donc calculé avant, comme au
  gabarit (`vues/carte.tsx:38`).
- **Les coordonnées restent des chaînes** à une décimale : passer les nombres bruts à React
  écrirait `cx="510"` là où le gabarit écrivait `cx="510.0"`.
- **Le bandeau tient en deux nœuds de texte** — « ◈ » et le blanc après le titre — écrits comme
  littéraux séparés. Recollés, ils donneraient « ◈Carte du parcoursschéma » (piège n°2, #111/#116).

`peindre(box, null)` est ajouté aux **trois** sorties qui masquent : le conteneur appartient
désormais à React, et poser `hidden` seul y laisserait le dessin précédent, prêt à réapparaître.

## Vérification

**`node --test` → 483 tests, 483 pass, 0 fail** (415 ms).

**`npx playwright test` → 209 passed, 2 skipped, 0 failed** (1,2 min ; les 2 `test.skip` sont
conditionnels au jeu de données et préexistants).

**`npx tsc --noEmit` → silencieux.**

**Le relevé du SVG sérialisé, avant/après** — outil de PR écrit pour l'occasion, plus fin que le
relevé des styles calculés, qui ne regarde pas les attributs (`cx`, `cy`, `d`, `opacity`) : il
sérialise chaque descendant de `#journeyMap` par **rang**, attributs **triés**, nœuds de texte
directs joints par un séparateur **visible** (c'est ce qui rend un découpage en plusieurs nœuds
lisible), sur deux scénarios — parcours intra-système et saut inter-système routé par les
passerelles.

Résultat : **146 lignes relevées / 143 strictement identiques** (intra) et **152 / 149** (saut).
Les 3 + 3 écarts sont tous sur l'attribut `style` et tous de **sérialisation CSSOM** — React assigne
`style.transform`, ce qui ajoute un `;` final et normalise `510.0px` en `510px` :

```
< 1/82|g|class=jm-vaisseau;style=transform: translate(216.7px, 190.1px) rotate(-27.4deg)
> 1/82|g|class=jm-vaisseau;style=transform: translate(216.7px, 190.1px) rotate(-27.4deg);
```

Pour trancher entre sérialisation et dessin, le relevé capture aussi le `transform` **calculé** :
les 6 matrices sont identiques au chiffre près, ex.
`matrix(0.887815, -0.4602, 0.4602, 0.887815, 216.7, 190.1)` des deux côtés.

**Trois caractérisations ajoutées avant de toucher au code** (commit `f5f729b`), sur ce que la
suite ne regardait pas — elle compte des formes et lit des `d` :

1. le ciel ne scintille pas d'un rendu à l'autre (le code en fait la promesse, seule la graine la
   tenait) ;
2. le bandeau garde ses espaces significatives ;
3. les escales restent des boutons annoncés (`role`, `tabindex`, `aria-label`, `data-i`) et
   effacent le libellé du corps où elles se posent.

Chacune a été **vue échouer** sur sa mutation propre d'`app.js` — graine rendue variable, espaces
retirées, `role="button"` supprimé, garde `!b.occupe` levée — avant d'être reprise au vert. Une
première version de la troisième comparait les **noms** (escale vs corps) et passait la mutation
sans rien voir : « The Golden Riviera » se pose sur « Cellin », les deux listes ne se croisent
jamais. Elle compte désormais les libellés contre les disques.

Effet de bord découvert au passage : retirer `role="button"` fait aussi tomber le test **existant**
des écouteurs directs — Playwright n'arrive alors plus à cliquer `.jm-cible`, le `.jm-point`
concentrique interceptant le pointeur.

Bundle : 344,40 → 344,80 ko (+0,4 ko), précache à 20 entrées — loin du plafond de coquille.

## Ce qui n'est pas couvert

- Le relevé du SVG est un **outil de PR**, pas un test permanent : il n'est pas commité (comme le
  relevé des styles calculés). Ce qui reste au dépôt, ce sont les trois caractérisations.
- Les deux scénarios relevés ne couvrent pas les états **rares** de la carte : arrêt `orphelin`,
  jambe `faite`, vaisseau `en-vol`. Ces branches sont des ajouts de classe conditionnels,
  transcrits à l'identique, mais aucune mesure ne l'atteste ici.
- `renderJourneyMap` reste dans app.js et lit toujours quatre globales : c'est le branchement à
  l'état, il partira avec les tableaux indexés par rang, pas avant.
- Le semis reste calculé à **chaque** rendu (70 tirages) plutôt que mémoïsé : c'est ce que faisait
  le gabarit, et la PR ne change pas les performances qu'elle n'a pas mesurées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
