### PR TITLE
fix(carte): le dépliant du mode multi suit sa ligne au lieu de mentir

### DIFF
--- a/app.js
+++ b/app.js
@@ -110,19 +110,9 @@ function outpostTag(isOutpost) {
   return isOutpost ? ' <span class="outpost" title="Avant-poste : élévateur de fret parfois en panne">⚠ avant-poste</span>' : "";
 }
 
-// Icône emoji par catégorie de commodité (repère visuel). La table vit désormais dans
-// vues/communs.tsx, importée en tête : une seule source, sans quoi les deux copies divergeraient
-// sans qu'aucun test ne le voie.
-function commodityIcon(kind) {
-  const k = kind || "other";
-  const emoji = KIND_ICON[k] || KIND_ICON.other;
-  return `<span class="cicon k-${esc(k)}" title="${esc(k)}">${emoji}</span>`;
-}
-
-// Marqueur pour les commodités illégales (risque de scan / zones de sécurité).
-function illegalTag(isIllegal) {
-  return isIllegal ? ' <span class="illegal" title="Commodité illégale : contrebande, risque de scan">⛔ illégal</span>' : "";
-}
+// L'icône de commodité et le marqueur « illégal » sont rendus par `IconeCommodite` et `TagIllegal`
+// (vues/communs.tsx). Leurs versions en chaîne ont disparu avec `multiCargoHTML`, leur dernier
+// appelant. `KIND_ICON` reste importé : la table d'emoji n'a qu'une source.
 
 // ---------- Fiabilité : fraîcheur, statut de stock, aberrations ----------
 // (ageDays/pairAge et les calculs de temps/score viennent de logic.mjs)
@@ -556,6 +546,11 @@ function renderMulti(f) {
     libelleCaisses: (t) => (t.units ? cargoBoxesLabel(t.lines, t.origin.maxBox) : null),
     // Le relevé le plus ANCIEN du chargement : un trajet ne vaut pas mieux que sa ligne la moins sûre.
     releveLePlusAncien: (t) => t.lines.reduce((m, l) => { const u = lineFreshUpdated(l); return m && u ? Math.min(m, u) : m || u; }, 0),
+    // Les deux que le DÉPLIANT réclame. Elles restent ici : la première dépend du contexte de
+    // frais, la seconde du plafond de caisse du terminal d'achat — ni l'un ni l'autre n'est connu
+    // de l'îlot.
+    texteProfitLigne: lineProfitText,
+    libelleCaissesScu: scuBoxesLabel,
   }));
   empty.hidden = trips.length > 0;
   // Rappel : seuls les chargements COMBINÉS (≥ 2 commodités) sont listés ici — un trajet dont le
@@ -568,19 +563,9 @@ function renderMulti(f) {
   notifySuperseded();
 }
 
-// Ligne de tableau d'un trajet multi-commodité (mêmes colonnes que les trajets simples).
-// `multiRowHTML` a été remplacé par vues/trajets.tsx.
-function multiCargoHTML(t) {
-  const lines = t.lines.map((l) =>
-    `<div class="sline">${commodityIcon(l.kind)}` +
-    `<span class="mname">${esc(l.name)}${illegalTag(l.illegal)}</span>` +
-    `<span class="mstock">stock ${fmt(l.stock)} · dem. ${fmtVol(l.demand)}</span>` +
-    `<span class="mprice">${fmt(l.buyPrice)} → ${fmt(l.sellPrice)} · marge ${fmt(l.margin)}</span>` +
-    `<span class="mprofit profit">${lineProfitText(l.units, l, t.fee)}</span>` +
-    `<span class="mboxes" title="Caisses SCU standard à charger">📦 ${fmt(l.units)} SCU · ${scuBoxesLabel(l.units, t.origin.maxBox)}</span></div>`
-  ).join("");
-  return `<div class="multi-cargo"><div class="suggest-head">Chargement — ${t.lines.length} commodité${t.lines.length > 1 ? "s" : ""}, ${fmt(t.units)}/${fmt(t.cargo)} SCU</div>${lines}</div>`;
-}
+// Le chargement déplié d'un trajet multi est rendu par `ChargementDeplie` (vues/trajets.tsx), avec
+// l'état d'ouverture — `multiCargoHTML` y a disparu, et `commodityIcon`/`illegalTag` avec lui : ils
+// n'avaient pas d'autre appelant.
 
 // Ligne de tableau pour une route évaluée (partagée par « Trajets simples » et « En route »).
 // `routeRowHTML` a été remplacé par vues/trajets.tsx, pour `#rows` ET `#enrouteRows`.
