### PR TITLE
feat(soute): la carte de déclaration passe en React, et son garde de focus disparaît

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,6 +38,7 @@ import { carteManifeste, indiceSouteInactive, indiceSoutePleine, indiceAucunChar
 import { carteSoute, carteEntrepots } from "./vues/soute.tsx";
 import { carteVoyage, recapVoyage, inviteVoyage } from "./vues/voyage.tsx";
 import { carteParcours } from "./vues/carte.tsx";
+import { carteDeclaration } from "./vues/declaration.tsx";
 import { KIND_ICON } from "./vues/communs.tsx";
 
 // Libellé compact des caisses SCU standard, ex. « 8×32 · 1×16 · 1×4 · 1×2 · 1×1 ».
@@ -1483,50 +1484,31 @@ let ecoulerOuvert = false;
 // Commodités, qui n'ont aucun rapport avec un voyage.
 let declarationOuverte = false;
 
-// `force` : repeindre malgré un champ en cours de saisie. Sans lui, cette carte — rendue à CHAQUE
-// rafraîchissement, donc à chaque frappe ailleurs et à chaque arrivée du marché — détruirait le
-// texte tapé et son focus. Les gestes qui changent VRAIMENT son état (ouvrir, annuler, valider)
-// forcent ; les rendus de passage s'abstiennent.
-function renderDeclaration(force = false) {
+// Le dessin vit dans `vues/declaration.tsx` ; ici il ne reste que le branchement à l'état.
+//
+// LE GARDE DE FOCUS A DISPARU, et avec lui la relecture des valeurs tapées qui le doublait. Les
+// deux existaient parce qu'un `innerHTML` détruit les champs qu'il réécrit : cette carte est rendue
+// à CHAQUE rafraîchissement — donc à chaque frappe ailleurs et à chaque arrivée du marché — et elle
+// effaçait la saisie en cours. Des champs non contrôlés sous une racine mémorisée rendent le
+// repeint inoffensif : React réutilise leur nœud et n'écrit jamais leur valeur.
+//
+// `synchrone` remplace l'ancien `force`, et ne dit plus du tout la même chose : deux appelants
+// MESURENT ou FOCALISENT juste après le rendu et ne peuvent pas attendre le lot de React. Voir
+// `renderSoute` pour le même contrat sur la carte voisine.
+function renderDeclaration(synchrone = false) {
   const box = $("holdDeclare");
   if (!box) return;
-  if (!force && box.contains(document.activeElement)) return;
   box.hidden = false;
-  // « Je suis à » : sans voyage, la position EST le terminal de départ d'« En route » — déjà le
-  // repli de stationCourante(). On ne crée pas un second store, on rend le premier atteignable
-  // d'ici : deux positions divergeraient au premier aller-retour entre les deux vues. Avec un
-  // voyage, l'étape courante la dit déjà, et un champ ici mentirait.
-  const position = !JOURNEY && (SOUTE.length || declarationOuverte)
-    ? `<div class="hold-ici">
-         <label for="holdWhere">◈ Je suis à</label>
-         <input id="holdWhere" list="originList" type="text" autocomplete="off" value="${esc($("origin").value)}"
-           placeholder="Tape un terminal (ex : Megumi — Pyro)"
-           title="D'où tu pars. Ce terminal fixe le prix d'une vente et le classement de « où écouler » — c'est le même que le départ d'« En route »." />
-       </div>`
-    : "";
-  // Les valeurs tapées sont RELUES avant le repeint et réémises, comme le fait déjà `holdWhere`
-  // juste au-dessus. La garde de focus ne suffisait pas : elle protège tant que le curseur est dans
-  // la carte, mais un geste fait AILLEURS — toucher la soute, changer de vue — repeignait des
-  // champs sans `value` et effaçait la saisie en silence, le formulaire restant ouvert et vide.
-  // C'est la classe de bug que ce dépôt a déjà rencontrée deux fois (#24, et le champ #journeyStart
-  // commenté plus bas) : ici on ne se contente pas de ne pas repeindre, on rend le repeint inoffensif.
-  const saisi = (id) => esc($(id)?.value ?? "");
-  const [nomSaisi, scuSaisi, paidSaisi] = ["holdAddName", "holdAddScu", "holdAddPaid"].map(saisi);
-  const corps = declarationOuverte
-    ? `<div class="hold-add">
-         <input id="holdAddName" list="commodityList" type="text" autocomplete="off" value="${nomSaisi}" placeholder="Commodité (nom ou code UEX)" aria-label="Commodité à déclarer" />
-         <input id="holdAddScu" type="number" min="1" step="1" value="${scuSaisi}" placeholder="SCU" aria-label="SCU à bord" />
-         <input id="holdAddPaid" type="number" min="0" step="1" value="${paidSaisi}" placeholder="prix payé /SCU" aria-label="Prix payé au SCU"
-           title="Laisse vide pour du butin : minage, salvage, caisse trouvée — un coût réellement nul." />
-         <button id="holdAddOk" class="hold-sell-ok" title="Ajouter ce lot à la soute">✓ à bord</button>
-         <button id="holdAddNo" class="hold-sell-no" title="Annuler" aria-label="Annuler">✕</button>
-       </div>
-       <p class="hold-add-hint">Prix vide = <b>butin</b>, coût nul : « où écouler » comptera alors tout l'encaissement comme profit.</p>`
-    : `<button id="holdAddOpen" class="hold-add-open" title="Déclarer du fret déjà à bord : butin ramassé, vaisseau rangé plein, cargaison achetée hors de l'app">+ déclarer ce que j'ai à bord</button>`;
-  // L'en-tête n'apparaît QU'à vide : au-dessus d'une carte Soute déjà titrée, un second « ◈ Soute »
-  // ferait lire deux panneaux là où il n'y en a qu'un.
-  const tete = SOUTE.length ? "" : `<div class="hold-head"><span class="hold-title">◈ Soute</span><span class="muted">vide</span></div>`;
-  box.innerHTML = tete + position + corps;
+  peindre(box, carteDeclaration({
+    souteVide: !SOUTE.length,
+    // « Je suis à » : sans voyage, la position EST le terminal de départ d'« En route » — déjà le
+    // repli de stationCourante(). On ne crée pas un second store, on rend le premier atteignable
+    // d'ici : deux positions divergeraient au premier aller-retour entre les deux vues. Avec un
+    // voyage, l'étape courante la dit déjà, et un champ ici mentirait.
+    avecPosition: !JOURNEY && !!(SOUTE.length || declarationOuverte),
+    ouvert: declarationOuverte,
+    origine: $("origin").value,
+  }), { synchrone });
 }
 
 function ouvrirDeclaration() {
@@ -1534,10 +1516,13 @@ function ouvrirDeclaration() {
   // nom saisi. On l'attend plutôt que d'ouvrir un formulaire inerte.
   if (!MARKET) { withMarket(ouvrirDeclaration); return; }
   declarationOuverte = true;
+  // SYNCHRONE, et c'est un contrat : le champ naît avec le formulaire, il n'existe donc pas avant
+  // le rendu. Différé, le `?.` ci-dessous court-circuiterait et le formulaire s'ouvrirait sans
+  // curseur — l'utilisateur taperait dans le vide. Même piège que `.hold-sell-qty` sur la soute.
   renderDeclaration(true);
   $("holdAddName")?.focus();
 }
-function fermerDeclaration() { declarationOuverte = false; renderDeclaration(true); }
+function fermerDeclaration() { declarationOuverte = false; renderDeclaration(); }
 
 // Le geste : cette commodité, ce nombre de SCU, à ce prix. Le prix est FACULTATIF et vaut 0 — du
 // butin n'a rien coûté (ADR-002). Une commodité que le marché ne connaît pas est refusée : l'app ne
@@ -1554,7 +1539,7 @@ function declarerABord() {
   if (SOUTE === avant) return; // la fonction pure a refusé : rien à persister
   saveSoute();
   declarationOuverte = false;
-  renderDeclaration(true);
+  renderDeclaration();
   refresh();
   showToast(`◈ ${fmt(units)} SCU de ${c.name} déclarés à bord — ` +
     (prix > 0 ? `${fmt(prix)} aUEC/SCU payés` : "butin, coût nul"));
@@ -1583,7 +1568,12 @@ function renderSoute(synchrone = false) {
   if (!box) return;
   // AVANT le retour anticipé : le point d'entrée « déclarer », lui, doit exister précisément quand
   // la carte n'existe pas. C'est le seul rendu appelé depuis tous les chemins qui repeignent la soute.
-  renderDeclaration();
+  //
+  // Le drapeau se PROPAGE, et ça n'a rien de décoratif : `ajusterRangeeVoyage` mesure la hauteur de
+  // `#voyageLeft` juste après `renderSoute(true)`, et `#holdDeclare` en est un enfant direct. Rendue
+  // en différé, cette carte ferait mesurer la hauteur du rendu PRÉCÉDENT. `innerHTML` étant
+  // synchrone par nature, la question ne se posait pas — le drapeau n'était donc pas transmis.
+  renderDeclaration(synchrone);
   if (!SOUTE.length) { box.hidden = true; peindre(box, null); return; }
   box.hidden = false;
   // Du fret à bord et pas de graphe : la vue par défaut ne lit que routes.json, et sans marché la

--- a/e2e/declaration.pw.mjs
+++ b/e2e/declaration.pw.mjs
@@ -1,0 +1,129 @@
+import { test, expect } from "@playwright/test";
+
+// La carte de DÉCLARATION de soute (`#holdDeclare`, #55) — « j'ai déjà ça à bord ».
+//
+// Ces tests sont écrits AVANT sa migration en îlot React, et ils gardent ce que la suite ne
+// regardait pas. Vingt-deux tests répartis sur quatre fichiers TRAVERSENT cette carte pour se
+// donner du fret (elle est le seul robinet à soute de la suite), mais presque aucun ne la VISE :
+// rien n'y vérifiait le focus, le clavier, ni la structure conditionnelle du panneau.
+//
+// Ce sont précisément les trois choses qu'un rendu React reconstruit peut casser en silence :
+// le focus dépend d'un rendu SYNCHRONE, le clavier d'une classe que le JSX doit réémettre, et la
+// structure conditionnelle de la façon dont React réconcilie des emplacements qui apparaissent et
+// disparaissent.
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/index.html");
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+});
+
+// Le premier clic sur « déclarer » passe TOUJOURS par `withMarket` (app.js:1535) : la vue par
+// défaut ne charge pas market.json. Le formulaire n'apparaît donc qu'après ce chargement.
+async function ouvrirFormulaire(page) {
+  await page.locator("#holdAddOpen").click();
+  await expect(page.locator("#holdAddName")).toBeVisible({ timeout: 20_000 });
+}
+
+test("Déclaration : ouvrir le formulaire y pose le curseur, sans un geste de plus (#55)", async ({ page }) => {
+  // `ouvrirDeclaration` rend PUIS prend le focus dans la foulée (app.js:1537-1538) : le champ
+  // n'existe pas avant le rendu. Un rendu différé ferait court-circuiter le `?.` et le formulaire
+  // s'ouvrirait curseur nulle part — l'utilisateur tape dans le vide. Aucun test ne le voyait :
+  // `page.fill` focalise lui-même, donc tous les helpers de la suite masquent la panne.
+  await ouvrirFormulaire(page);
+  await expect(page.locator("#holdAddName")).toBeFocused();
+});
+
+test("Déclaration : Entrée valide depuis n'importe quel champ, Échap abandonne (#55)", async ({ page }) => {
+  // La délégation clavier (app.js:3386-3390) se garde par `closest(".hold-add")` : c'est la CLASSE
+  // qui porte le contrat, pas les ids. Un JSX qui la renommerait ferait taire tout le clavier de la
+  // carte sans casser un seul test existant — la moitié de son ergonomie.
+  await ouvrirFormulaire(page);
+  await page.fill("#holdAddName", "Titanium");
+  await page.fill("#holdAddScu", "12");
+  await page.locator("#holdAddScu").press("Enter");
+  await expect(page.locator("#holdCard")).toBeVisible();
+  await expect(page.locator("#holdCard")).toContainText("Titanium");
+  // Validé : le formulaire se referme et le point d'entrée revient.
+  await expect(page.locator("#holdAddOpen")).toBeVisible();
+
+  await ouvrirFormulaire(page);
+  await page.fill("#holdAddName", "Gold");
+  await page.locator("#holdAddName").press("Escape");
+  await expect(page.locator("#holdAddOpen")).toBeVisible();
+  await expect(page.locator("#holdAddName")).toHaveCount(0);
+});
+
+test("Déclaration : les trois blocs apparaissent et disparaissent chacun à sa condition (#55)", async ({ page }) => {
+  // C'est ce que la réconciliation React peut casser : les emplacements ne sont pas tous présents
+  // en même temps, et deux d'entre eux changent de rang selon l'état. `.hold-head` sort quand la
+  // soute se remplit, `.hold-ici` n'existe que HORS voyage — donc l'index d'un bloc ne dit rien de
+  // son identité, et un rendu par liste réutiliserait le mauvais nœud.
+  const tete = page.locator("#holdDeclare .hold-head");
+  const ici = page.locator("#holdDeclare .hold-ici");
+
+  // Soute vide, formulaire fermé : l'en-tête « ◈ Soute vide » est là, « Je suis à » non.
+  await expect(tete).toBeVisible();
+  await expect(tete).toContainText("Soute");
+  await expect(ici).toHaveCount(0);
+
+  // Formulaire ouvert : « Je suis à » apparaît, l'en-tête reste (la soute est toujours vide).
+  await ouvrirFormulaire(page);
+  await expect(ici).toBeVisible();
+  await expect(tete).toBeVisible();
+  await expect(page.locator("#holdDeclare .hold-add-hint")).toBeVisible();
+
+  // Soute remplie : l'en-tête sort — au-dessus d'une carte Soute déjà titrée, un second « ◈ Soute »
+  // ferait lire deux panneaux là où il n'y en a qu'un (app.js:1526-1527).
+  await page.fill("#holdAddName", "Titanium");
+  await page.fill("#holdAddScu", "20");
+  await page.locator("#holdAddOk").click();
+  await expect(page.locator("#holdCard")).toBeVisible();
+  await expect(tete).toHaveCount(0);
+  await expect(ici).toBeVisible();
+
+  // Sous voyage : « Je suis à » sort à son tour — l'étape courante dit déjà où l'on est, et un
+  // champ ici mentirait (app.js:1495-1498).
+  await page.locator("#rows tr").first().locator(".journey-pick").click();
+  await expect(page.locator("#journeyCard .jstep")).toHaveCount(2);
+  await expect(ici).toHaveCount(0);
+});
+
+test("Déclaration : « Je suis à » suit le départ d'« En route », qui est le même champ (#55)", async ({ page }) => {
+  // Le sens JAMAIS testé. `#holdWhere` n'est pas un second store : il RELIT `#origin` à chaque
+  // rendu (app.js:1502). Un champ non contrôlé n'adopterait plus jamais cette valeur recalculée —
+  // c'est exactement le piège payé au manifeste (#117), et ici rien ne l'aurait rattrapé.
+  await ouvrirFormulaire(page);
+  await expect(page.locator("#holdWhere")).toBeVisible();
+
+  await page.click("#viewEnroute");
+  await expect(page.locator("#stationList option").first()).toBeAttached({ timeout: 20_000 });
+  await page.fill("#origin", "Megumi — Pyro");
+  await page.locator("#origin").blur();
+
+  await expect(page.locator("#holdWhere")).toHaveValue("Megumi — Pyro", { timeout: 10_000 });
+});
+
+test("Déclaration : les QUATRE champs survivent à un geste fait ailleurs (#55)", async ({ page }) => {
+  // Élargit smoke.pw.mjs:2895, qui ne couvrait que deux des quatre champs. `#holdAddPaid` et
+  // `#holdWhere` ne sont gardés par rien, alors que ce sont les deux qui changent de mécanisme à la
+  // migration : le premier est un champ libre de plus, le second porte une valeur recalculée.
+  await ouvrirFormulaire(page);
+  await page.fill("#holdAddName", "Titanium");
+  await page.fill("#holdAddScu", "42");
+  await page.fill("#holdAddPaid", "137");
+  await page.fill("#holdWhere", "Megumi — Pyro");
+
+  await page.fill("#cargo", "120"); // un geste ailleurs, qui déclenche un rendu
+  await page.locator("#cargo").blur();
+  await page.waitForTimeout(400);
+
+  await expect(page.locator("#holdAddName")).toHaveValue("Titanium");
+  await expect(page.locator("#holdAddScu")).toHaveValue("42");
+  await expect(page.locator("#holdAddPaid")).toHaveValue("137");
+  await expect(page.locator("#holdWhere")).toHaveValue("Megumi — Pyro");
+
+  await page.click("#viewLoops"); // et un changement de vue
+  await page.click("#viewRoutes");
+  await expect(page.locator("#holdAddPaid")).toHaveValue("137");
+  await expect(page.locator("#holdWhere")).toHaveValue("Megumi — Pyro");
+});

--- a/e2e/injection.pw.mjs
+++ b/e2e/injection.pw.mjs
@@ -113,3 +113,45 @@ test("la même charge venue de market.json (vue En route) reste inerte", async (
   expect(await page.evaluate(() => window.__xss)).toBeUndefined();
   expect(erreurs).toEqual([]);
 });
+
+test("un NOM de terminal hostile reste inerte dans « Je suis à » (carte de déclaration)", async ({ page }) => {
+  // Quatrième surface d'interpolation, et la seule qui recopie un nom de terminal dans un ATTRIBUT
+  // `value=` (app.js:1502) : la charge y referme l'attribut au lieu d'ouvrir une balise. Elle n'a
+  // jamais été couverte — « hold » n'apparaissait pas une seule fois dans ce fichier.
+  const erreurs = [];
+  page.on("pageerror", (e) => erreurs.push(String(e)));
+  await page.route("**/data/market.json", async (route) => {
+    const res = await route.fetch();
+    const market = await res.json();
+    for (const t of market.terminals) t.name += CHARGE;
+    await route.fulfill({ response: res, json: market });
+  });
+  await page.goto("/index.html");
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+
+  // Ouvrir le formulaire fait naître « Je suis à », et charge le marché empoisonné au passage.
+  await page.locator("#holdAddOpen").click();
+  await expect(page.locator("#holdWhere")).toBeVisible({ timeout: 20_000 });
+
+  // Poser la position par le champ de départ d'« En route » : c'est le même champ derrière, et
+  // c'est lui que la carte relit pour réémettre son `value=`.
+  await page.click("#viewEnroute");
+  await expect(page.locator("#originList option").first()).toBeAttached({ timeout: 8000 });
+  const empoisonne = await page.locator("#originList option").first().getAttribute("value");
+  expect(empoisonne, "la charge n'a pas atteint la datalist").toContain("onfocus");
+  await page.fill("#origin", empoisonne);
+  await page.locator("#origin").blur();
+
+  // Non vacuisant : la valeur hostile est bien arrivée jusqu'au champ, en TEXTE et non en balisage.
+  await expect(page.locator("#holdWhere")).toHaveValue(empoisonne, { timeout: 10_000 });
+
+  const attrs = await page.locator("#holdDeclare").evaluate((el) =>
+    [...el.querySelectorAll("*")].flatMap((n) => n.getAttributeNames())
+  );
+  for (const interdit of ["onfocus", "autofocus", "onmouseover", "data-x"]) {
+    expect(attrs, `attribut injecté « ${interdit} » dans #holdDeclare`).not.toContain(interdit);
+  }
+  await page.mouse.move(10, 10);
+  expect(await page.evaluate(() => window.__xss)).toBeUndefined();
+  expect(erreurs).toEqual([]);
+});

--- a/vues/declaration.tsx
+++ b/vues/declaration.tsx
@@ -1,0 +1,134 @@
+// La carte de DÉCLARATION de soute (`#holdDeclare`, #55), treizième îlot React (ADR-008 #96).
+//
+// « J'ai déjà ça à bord » : le seul chemin qui fait entrer du fret sans jambe — butin ramassé,
+// vaisseau rangé plein, cargaison achetée hors de l'app. Carte SÉPARÉE de `#holdCard`, et c'est
+// tout le point : celle-ci se masque dès que la soute est vide, un bouton posé dedans serait
+// invisible au moment exact où il sert.
+//
+// ON REND UN FRAGMENT, PAS UN CONTENEUR. `.hold-declare` (`display:flex; column; gap:9px`,
+// style.css:697) et `.hold-card` sont posées sur `#holdDeclare` lui-même (index.html:226) : un
+// `<div>` d'enrobage ramènerait la carte à UN seul enfant et le `gap` disparaîtrait.
+//
+// LES QUATRE EMPLACEMENTS SONT FIXES, `null` pour l'absent. Ce n'est pas du style : les blocs
+// n'apparaissent pas tous en même temps et changent de RANG selon l'état — `.hold-head` sort quand
+// la soute se remplit, `.hold-ici` glisse alors de l'index 1 à l'index 0. Rendus par une liste,
+// React verrait `div` contre `div`, RÉUTILISERAIT le nœud et le rapiècerait : le champ « Je suis à »
+// serait reconstruit à partir de l'ancien en-tête. Des emplacements fixes rendent la question sans
+// objet, chacun se réconciliant avec lui-même.
+import { useEffect, useRef } from "react";
+
+export type PropsDeclaration = {
+  /** L'en-tête « ◈ Soute vide » n'apparaît QU'à vide : au-dessus d'une carte Soute déjà titrée, un
+   *  second « ◈ Soute » ferait lire deux panneaux là où il n'y en a qu'un. */
+  souteVide: boolean;
+  /** « Je suis à » n'a de sens que HORS voyage : avec un parcours, l'étape courante dit déjà où
+   *  l'on est, et un champ ici mentirait. */
+  avecPosition: boolean;
+  /** Le formulaire est déplié (`declarationOuverte` d'app.js). */
+  ouvert: boolean;
+  /** La valeur de `#origin`, le champ de départ d'« En route ». Voir `ChampPosition`. */
+  origine: string;
+};
+
+// « Je suis à » n'est pas un second magasin : c'est une SECONDE ENTRÉE de `#origin`, dans les deux
+// sens. La frappe y écrit (délégation `input` d'app.js → `poserPosition`), et le champ relit
+// `#origin` à chaque rendu — qui a quatre autres écrivains, dont le permalien et le déplacement du
+// voyage. Deux positions divergeraient au premier aller-retour entre les vues.
+//
+// D'où un champ NON CONTRÔLÉ recopié à la main : `defaultValue` seul le figerait au montage et le
+// sens `#origin` → ici se perdrait (c'est le piège payé au manifeste, #117). Et le passer en
+// `value=` sans `onChange` le gèlerait pour de bon, React restaurant la valeur de la prop au premier
+// changement.
+//
+// La garde reproduit celle d'`app.js` À L'IDENTIQUE, mais rétrécie d'une carte à un champ : tant
+// qu'une saisie est en cours QUELQUE PART dans la carte, on ne réécrit rien. Écrite sur le seul
+// champ (`activeElement !== input`), elle écraserait un texte tapé ici puis abandonné pour un autre
+// champ, avant que le débounce de 150 ms n'ait propagé la frappe vers `#origin`.
+function ChampPosition({ origine }: { origine: string }) {
+  const champ = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    const el = champ.current;
+    if (!el) return;
+    const carte = el.closest("#holdDeclare");
+    if (carte && carte.contains(document.activeElement)) return;
+    if (el.value !== origine) el.value = origine;
+  });
+  return (
+    <div className="hold-ici">
+      <label htmlFor="holdWhere">◈ Je suis à</label>
+      <input
+        ref={champ}
+        id="holdWhere"
+        list="originList"
+        type="text"
+        autoComplete="off"
+        defaultValue={origine}
+        placeholder="Tape un terminal (ex : Megumi — Pyro)"
+        title="D'où tu pars. Ce terminal fixe le prix d'une vente et le classement de « où écouler » — c'est le même que le départ d'« En route »."
+      />
+    </div>
+  );
+}
+
+// Les trois champs sont NON CONTRÔLÉS et n'ont même pas de `defaultValue` : la racine React est
+// mémorisée par conteneur (pont.js), donc React réutilise leur nœud DOM d'un rendu à l'autre et
+// n'écrit jamais leur valeur. La frappe survit nativement — c'est ce qui rend inutiles, d'un coup,
+// la garde de focus d'`app.js` ET la relecture/réémission des valeurs avant repeint. Refermer le
+// formulaire démonte les nœuds : rouvrir redonne des champs vides, comme avant.
+//
+// Leurs ids portent aussi la LARGEUR (`#holdAddName{flex:1 1 130px}`, `#holdAddScu{flex:0 0 62px}`,
+// `#holdAddPaid{flex:0 0 96px}`, style.css:706-708) et `declarerABord` les lit dans le DOM SANS `?.`
+// — un id renommé lèverait et le lot n'entrerait jamais en soute. La classe `.hold-add` est le
+// contrat de la délégation clavier, qui se garde par `closest(".hold-add")`.
+function Formulaire() {
+  return (
+    <div className="hold-add">
+      <input id="holdAddName" list="commodityList" type="text" autoComplete="off" placeholder="Commodité (nom ou code UEX)" aria-label="Commodité à déclarer" />
+      <input id="holdAddScu" type="number" min="1" step="1" placeholder="SCU" aria-label="SCU à bord" />
+      <input
+        id="holdAddPaid"
+        type="number"
+        min="0"
+        step="1"
+        placeholder="prix payé /SCU"
+        aria-label="Prix payé au SCU"
+        title="Laisse vide pour du butin : minage, salvage, caisse trouvée — un coût réellement nul."
+      />
+      <button id="holdAddOk" className="hold-sell-ok" title="Ajouter ce lot à la soute">✓ à bord</button>
+      <button id="holdAddNo" className="hold-sell-no" title="Annuler" aria-label="Annuler">✕</button>
+    </div>
+  );
+}
+
+export function carteDeclaration(p: PropsDeclaration) {
+  return (
+    <>
+      {p.souteVide ? (
+        <div className="hold-head">
+          <span className="hold-title">◈ Soute</span>
+          <span className="muted">vide</span>
+        </div>
+      ) : null}
+
+      {p.avecPosition ? <ChampPosition origine={p.origine} /> : null}
+
+      {p.ouvert ? (
+        <Formulaire />
+      ) : (
+        <button
+          id="holdAddOpen"
+          className="hold-add-open"
+          title="Déclarer du fret déjà à bord : butin ramassé, vaisseau rangé plein, cargaison achetée hors de l'app"
+        >
+          + déclarer ce que j'ai à bord
+        </button>
+      )}
+
+      {/* Frère de `.hold-add`, jamais son enfant : dans un conteneur `flex-wrap` il passerait pour
+          un sixième contrôle. */}
+      {p.ouvert ? (
+        <p className="hold-add-hint">Prix vide = <b>butin</b>, coût nul : « où écouler » comptera alors tout l'encaissement comme profit.</p>
+      ) : null}
+    </>
+  );
+}


### PR DESCRIPTION
## Ce que ça change

Rien à l'écran. La carte « j'ai déjà ça à bord » (`#holdDeclare`) est dessinée par React au lieu
d'un gabarit `innerHTML` — et elle cesse d'avoir besoin de se protéger d'elle-même.

## Pourquoi

Treizième îlot de la refonte (#96). Cette carte portait **deux** protections contre son propre
rendu, parce qu'un `innerHTML` détruit les champs qu'il réécrit et qu'elle est repeinte à **chaque**
rafraîchissement — donc à chaque frappe faite ailleurs et à chaque arrivée du marché :

1. un garde de focus, `if (!force && box.contains(document.activeElement)) return` ;
2. et, parce qu'il ne suffisait pas (un geste fait **ailleurs** repeignait des champs sans `value`),
   une relecture-réémission des valeurs tapées avant chaque repeint.

Des champs **non contrôlés** sous une racine mémorisée (`pont.js`) rendent le repeint inoffensif :
React réutilise leur nœud DOM et n'écrit jamais leur valeur. Les deux protections partent. Un
`innerHTML` de moins dans app.js (10 → 9), `-44 / +34` lignes.

### Ce qui reste, et pourquoi

- **Quatre emplacements fixes**, `null` pour l'absent. Les blocs changent de **rang** selon l'état :
  `.hold-head` sort quand la soute se remplit, et `.hold-ici` glisse alors de l'index 1 à l'index 0.
  Rendus par une liste, React verrait `div` contre `div`, réutiliserait le nœud et le rapiècerait —
  « Je suis à » serait reconstruit à partir de l'ancien en-tête.
- **`#holdWhere` garde son garde, rétréci d'une carte à un champ.** Ce n'est pas un second magasin :
  il **relit** `#origin` à chaque rendu, et `#origin` a quatre autres écrivains (frappe directe,
  `syncViewsToJourney`, `applyState`, `poserPosition`). Un `defaultValue` seul le figerait au montage
  — exactement le piège payé au manifeste (#117) — et un `value=` sans `onChange` le gèlerait pour de
  bon. D'où une recopie par `ref`, sautée tant qu'une saisie est en cours **dans la carte** (et non
  seulement dans le champ : sinon un texte tapé ici puis abandonné pour un autre champ serait écrasé
  avant que le débounce de 150 ms n'ait propagé la frappe).
- **Les ids et la classe `.hold-add`.** `declarerABord` lit les trois champs **sans `?.`** — un id
  renommé lèverait et le lot n'entrerait jamais en soute. La délégation clavier se garde par
  `closest(".hold-add")`. Et les trois ids portent aussi la largeur (`style.css:706-708`).

### Le quatrième appelant, qui manquait

`renderSoute` appelait `renderDeclaration()` **nu** : son drapeau `synchrone` n'était pas transmis.
Or `app.js:2120-2123` écrit déjà le contrat — « SYNCHRONES, les quatre : `ajusterRangeeVoyage`
**MESURE** les hauteurs juste en dessous » — et `#holdDeclare` est un enfant **direct** de
`#voyageLeft`, l'une des deux hauteurs mesurées. Cette carte était la seule de la rangée à échapper
au contrat, sans que ça se voie : `innerHTML` est synchrone par nature. Le drapeau se propage
désormais, et `force` devient `synchrone`.

## Vérification

**`node --test` → 483 tests, 483 pass, 0 fail.**
**`npx playwright test` → 219 passed, 2 skipped, 0 failed** (1,3 min ; les 2 `skip` sont
conditionnels au jeu de données et préexistants).
**`npx tsc --noEmit` → silencieux.**

**Six caractérisations écrites AVANT de toucher au code** (commit `e830f34`). Vingt-deux tests
répartis sur quatre fichiers **traversent** cette carte pour se donner du fret — elle est le seul
robinet à soute de la suite — mais presque aucun ne la **visait** :

| ce qui n'était gardé par rien | mutation qui l'a fait échouer |
|---|---|
| le focus après ouverture | `$("holdAddName")?.focus()` retiré |
| Entrée valide / Échap abandonne | classe `.hold-add` renommée |
| les trois blocs conditionnels | garde `SOUTE.length` levée |
| `#origin` → `#holdWhere` | `value=""` figé |
| la survie des **quatre** champs | relecture des saisies neutralisée |
| l'injection dans `value=` | `esc()` retiré |

Aucune n'a été écrite sans l'avoir vue rouge d'abord. Détail utile : `#holdWhere` est la seule
surface du dépôt qui recopie un nom de terminal tiers dans un **attribut** `value=`, et « hold »
n'apparaissait pas une seule fois dans `injection.pw.mjs`.

**Relevé DOM avant/après**, sur les cinq états de la carte (soute vide ; formulaire ouvert ; saisie
en cours après un rendu déclenché ailleurs ; soute remplie ; sous voyage) — attributs triés, nœuds
de texte directs, **et la valeur-propriété de chaque champ**, sans quoi le relevé ne verrait pas
qu'une saisie a été perdue :

**50 lignes relevées, 39 strictement identiques.** Les 11 écarts sont de deux familles, toutes deux
attendues :

- **5** nœuds de texte **blancs seuls** (l'indentation du gabarit), dans `.hold-ici` et `.hold-add`
  qui sont l'un et l'autre `display: flex` — un texte blanc n'y est pas un item, donc aucun effet de
  mise en page ;
- **6** attributs `value=` disparus sur les trois champs devenus non contrôlés. La **propriété**
  `value`, elle, est identique des deux côtés — y compris à l'état « saisie en cours » :
  `Titanium` / `20` / `137` avant comme après. C'est précisément ce que le lot devait préserver.

`#holdWhere` est identique au caractère près, attribut `value=` compris.

## Ce qui n'est pas couvert

- **Le contrat de mesure (`ajusterRangeeVoyage`) est honoré par construction, pas par un test.**
  Mesuré plutôt que supposé : le formulaire n'ajoute que **36 px** à `#voyageLeft`, pour un seuil de
  **140 px** et un écart courant de **−12 px**. La bascule `stacked` n'est donc pas atteignable par
  ce levier dans un état réaliste, et un test l'y forçant serait instable avant d'être utile.
  `grep stacked e2e/` ne rend toujours rien — c'est un trou antérieur à cette PR.
- Le **coût** du rendu synchrone supplémentaire n'est pas mesuré. Il s'ajoute à trois rendus
  synchrones déjà faits au même endroit (`renderJourneyCard`, `renderSoute`, `renderEntrepots`) sur
  la plus petite carte des quatre, mais aucun chiffre ne l'atteste.
- Le relevé DOM est un **outil de PR**, non commité. Ce qui reste au dépôt, ce sont les six
  caractérisations.
- `renderDeclaration` reste dans app.js et lit trois globales : c'est le branchement à l'état.

## Trouvé en chemin, hors périmètre

L'audit de cette zone a mis au jour un bug **vivant** et sans rapport avec cette PR, ouvert en
**#125** : en mode multi-commodité, le dépliant 📦 reste accroché sous un **autre trajet** après un
tri, et devient indéracinable en repassant en lignes simples. Cause racine : `app.js:3352` écrit
dans `#rows`, racine React, par `insertAdjacentHTML` — qu'un `grep innerHTML` ne trouve pas. Il sera
corrigé avec le lot des tableaux indexés par rang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