@@ -3325,23 +3310,15 @@ async function init() {
     if (e.target.id === "manifestAddInput" && e.key === "Enter") { e.preventDefault(); addManifestCommodity(e.target.value); }
   });
   // Chargement d'un trajet multi-commodité : déplie/replie le manifeste sous la ligne cliquée.
-  // Seule table à porter encore un dépliant (#30) — ailleurs la carte 2D du parcours montre la
-  // géographie que le schéma répétait.
-  document.addEventListener("click", (e) => {
-    const btn = e.target.closest(".route-toggle");
-    if (!btn) return;
-    const tr = btn.closest("tr");
-    const next = tr.nextElementSibling;
-    if (next && next.classList.contains("schema-row")) { next.remove(); btn.classList.remove("open"); return; }
-    // Le bouton n'est émis que par les lignes multi. Si la vue n'y est plus au moment du clic
-    // (marché encore en chargement, cf. #25), on ne déplie rien plutôt que d'indexer `shownMulti`
-    // avec le numéro de ligne d'un autre tableau.
-    if (!isMultiRoutes()) return;
-    const item = shownMulti[Number(btn.dataset.row)];
-    if (!item) return;
-    tr.insertAdjacentHTML("afterend", `<tr class="schema-row"><td colspan="${tr.children.length}">${multiCargoHTML(item)}</td></tr>`);
-    btn.classList.add("open");
-  });
+  // Le dépliant (#30) n'a plus de délégation : son ouverture est un ÉTAT de `VueTrajetsMulti`, et
+  // sa ligne un frère rendu par le JSX. Celle qui vivait ici injectait une `<tr>` dans `#rows` par
+  // `insertAdjacentHTML` et posait `open` à la main sur un bouton rendu par React — deux écritures
+  // que React ne voyait pas, donc qui survivaient à ses rendus en devenant fausses (#125).
+  //
+  // La garde `isMultiRoutes()` que cette délégation portait disparaît avec elle — elle existait
+  // parce qu'un bouton cliqué après un retour en lignes simples indexait `shownMulti` avec le rang
+  // d'un autre tableau (#25). Un rappel fermé sur SON trajet ne peut pas se tromper de tableau.
+  // (`isMultiRoutes` reste : `.journey-pick` s'en sert encore, elle indexe toujours par rang.)
   // Carte du parcours : cliquer une escale déplace « je suis ici », comme le fil d'étapes.
   $("holdCard").addEventListener("click", (e) => {
     if (e.target.closest("#holdClear")) { viderSoute(); return; }

--- a/e2e/depliant.pw.mjs
+++ b/e2e/depliant.pw.mjs
@@ -1,0 +1,73 @@
+import { test, expect } from "@playwright/test";
+
+// Le dépliant 📦 du mode multi-commodité (#30), et sa panne #125.
+//
+// Les deux tests existants (smoke.pw.mjs:135, autoload.pw.mjs:195) ouvrent, lisent et referment
+// SANS aucun re-rendu entre les deux : c'est exactement l'angle mort. Le dépliant était injecté
+// dans `#rows` — racine React — par `insertAdjacentHTML`, et React n'en savait rien. Il survivait
+// donc aux rendus en devenant faux.
+
+async function modeMulti(page) {
+  await page.goto("/index.html");
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+  await page.check("#multiCommodity");
+  await expect(page.locator("#rows .route-toggle").first()).toBeVisible({ timeout: 20_000 });
+}
+
+// L'état du dépliant, vu du DOM : sous quelle ligne il pend, et si cette ligne est bien celle dont
+// le bouton est ouvert.
+const etatDepliant = (page) =>
+  page.evaluate(() => {
+    const s = document.querySelector("#rows tr.schema-row");
+    if (!s) return { ouvert: false, orphelin: false };
+    const hote = s.previousElementSibling;
+    const bouton = document.querySelector("#rows .route-toggle.open");
+    return {
+      ouvert: true,
+      orphelin: !bouton,
+      surSonHote: !!bouton && !!hote && hote.contains(bouton),
+      nbHote: (hote?.querySelector(".cname")?.textContent || "").trim(),
+      entete: (s.querySelector(".suggest-head")?.textContent || "").trim(),
+    };
+  });
+
+test("Dépliant : il décrit toujours la ligne sous laquelle il pend, même après un tri (#125)", async ({ page }) => {
+  await modeMulti(page);
+  await page.locator("#rows .route-toggle").first().click();
+  await expect(page.locator("#rows tr.schema-row")).toHaveCount(1);
+
+  const avant = await etatDepliant(page);
+  expect(avant.surSonHote, "le dépliant ne pend pas sous la ligne qu'on vient d'ouvrir").toBe(true);
+  expect(avant.entete).toContain(avant.nbHote); // « Chargement — 3 commodités, … » sous « 3 commodités »
+
+  // Deux clics sur la même colonne inversent le sens du tri (app.js:2463) : le trajet au même rang
+  // change. Avec un dépliant posé à la main dans un tableau que React re-rend, il restait en place
+  // et se mettait à décrire un AUTRE trajet que sa ligne.
+  const colonne = page.locator("th[data-sort]").first();
+  await colonne.click();
+  await page.waitForTimeout(300);
+  await colonne.click();
+  await page.waitForTimeout(600);
+
+  const apres = await etatDepliant(page);
+  if (apres.ouvert) {
+    expect(apres.orphelin, "le dépliant a survécu sans son bouton").toBe(false);
+    expect(apres.surSonHote, "le dépliant pend sous une autre ligne que celle qui est ouverte").toBe(true);
+    expect(apres.entete, "le dépliant décrit un autre chargement que sa ligne").toContain(apres.nbHote);
+  }
+});
+
+test("Dépliant : repasser en lignes simples ne laisse pas de ligne fantôme (#125)", async ({ page }) => {
+  await modeMulti(page);
+  await page.locator("#rows .route-toggle").first().click();
+  await expect(page.locator("#rows tr.schema-row")).toHaveCount(1);
+
+  // Les lignes simples n'émettent aucun 📦 : un dépliant qui leur survivrait serait INDÉRACINABLE,
+  // le seul retrait passant par un clic sur `.route-toggle`. Et il compterait dans `#rows tr`, sur
+  // quoi une vingtaine de sélecteurs de la suite font `.first()` / `.nth(i)`.
+  await page.uncheck("#multiCommodity");
+  await expect(page.locator("#rows .route-toggle")).toHaveCount(0, { timeout: 20_000 });
+  await page.waitForTimeout(400);
+
+  await expect(page.locator("#rows tr.schema-row")).toHaveCount(0);
+});

--- a/vues/trajets.tsx
+++ b/vues/trajets.tsx
@@ -12,7 +12,8 @@
 //
 // Le `<thead>` et son tri restent eux aussi dans index.html, câblés par `setupSort` : React ne
 // possède que le corps du tableau, comme pour Boucles.
-import type { Route } from "../types.ts";
+import { useState } from "react";
+import type { LigneManifeste, PaireFrais, Route } from "../types.ts";
 import { BadgeSysteme, TagAvantPoste, TagIllegal, IconeCommodite, PastilleFraicheur, CelluleFiabilite, ValeurEditable, PastilleStatut } from "./communs.tsx";
 
 type Fmt = (n: number) => string;
@@ -143,7 +144,15 @@ export function VueTrajets({ lignes, celluleFrais, suspect, libelleCaisses, ...c
 export type LigneMulti = {
   origin: { name: string; system: string; planet: string; outpost: boolean; maxBox?: number };
   dest: { name: string; system: string; planet: string; outpost: boolean };
-  lines: { name: string; kind: string; units: number; illegal: boolean }[];
+  /** Le chargement ENTIER, et non les quatre champs de la pastille : le dépliant lit aussi le
+   *  stock, la demande, les deux prix et la marge. Il était nourri par un gabarit d'app.js, qui
+   *  lisait le même objet — c'est le type qui était trop étroit, pas la donnée qui manquait. */
+  lines: LigneManifeste[];
+  /** Les deux index du couple. Ils font la CLÉ STABLE d'une ligne : `multiTrips` ne produit qu'un
+   *  trajet par couple origine/destination, alors que le rang, lui, change à chaque tri. */
+  originIdx: number; destIdx: number;
+  fee: PaireFrais | null;
+  cargo: number;
   cross: boolean;
   fiabilite: number; age: number | null; partVolume: number;
   margin: number; roi: number; units: number; investment: number;
@@ -157,15 +166,68 @@ export type ProprietesMulti = ProprietesCommunes & {
   libelleCaisses: (t: LigneMulti) => string | null;
   /** Le relevé le plus ANCIEN du chargement : un trajet ne vaut pas mieux que sa ligne la moins sûre. */
   releveLePlusAncien: (t: LigneMulti) => number;
+  /** Ce que rapporte UNE ligne du chargement, frais compris. Reste à app.js : dépend du contexte
+   *  de frais, que l'îlot ne connaît pas. */
+  texteProfitLigne: (units: number, l: LigneManifeste, fee: PaireFrais | null) => string;
+  /** « 8×32 · 1×16 · … » — dépend du plafond de caisse du terminal d'achat. */
+  libelleCaissesScu: (units: number, maxBox?: number) => string;
 };
+
+/** L'identité d'un trajet, indépendante de son RANG. C'est ce qui fait qu'un dépliant ouvert suit
+ *  sa ligne quand le classement change, au lieu de rester en place et de décrire un autre trajet
+ *  (#125). `multiTrips` groupe par destination et boucle sur les origines : le couple est unique. */
+const cleTrajet = (t: LigneMulti) => `${t.originIdx}->${t.destIdx}`;
 
 const MAX_ICONES = 6;
 
-function LigneComposee({ t, i, celluleFrais, libelleCaisses, releveLePlusAncien, ...c }: {
+/** Les colonnes d'une ligne multi, que le dépliant doit enjamber d'un `colSpan`. Le gabarit lisait
+ *  `tr.children.length` sur le nœud déjà posé ; ici la ligne est écrite juste en dessous, et ses
+ *  `<td>` se comptent à l'œil : loc, origine, destination, fiabilité, marge, ROI, SCU, invest,
+ *  profit, profit/h. */
+const COLONNES = 10;
+
+// Le chargement déplié, en FRÈRE de sa ligne — une `<tr>` de plus, comme le faisait le gabarit.
+// Il était injecté à la main dans `#rows` par `insertAdjacentHTML` alors que React possède ce
+// `<tbody>` : React n'en savait rien, ne le déplaçait pas au re-tri et ne l'effaçait pas au
+// changement de mode. Il survivait donc aux rendus en devenant faux (#125). Rendu ici, il n'a plus
+// d'existence propre : il est une conséquence de l'état, comme le reste du tableau.
+function ChargementDeplie({ t, colonnes, texteProfitLigne, libelleCaissesScu, fmt, fmtVol }: {
+  t: LigneMulti; colonnes: number;
+  texteProfitLigne: ProprietesMulti["texteProfitLigne"];
+  libelleCaissesScu: ProprietesMulti["libelleCaissesScu"];
+  fmt: Fmt;
+  fmtVol: ProprietesCommunes["fmtVol"];
+}) {
+  return (
+    <tr className="schema-row">
+      <td colSpan={colonnes}>
+        <div className="multi-cargo">
+          <div className="suggest-head">{`Chargement — ${t.lines.length} commodité${t.lines.length > 1 ? "s" : ""}, ${fmt(t.units)}/${fmt(t.cargo)} SCU`}</div>
+          {t.lines.map((l, k) => (
+            <div className="sline" key={k}>
+              <IconeCommodite kind={l.kind} />
+              <span className="mname">{l.name}<TagIllegal illegal={l.illegal} /></span>
+              <span className="mstock">{`stock ${fmt(l.stock as number)} · dem. ${fmtVol(l.demand as number | null)}`}</span>
+              <span className="mprice">{`${fmt(l.buyPrice)} → ${fmt(l.sellPrice)} · marge ${fmt(l.margin)}`}</span>
+              <span className="mprofit profit">{texteProfitLigne(l.units, l, t.fee)}</span>
+              <span className="mboxes" title="Caisses SCU standard à charger">{`📦 ${fmt(l.units)} SCU · ${libelleCaissesScu(l.units, t.origin.maxBox)}`}</span>
+            </div>
+          ))}
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+function LigneComposee({ t, i, celluleFrais, libelleCaisses, releveLePlusAncien, texteProfitLigne, libelleCaissesScu, deplie, basculer, ...c }: {
   t: LigneMulti; i: number;
   celluleFrais: ProprietesMulti["celluleFrais"];
   libelleCaisses: ProprietesMulti["libelleCaisses"];
   releveLePlusAncien: ProprietesMulti["releveLePlusAncien"];
+  texteProfitLigne: ProprietesMulti["texteProfitLigne"];
+  libelleCaissesScu: ProprietesMulti["libelleCaissesScu"];
+  deplie: boolean;
+  basculer: () => void;
 } & ProprietesCommunes) {
   const n = t.lines.length;
   const fc = celluleFrais(t);
@@ -182,14 +244,21 @@ function LigneComposee({ t, i, celluleFrais, libelleCaisses, releveLePlusAncien,
     </td>
   );
 
-  return (
+  const ligne = (
     <tr data-row={i}>
       <td className="loc">
         <div className="commodity-cell">
           <BoutonVoyage i={i} />
-          {/* `.route-toggle` déplie le chargement. Sa délégation lit `shownMulti[dataset.row]` :
-              l'index doit correspondre au rang, comme pour `.journey-pick`. */}
-          <button className="route-toggle" data-row={i} title="Voir le chargement" aria-label="Voir le chargement">📦</button>
+          {/* La classe `open` est DÉRIVÉE de l'état, et n'est plus posée à la main sur le nœud :
+              c'est ce qui la faisait survivre à un re-rendu, React ne réécrivant jamais un
+              `className` littéral constant (#125). */}
+          <button
+            className={deplie ? "route-toggle open" : "route-toggle"}
+            onClick={basculer}
+            title="Voir le chargement"
+            aria-label="Voir le chargement"
+            aria-expanded={deplie}
+          >📦</button>
           <span className="multi-icons" title={noms}>
             {t.lines.slice(0, MAX_ICONES).map((l, k) => <IconeCommodite key={k} kind={l.kind} />)}
             {n > MAX_ICONES ? <span className="muted">+{n - MAX_ICONES}</span> : null}
@@ -221,15 +290,35 @@ function LigneComposee({ t, i, celluleFrais, libelleCaisses, releveLePlusAncien,
       </td>
     </tr>
   );
+
+  return deplie
+    ? <>{ligne}<ChargementDeplie t={t} colonnes={COLONNES} texteProfitLigne={texteProfitLigne} libelleCaissesScu={libelleCaissesScu} fmt={c.fmt} fmtVol={c.fmtVol} /></>
+    : ligne;
 }
 
-export function VueTrajetsMulti({ lignes, celluleFrais, libelleCaisses, releveLePlusAncien, ...c }: ProprietesMulti) {
+export function VueTrajetsMulti({ lignes, celluleFrais, libelleCaisses, releveLePlusAncien, texteProfitLigne, libelleCaissesScu, ...c }: ProprietesMulti) {
+  // L'état du dépliant vit ICI, dans l'îlot, et il est porté par la CLÉ du trajet — jamais par son
+  // rang. Un `Set` et non un seul ouvert : rien n'a jamais empêché d'en déplier plusieurs, et ce
+  // correctif n'est pas l'endroit pour changer ça.
+  const [ouverts, setOuverts] = useState<Set<string>>(() => new Set());
+  const basculer = (cle: string) =>
+    setOuverts((avant) => {
+      const apres = new Set(avant);
+      if (!apres.delete(cle)) apres.add(cle);
+      return apres;
+    });
+
   return (
     <>
-      {lignes.map((t, i) => (
-        <LigneComposee key={i} t={t} i={i} celluleFrais={celluleFrais} libelleCaisses={libelleCaisses}
-                       releveLePlusAncien={releveLePlusAncien} {...c} />
-      ))}
+      {lignes.map((t, i) => {
+        const cle = cleTrajet(t);
+        return (
+          <LigneComposee key={cle} t={t} i={i} celluleFrais={celluleFrais} libelleCaisses={libelleCaisses}
+                         releveLePlusAncien={releveLePlusAncien} texteProfitLigne={texteProfitLigne}
+                         libelleCaissesScu={libelleCaissesScu}
+                         deplie={ouverts.has(cle)} basculer={() => basculer(cle)} {...c} />
+        );
+      })}
     </>
   );
 }


### PR DESCRIPTION
## Ce que ça change

En mode multi-commodité, le chargement déplié par 📦 reste attaché à **son** trajet quand on trie
une colonne, et disparaît proprement quand on repasse en lignes simples.

## Pourquoi

Avant, il faisait les deux contraires — mesuré :

```
[SONDE] après tri inversé : schema-row=1, route-toggle.open=1
hôte avant = "▶📦🍸☠️☠️3 commodités ⛔ illégal⚡ saut inter-systèmeThe Golden Riviera"
hôte après = "▶📦🔩🔩2 commodités⚡ saut inter-systèmeShubin SMCa-8Stanton ⚠ avant-po"
=> DÉPLIANT PÉRIMÉ : il décrit un autre trajet que sa ligne

[SONDE] en lignes simples : schema-row=1, .route-toggle=0
=> ORPHELINE, PLUS AUCUN MOYEN DE LA RETIRER
```

**Cause racine** : `app.js:3342` injectait la ligne dans `#rows` par `insertAdjacentHTML`, et
`app.js:3343` posait `open` à la main sur un bouton rendu par React. Or `#rows` est une **racine
React** depuis la migration des tables (#116), peinte en 512/529/540/551. React ne connaissait ni la
`schema-row` ni la classe :

- avec `key={i}` (`vues/trajets.tsx:230`) il réutilisait le même `<tr>` d'un rendu à l'autre, alors
  que `trips.sort(...)` (`app.js:549`) rejoue à chaque rendu — le rang change de trajet ;
- `className="route-toggle"` étant un littéral constant, il ne réécrivait jamais l'attribut `class`
  et n'effaçait pas le `open` posé à la main.

Ce n'était pas un défaut d'origine : c'est une écriture impérative devenue **illégitime** quand son
conteneur est passé à React. Un `grep '\.innerHTML *='` ne la trouvait pas — c'est un
`insertAdjacentHTML`, et c'est la leçon à retenir de cette PR.

**Le correctif** : le dépliant devient un frère rendu par le JSX (`ChargementDeplie`), son ouverture
un état de `VueTrajetsMulti`, et `open` une classe **dérivée**. La clé de ligne passe de `key={i}` à
`${originIdx}->${destIdx}` — sans clé stable, l'état « ouvert » resterait porté par le **rang** et
reproduirait le même défaut sous une autre forme. `multiTrips` ne produit qu'un trajet par couple,
l'unicité est acquise.

La délégation `.route-toggle` disparaît, et sa garde `isMultiRoutes()` avec elle : elle n'existait
que parce qu'un bouton cliqué après un retour en lignes simples indexait `shownMulti` avec le rang
d'un autre tableau (#25). Un rappel fermé sur **son** trajet ne peut pas se tromper de tableau.
`multiCargoHTML` perd son dernier appelant, et `commodityIcon` / `illegalTag` avec lui — vérifié en
grepant les **appels**, pas les définitions (leçon de #116).

## Vérification

**Deux tests écrits d'abord, vus ROUGES sur le code d'avant :**

```
✘ Dépliant : il décrit toujours la ligne sous laquelle il pend, même après un tri (#125)
    Error: le dépliant décrit un autre chargement que sa ligne
    Expected substring: "2 commodités"
    Received string:    "Chargement — 3 commodités, 12/96 SCU"
✘ Dépliant : repasser en lignes simples ne laisse pas de ligne fantôme (#125)
    Expected: 0   Received: 1
```

Puis verts après le correctif.

**`node --test` → 483 tests, 483 pass, 0 fail.**
**`npx playwright test` → 221 passed, 2 skipped, 0 failed.**
**`npx tsc --noEmit` → silencieux.**

Honnêteté sur la suite : au **premier** passage complet, `smoke.pw.mjs:650` (« Soute : avoir pris
plus que le stock publié… ») a échoué une fois. Relancé seul → vert ; suite complète relancée →
221/221. Ce test ne touche ni au mode multi ni au dépliant. Instable sous charge parallèle, pas une
régression de cette PR.

**Relevé DOM du dépliant fraîchement ouvert** — le seul état où l'ancien et le nouveau doivent
coïncider, puisque partout ailleurs l'ancien était faux : **28 lignes relevées, 25 identiques.** Les
3 écarts sont le même : `.mname` passe d'**un** nœud de texte (`Osoian Hides `) à **deux**
(`Osoian Hides` + ` `), parce que le composant partagé `TagIllegal` porte l'espace dans son
fragment. C'est la forme que `vues/manifeste.tsx:269-271` a déjà adoptée en #117.

Comme le dépôt a déjà payé ce piège en sous-pixels, la largeur a été **mesurée** plutôt que
supposée, au 1/100 de pixel sur `.mname`, `.sline` et `.mprice` : **aucun écart**. L'espace est
préservé, il change seulement de nœud.

## Ce qui n'est pas couvert

- **`aria-expanded` est ajouté** au bouton 📦. C'est un ajout, pas une reproduction : le bouton
  déplie réellement quelque chose et ne le disait pas. Aucun test ne le garde.
- **L'exclusivité n'est pas introduite** : comme avant, plusieurs lignes peuvent être dépliées en
  même temps (`Set`, et non un seul ouvert). Ce correctif n'est pas l'endroit pour changer ça, et
  aucun test n'en ouvre deux.
- `shownMulti` **survit** : sa seconde lecture, dans la délégation `.journey-pick`
  (`app.js:3389`), indexe toujours par rang. Elle part avec le lot des tableaux indexés par rang,
  dont cette PR est le premier morceau.
- Le relevé DOM est un **outil de PR**, non commité.

Closes #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
