### PR TITLE
refactor(voyage): le ▶ porte sa ligne, et les quatre tableaux par rang disparaissent

### DIFF
--- a/app.js
+++ b/app.js
@@ -66,8 +66,6 @@ let sortKey = "profit";
 let sortDir = -1; // -1 = décroissant, 1 = croissant
 let loopSortKey = "profit";
 let loopSortDir = -1;
-// Lignes actuellement affichées (dans l'ordre du DOM) pour déplier le schéma de trajet.
-let shownRoutes = [], shownEnroute = [], shownLoops = [], shownMulti = [];
 // Vue « Commodités » : mode de tri (margin|code|kind|custom), clé/sens custom, sélection.
 let commMode = "margin", commSortKey = "margin", commSortDir = -1, commSelected = null, shownCommodities = [];
 // Board « Commodités » : "market" = marge achat→vente ; "loot" = prix de revente d'une ressource
@@ -441,8 +439,6 @@ function readFilters() {
   };
 }
 
-// Mode « Multi commodité » actif (uniquement pertinent dans la vue Trajets).
-const isMultiRoutes = () => view === "routes" && $("multiCommodity").checked;
 
 // Message de #empty tel qu'il est écrit dans index.html. Le <p> est PARTAGÉ par les vues Trajets /
 // Boucles / En route, et « En route » comme le mode multi-commodité réécrivent son texte : sans
@@ -486,6 +482,10 @@ function propsLignesSimples() {
     // de la station. Le prendre dans `feeInfo` le faisait disparaître dès l'interrupteur relâché, et
     // la ligne annonçait « 3×32 » à côté d'un manifeste qui affichait « 6×16 » pour la même cargaison.
     libelleCaisses: (r) => (r.units ? scuBoxesLabel(r.units, (termByName.get(r.buy.terminal) || {}).maxBox) : null),
+    // ▶ : le rappel est ÉTALÉ avec le reste, donc il sert les DEUX tables à lignes simples d'un
+    // coup. Le poser au seul site d'appel de `#rows` ferait taire le ▶ d'« En route » — la
+    // sur-suppression de #116 en négatif. C'est désormais gardé (e2e/choix-trajet.pw.mjs).
+    choisirTrajet: (r) => pickJourney([legFromRoute(r)]),
   };
 }
 
@@ -499,7 +499,6 @@ function render() {
 
   rows.sort(bySort(sortKey, sortDir));
 
-  shownRoutes = rows;
   peindre($("rows"), vueTrajets({
     ...propsTrajetsCommunes(),
     ...propsLignesSimples(),
@@ -516,18 +515,18 @@ function renderMulti(f) {
   const empty = $("empty");
   // Sans soute bornée, « remplir la soute » n'a pas de sens (cf. manifeste d'« En route »).
   if (!f.useCargo || !(f.cargo > 0)) {
-    shownMulti = [];
     peindre($("rows"), null);
     empty.hidden = false;
     empty.textContent = "Active la soute (SCU) pour calculer des trajets multi-commodité.";
     return;
   }
-  // Graphe requis. On vide comme le fait la branche « soute inactive » juste au-dessus : laisser les
-  // trajets à UNE commodité sous un mode qui promet des chargements combinés, c'est un tableau qui
-  // ne correspond plus à `shownMulti` — ▶ et 📦 y lisaient un index vide et ne faisaient RIEN.
+  // Graphe requis. On vide comme le fait la branche « soute inactive » juste au-dessus : laisser
+  // les trajets à UNE commodité sous un mode qui promet des chargements combinés, c'est afficher
+  // autre chose que ce qu'on annonce. (Historiquement le motif était plus dur : le tableau ne
+  // correspondait plus à `shownMulti`, et ▶ comme 📦 y lisaient un index vide — clic mort, #25.
+  // Les deux boutons portent maintenant leur ligne, mais vider reste la bonne réponse.)
   // #empty reste masqué : le tableau n'est pas vide à cause des filtres, le marché n'est pas là.
   if (!MARKET) {
-    shownMulti = [];
     peindre($("rows"), null);
     empty.hidden = true;
     withMarket(refresh);
@@ -538,7 +537,6 @@ function renderMulti(f) {
   const trips = multiTrips(MARKET, f, effVals, 300, f.multiAll ? 1 : 2, feeResolver(f))
     .map((t) => ({ ...t, feeInfo: feeCtx(f, t.origin.name, t.dest.name, t.origin, t.dest), ...tripMetrics(t) }));
   trips.sort(bySort(sortKey, sortDir));
-  shownMulti = trips;
   peindre($("rows"), vueTrajetsMulti({
     ...propsTrajetsCommunes(),
     lignes: trips,
@@ -551,6 +549,9 @@ function renderMulti(f) {
     // de l'îlot.
     texteProfitLigne: lineProfitText,
     libelleCaissesScu: scuBoxesLabel,
+    // EXPLICITE, et pas par `propsLignesSimples()` : cette vue-ci ne l'étale pas, et un chargement
+    // multi ne devient pas une jambe par le même chemin qu'une ligne simple.
+    choisirTrajet: (t) => pickJourney([legFromTrip(t)]),
   }));
   empty.hidden = trips.length > 0;
   // Rappel : seuls les chargements COMBINÉS (≥ 2 commodités) sont listés ici — un trajet dont le
@@ -601,17 +602,19 @@ function renderLoops() {
     rows.forEach((l) => { l._fromHere = l.a.terminal === hereArrival || l.b.terminal === hereArrival; });
     rows.sort((a, b) => (b._fromHere ? 1 : 0) - (a._fromHere ? 1 : 0)); // tri stable : pertinentes d'abord
   }
-  shownLoops = rows;
-
   // Le <tbody> passe à React ; le <thead> et ses `th[data-sort-loop]` restent dans index.html,
-  // câblés par setupLoopSort. `data-row` reproduit le rang dans `shownLoops`, que la délégation
-  // posée sur document lit au clic sur `.journey-pick` — c'est un contrat, pas un détail.
+  // câblés par setupLoopSort. React ne possède que le corps du tableau.
   peindre($("loopRows"), vueBoucles({
     lignes: rows,
     fmt,
     celluleFrais: (l) => feeCell(l.feeInfo, l.fees, () => `${fmt(l.unitsOut)} + ${fmt(l.unitsBack)} SCU, 4 opérations (charge et décharge à chaque bout)`, l.units > 0),
     fmtFee,
     avecTexteFrais: (base, cell) => (cell.text ? `${base} · ${cell.text}` : base),
+    // On entre dans le cycle par la FIN du parcours : la boucle l'étend au lieu de le remplacer.
+    // `journeyEnd(JOURNEY)` est relu DANS le corps de la flèche, donc au clic — et surtout PAS
+    // remplacé par `hereArrival` (calculé plus haut, au rendu) : le parcours a pu bouger entre les
+    // deux, et c'est la seule régression que ce lot pourrait introduire.
+    choisirBoucle: (l) => pickJourney(legsFromLoop(l, JOURNEY ? journeyEnd(JOURNEY)?.name : null)),
   }));
 
   $("empty").hidden = rows.length > 0;
@@ -1162,7 +1165,6 @@ function renderEnRoute() {
     .map((r) => evaluate(r, f));
 
   deals.sort(bySort(sortKey, sortDir));
-  shownEnroute = deals;
   peindre($("enrouteRows"), vueTrajets({ ...propsTrajetsCommunes(), ...propsLignesSimples(), lignes: deals }));
   emptyMsg.hidden = deals.length > 0;
   if (!deals.length) emptyMsg.textContent = "Aucun fret rentable depuis ce terminal avec ces filtres.";
@@ -3295,8 +3297,10 @@ async function init() {
     if (e.target.classList.contains("mqty-input")) updateManifestTotals();
   });
   $("manifest").addEventListener("click", (e) => {
-    // Ici et pas dans le délégué global du compagnon : celui-ci lit `pick.closest("table").id`,
-    // qui lèverait un TypeError depuis une carte. La carte n'est pas un tableau.
+    // Ici et pas dans le délégué global du compagnon. La raison d'origine a disparu avec la
+    // délégation `.journey-pick` (elle lisait `pick.closest("table").id`, qui levait depuis une
+    // carte) ; ce qui reste vaut toujours : cet écouteur est posé sur `#manifest`, donc il ne voit
+    // que sa carte, là où le délégué global voit toute la page.
     if (e.target.closest("#manifestToJourney")) { manifestToJourney(); return; }
     if (e.target.closest("#copyManifest")) { copyManifest(); return; }
     if (e.target.closest("#manifestAddBtn")) { addManifestCommodity($("manifestAddInput").value); return; }
@@ -3318,7 +3322,8 @@ async function init() {
   // La garde `isMultiRoutes()` que cette délégation portait disparaît avec elle — elle existait
   // parce qu'un bouton cliqué après un retour en lignes simples indexait `shownMulti` avec le rang
   // d'un autre tableau (#25). Un rappel fermé sur SON trajet ne peut pas se tromper de tableau.
-  // (`isMultiRoutes` reste : `.journey-pick` s'en sert encore, elle indexe toujours par rang.)
+  // `isMultiRoutes` a suivi le même chemin avec le ▶ : plus personne ne demande « quel mode ? »
+  // au moment du clic, puisqu'aucun bouton de CES TABLES n'a plus de rang à interpréter.
   // Carte du parcours : cliquer une escale déplace « je suis ici », comme le fil d'étapes.
   $("holdCard").addEventListener("click", (e) => {
     if (e.target.closest("#holdClear")) { viderSoute(); return; }
@@ -3378,19 +3383,23 @@ async function init() {
     const a = e.target.closest(".jm-arret");
     if (a && (e.key === "Enter" || e.key === " ")) { e.preventDefault(); setJourneyStop(Number(a.dataset.i)); }
   });
-  // Compagnon de voyage : ▶ sélectionne un trajet (Trajets / En route) ; ✕ efface le parcours.
+  // Compagnon de voyage : ✕ efface le parcours, ▶ n'est plus ici.
+  //
+  // Le ▶ était la dernière lecture par rang DES TABLES DE TRAJETS : la délégation lisait
+  // `pick.dataset.row` puis indexait l'un des quatre tableaux `shown*` selon
+  // `pick.closest("table").id`. Un tableau rempli au RENDU et relu au CLIC, avec ce que ça suppose :
+  // que les deux soient d'accord. Chaque îlot ferme désormais son bouton sur SA ligne.
+  //
+  // Le motif SURVIT ailleurs, et il faut le dire pour ne pas croire le dossier clos : la soute
+  // (`retirerLot`), le fil d'étapes, la carte du parcours et surtout l'autocomplétion
+  // (`matches[Number(li.dataset.i)]`) lisent tous un rang posé au rendu. Ce lot ne traite que les
+  // tables de trajets.
+  //
+  // Trois choses partent avec la délégation : le `closest("table").id` (et son TypeError si un ▶
+  // naissait hors table), le `else` fourre-tout qui faisait retomber toute table inconnue sur
+  // `shownRoutes`, et la garde `isMultiRoutes()` qui rattrapait le mode déjà changé au moment du
+  // clic (#25) — un rappel fermé sur SON trajet ne peut pas se tromper de tableau.
   document.addEventListener("click", (e) => {
-    const pick = e.target.closest(".journey-pick");
-    if (pick) {
-      const tableId = pick.closest("table").id;
-      const i = Number(pick.dataset.row);
-      // Boucle : on entre dans le cycle par la fin du parcours (elle est marquée « from-here » si
-      // l'un OU l'autre de ses bouts y touche) -> elle étend le voyage au lieu de le remplacer.
-      if (tableId === "loops") { const l = shownLoops[i]; if (l) pickJourney(legsFromLoop(l, JOURNEY ? journeyEnd(JOURNEY)?.name : null)); }
-      else if (tableId === "routes" && isMultiRoutes()) { const t = shownMulti[i]; if (t) pickJourney([legFromTrip(t)]); }
-      else { const r = (tableId === "enroute" ? shownEnroute : shownRoutes)[i]; if (r) pickJourney([legFromRoute(r)]); }
-      return;
-    }
     if (e.target.closest("#chainToJourney") && shownChain) { pickJourney(legsFromChain(shownChain, MARKET.terminals)); return; }
     if (e.target.closest("#journeyClear")) { clearJourney(); return; }
     // Démarrer un voyage « de zéro » : bouton « Commencer » depuis l'invite.

--- a/e2e/choix-trajet.pw.mjs
+++ b/e2e/choix-trajet.pw.mjs
@@ -1,0 +1,88 @@
+import { test, expect } from "@playwright/test";
+
+// Le bouton ▶ — « faire ce trajet » — dans les tables qui le portent.
+//
+// Il est le pont entre un tableau et le compagnon de voyage, et c'était le geste le moins gardé du
+// dépôt : sur les 28 clics `.journey-pick` que comptait la suite, aucun ne visait le mode
+// multi-commodité ni « En route », et aucun ne recliquait après un changement de tri. Trois
+// branches sur quatre de l'ancienne délégation étaient donc aveugles.
+//
+// Ce qui rendait le trou dangereux : chaque branche indexait un tableau global par le RANG de la
+// ligne (`data-row`). Un rang qui ne correspond plus à son tableau ne casse rien de visible — il
+// ouvre simplement le mauvais trajet. Ces tests comparent donc les deux bouts de la ligne CLIQUÉE
+// aux étapes du parcours obtenu ; ils gardent ce contrat quel que soit le mécanisme derrière.
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/index.html");
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+});
+
+// Les deux bouts d'une ligne, tels qu'elle les affiche.
+const boutsDe = (ligne) => ligne.locator(".term-name").allTextContents();
+
+// Les étapes du parcours, dans l'ordre.
+const etapes = (page) => page.locator("#journeyCard .jstep").allTextContents();
+
+test("▶ en mode MULTI-COMMODITÉ ajoute le trajet de SA ligne (#96)", async ({ page }) => {
+  await page.check("#multiCommodity");
+  // On attend `.route-toggle`, PAS `.journey-pick` : le ▶ est partagé avec les lignes simples, donc
+  // l'attendre laisserait le test vert sur un tableau resté en mode simple — c'est-à-dire
+  // exactement la régression #25 que ce test doit voir. Le 📦 n'est émis que par `LigneComposee`.
+  await expect(page.locator("#rows .route-toggle").first()).toBeVisible({ timeout: 20_000 });
+
+  const ligne = page.locator("#rows tr").first();
+  const bouts = await boutsDe(ligne);
+  expect(bouts, "la ligne multi n'affiche pas ses deux bouts").toHaveLength(2);
+  await ligne.locator(".journey-pick").click();
+
+  await expect(page.locator("#journeyCard .jstep")).toHaveCount(2);
+  expect(await etapes(page)).toEqual(bouts);
+});
+
+test("▶ dans « En route » ajoute le trajet de SA ligne (#96)", async ({ page }) => {
+  // Le second appelant de `vueTrajets` (`#enrouteRows`), que rien ne gardait : les deux tables à
+  // lignes simples partagent leur rendu ET leurs props — un rappel posé sur un seul des deux sites
+  // ferait taire ce ▶-ci.
+  await page.click("#viewEnroute");
+  await expect(page.locator("#originList option").first()).toBeAttached({ timeout: 10_000 });
+  await page.fill("#origin", await page.locator("#originList option").first().getAttribute("value"));
+
+  // On laisse le tableau se remplir AVANT de conclure : compter tout de suite renverrait zéro sur
+  // un rendu simplement pas encore arrivé, et le saut ci-dessous avalerait le test au lieu de le
+  // protéger. Le jeu de données étant régénéré chaque jour, ce terminal peut n'avoir aucun fret
+  // rentable — on saute alors plutôt que d'échouer, sinon une régression de DONNÉES se lirait
+  // comme une régression du ▶ (le dépôt a déjà tranché ce cas, cf. e2e/smoke.pw.mjs:371).
+  const lignes = page.locator("#enrouteRows .journey-pick");
+  await lignes.first().waitFor({ state: "visible", timeout: 10_000 }).catch(() => {});
+  test.skip(!(await lignes.count()), "aucun fret rentable depuis ce terminal avec ces filtres");
+
+  const ligne = page.locator("#enrouteRows tr").first();
+  const bouts = await boutsDe(ligne);
+  expect(bouts).toHaveLength(2);
+  await ligne.locator(".journey-pick").click();
+
+  await expect(page.locator("#journeyCard .jstep")).toHaveCount(2);
+  expect(await etapes(page)).toEqual(bouts);
+});
+
+test("▶ suit sa ligne quand le classement change (#96)", async ({ page }) => {
+  // L'invariant central du lot. Le tri est une MISE EN SCÈNE, donc on vérifie qu'elle a bien eu
+  // lieu : sans ça, le test passerait aussi le jour où les deux clics de tri ne changeraient plus
+  // rien, et il garderait une situation qui ne se produit jamais.
+  const ligne = page.locator("#rows tr").first();
+  const avant = await boutsDe(ligne);
+
+  const colonne = page.locator("th[data-sort]").first();
+  await colonne.click();
+  await page.waitForTimeout(300);
+  await colonne.click(); // sens inversé
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+  await page.waitForTimeout(300);
+
+  const apres = await boutsDe(ligne);
+  expect(apres, "le tri n'a pas changé la première ligne : le test ne prouverait rien").not.toEqual(avant);
+
+  await ligne.locator(".journey-pick").click();
+  await expect(page.locator("#journeyCard .jstep")).toHaveCount(2);
+  expect(await etapes(page)).toEqual(apres);
+});

--- a/vues/boucles.tsx
+++ b/vues/boucles.tsx
@@ -3,10 +3,9 @@
 // Plus exigeante que la Tournée malgré ses 73 lignes, et c'est pour ça qu'elle vient en second :
 // elle exerce trois choses que la Tournée n'avait pas.
 //
-//   1. Elle rend des LIGNES INTERACTIVES. Chaque `<tr>` porte `data-row`, et une délégation posée
-//      sur `document` (app.js) lit `shownLoops[btn.dataset.row]` au clic sur `.journey-pick`.
-//      L'index doit donc correspondre EXACTEMENT au rang dans le tableau que app.js a rangé dans
-//      la globale. React ne change rien à ce contrat : il le reproduit.
+//   1. Elle rend des LIGNES INTERACTIVES. Le ▶ recevait son rang par `data-row`, qu'une délégation
+//      posée sur `document` relisait dans `shownLoops` — un tableau rempli au RENDU et relu au
+//      CLIC. Il reçoit désormais un rappel fermé sur SA boucle : plus de rang, plus de globale.
 //   2. Elle vit dans un `<tbody>` dont le `<thead>` reste VANILLA (index.html), avec ses
 //      `th[data-sort-loop]` câblés par `setupLoopSort`. React ne possède que le corps du tableau.
 //   3. Ses cellules passent par des aides PARTAGÉES avec d'autres vues — d'où `communs.tsx`.
@@ -43,13 +42,16 @@ export type ProprietesBoucles = {
   celluleFrais: (l: BoucleEvaluee) => CelluleFrais;
   fmtFee: (n: number, fees: number) => string;
   avecTexteFrais: (base: string, cell: CelluleFrais) => string;
+  /** ▶ : ajouter cette boucle au voyage. Reçoit LA boucle, jamais son rang. */
+  choisirBoucle: (l: BoucleEvaluee) => void;
 };
 
-function LigneBoucle({ l, i, fmt, celluleFrais, fmtFee, avecTexteFrais }: {
-  l: BoucleEvaluee; i: number; fmt: Fmt;
+function LigneBoucle({ l, fmt, celluleFrais, fmtFee, avecTexteFrais, choisirBoucle }: {
+  l: BoucleEvaluee; fmt: Fmt;
   celluleFrais: ProprietesBoucles["celluleFrais"];
   fmtFee: ProprietesBoucles["fmtFee"];
   avecTexteFrais: ProprietesBoucles["avecTexteFrais"];
+  choisirBoucle: ProprietesBoucles["choisirBoucle"];
 }) {
   const fc = celluleFrais(l);
   // Le title des frais arrive déjà échappé depuis app.js (` title="…"`). React échappe de son côté,
@@ -63,9 +65,9 @@ function LigneBoucle({ l, i, fmt, celluleFrais, fmtFee, avecTexteFrais }: {
     : l.out.updated || l.back.updated || 0;
 
   return (
-    <tr data-row={i} className={l._fromHere ? "from-here" : undefined}>
+    <tr className={l._fromHere ? "from-here" : undefined}>
       <td className="loc loop-cell">
-        <button className="journey-pick" data-row={i} title="Ajouter cette boucle au voyage" aria-label="Ajouter au voyage">▶</button>
+        <button className="journey-pick" onClick={() => choisirBoucle(l)} title="Ajouter cette boucle au voyage" aria-label="Ajouter au voyage">▶</button>
         <div className="loop-ends">
           <div className="loop-end">
             <span className="term-name">{l.a.terminal}</span>
@@ -112,11 +114,12 @@ function LigneBoucle({ l, i, fmt, celluleFrais, fmtFee, avecTexteFrais }: {
   );
 }
 
-export function VueBoucles({ lignes, fmt, celluleFrais, fmtFee, avecTexteFrais }: ProprietesBoucles) {
+export function VueBoucles({ lignes, fmt, celluleFrais, fmtFee, avecTexteFrais, choisirBoucle }: ProprietesBoucles) {
   return (
     <>
       {lignes.map((l, i) => (
-        <LigneBoucle key={i} l={l} i={i} fmt={fmt} celluleFrais={celluleFrais} fmtFee={fmtFee} avecTexteFrais={avecTexteFrais} />
+        <LigneBoucle key={i} l={l} fmt={fmt} celluleFrais={celluleFrais} fmtFee={fmtFee}
+                     avecTexteFrais={avecTexteFrais} choisirBoucle={choisirBoucle} />
       ))}
     </>
   );

--- a/vues/trajets.tsx
+++ b/vues/trajets.tsx
@@ -48,20 +48,25 @@ export type ProprietesTrajets = ProprietesCommunes & {
    *  station, lue du marché et non du contexte de frais (sans quoi elle disparaît quand
    *  l'interrupteur d'autoload est relâché). */
   libelleCaisses: (r: LigneTrajet) => string | null;
+  /** ▶ : faire ce trajet. Reçoit LA ligne, jamais son rang — voir `BoutonVoyage`. */
+  choisirTrajet: (r: LigneTrajet) => void;
 };
 
-function BoutonVoyage({ i }: { i: number }) {
-  // `data-row` est un CONTRAT : une délégation posée sur `document` lit `shownRoutes[dataset.row]`.
+// La CLASSE reste le contrat — 28 clics e2e passaient par elle avant ce lot — mais le rang a
+// disparu du bouton, qui est fermé sur SA ligne : il ne peut plus désigner autre chose. C'est ce
+// qui remplace `shownRoutes[dataset.row]`, un tableau rempli au RENDU et relu au CLIC.
+function BoutonVoyage({ choisir }: { choisir: () => void }) {
   return (
-    <button className="journey-pick" data-row={i} title="Faire ce trajet — compagnon de voyage" aria-label="Sélectionner ce trajet">▶</button>
+    <button className="journey-pick" onClick={choisir} title="Faire ce trajet — compagnon de voyage" aria-label="Sélectionner ce trajet">▶</button>
   );
 }
 
-function LigneSimple({ r, i, celluleFrais, suspect, libelleCaisses, ...c }: {
-  r: LigneTrajet; i: number;
+function LigneSimple({ r, celluleFrais, suspect, libelleCaisses, choisirTrajet, ...c }: {
+  r: LigneTrajet;
   celluleFrais: ProprietesTrajets["celluleFrais"];
   suspect: ProprietesTrajets["suspect"];
   libelleCaisses: ProprietesTrajets["libelleCaisses"];
+  choisirTrajet: ProprietesTrajets["choisirTrajet"];
 } & ProprietesCommunes) {
   const fc = celluleFrais(r);
   const titreFrais = fc.text || undefined;
@@ -99,10 +104,10 @@ function LigneSimple({ r, i, celluleFrais, suspect, libelleCaisses, ...c }: {
   };
 
   return (
-    <tr data-row={i}>
+    <tr>
       <td className="loc">
         <div className="commodity-cell">
-          <BoutonVoyage i={i} />
+          <BoutonVoyage choisir={() => choisirTrajet(r)} />
           <IconeCommodite kind={r.kind} />
           <span className="cname">{r.commodity}</span>
         </div>
@@ -130,11 +135,12 @@ function LigneSimple({ r, i, celluleFrais, suspect, libelleCaisses, ...c }: {
   );
 }
 
-export function VueTrajets({ lignes, celluleFrais, suspect, libelleCaisses, ...c }: ProprietesTrajets) {
+export function VueTrajets({ lignes, celluleFrais, suspect, libelleCaisses, choisirTrajet, ...c }: ProprietesTrajets) {
   return (
     <>
       {lignes.map((r, i) => (
-        <LigneSimple key={i} r={r} i={i} celluleFrais={celluleFrais} suspect={suspect} libelleCaisses={libelleCaisses} {...c} />
+        <LigneSimple key={i} r={r} celluleFrais={celluleFrais} suspect={suspect}
+                     libelleCaisses={libelleCaisses} choisirTrajet={choisirTrajet} {...c} />
       ))}
     </>
   );
@@ -171,6 +177,9 @@ export type ProprietesMulti = ProprietesCommunes & {
   texteProfitLigne: (units: number, l: LigneManifeste, fee: PaireFrais | null) => string;
   /** « 8×32 · 1×16 · … » — dépend du plafond de caisse du terminal d'achat. */
   libelleCaissesScu: (units: number, maxBox?: number) => string;
+  /** ▶ : faire ce chargement. À passer EXPLICITEMENT — `propsLignesSimples()` d'app.js, qui porte
+   *  celui des lignes simples, n'est PAS étalée ici. */
+  choisirTrajet: (t: LigneMulti) => void;
 };
 
 /** L'identité d'un trajet, indépendante de son RANG. C'est ce qui fait qu'un dépliant ouvert suit
@@ -219,13 +228,14 @@ function ChargementDeplie({ t, colonnes, texteProfitLigne, libelleCaissesScu, fm
   );
 }
 
-function LigneComposee({ t, i, celluleFrais, libelleCaisses, releveLePlusAncien, texteProfitLigne, libelleCaissesScu, deplie, basculer, ...c }: {
-  t: LigneMulti; i: number;
+function LigneComposee({ t, celluleFrais, libelleCaisses, releveLePlusAncien, texteProfitLigne, libelleCaissesScu, choisirTrajet, deplie, basculer, ...c }: {
+  t: LigneMulti;
   celluleFrais: ProprietesMulti["celluleFrais"];
   libelleCaisses: ProprietesMulti["libelleCaisses"];
   releveLePlusAncien: ProprietesMulti["releveLePlusAncien"];
   texteProfitLigne: ProprietesMulti["texteProfitLigne"];
   libelleCaissesScu: ProprietesMulti["libelleCaissesScu"];
+  choisirTrajet: ProprietesMulti["choisirTrajet"];
   deplie: boolean;
   basculer: () => void;
 } & ProprietesCommunes) {
@@ -245,10 +255,10 @@ function LigneComposee({ t, i, celluleFrais, libelleCaisses, releveLePlusAncien,
   );
 
   const ligne = (
-    <tr data-row={i}>
+    <tr>
       <td className="loc">
         <div className="commodity-cell">
-          <BoutonVoyage i={i} />
+          <BoutonVoyage choisir={() => choisirTrajet(t)} />
           {/* La classe `open` est DÉRIVÉE de l'état, et n'est plus posée à la main sur le nœud :
               c'est ce qui la faisait survivre à un re-rendu, React ne réécrivant jamais un
               `className` littéral constant (#125). */}
@@ -296,7 +306,7 @@ function LigneComposee({ t, i, celluleFrais, libelleCaisses, releveLePlusAncien,
     : ligne;
 }
 
-export function VueTrajetsMulti({ lignes, celluleFrais, libelleCaisses, releveLePlusAncien, texteProfitLigne, libelleCaissesScu, ...c }: ProprietesMulti) {
+export function VueTrajetsMulti({ lignes, celluleFrais, libelleCaisses, releveLePlusAncien, texteProfitLigne, libelleCaissesScu, choisirTrajet, ...c }: ProprietesMulti) {
   // L'état du dépliant vit ICI, dans l'îlot, et il est porté par la CLÉ du trajet — jamais par son
   // rang. Un `Set` et non un seul ouvert : rien n'a jamais empêché d'en déplier plusieurs, et ce
   // correctif n'est pas l'endroit pour changer ça.
@@ -310,12 +320,12 @@ export function VueTrajetsMulti({ lignes, celluleFrais, libelleCaisses, releveLe
 
   return (
     <>
-      {lignes.map((t, i) => {
+      {lignes.map((t) => {
         const cle = cleTrajet(t);
         return (
-          <LigneComposee key={cle} t={t} i={i} celluleFrais={celluleFrais} libelleCaisses={libelleCaisses}
+          <LigneComposee key={cle} t={t} celluleFrais={celluleFrais} libelleCaisses={libelleCaisses}
                          releveLePlusAncien={releveLePlusAncien} texteProfitLigne={texteProfitLigne}
-                         libelleCaissesScu={libelleCaissesScu}
+                         libelleCaissesScu={libelleCaissesScu} choisirTrajet={choisirTrajet}
                          deplie={ouverts.has(cle)} basculer={() => basculer(cle)} {...c} />
         );
       })}


### PR DESCRIPTION
## Ce que ça change

Rien à l'écran. Le bouton ▶ (« faire ce trajet ») cesse de passer par un index : il porte sa ligne.
Les quatre tableaux globaux `shownRoutes`, `shownEnroute`, `shownLoops`, `shownMulti` disparaissent
— c'était le **préalable annoncé** à la suppression d'`app.js`.

## Pourquoi

Les quatre globales étaient déclarées sur une seule ligne et n'avaient **qu'un seul lecteur** : la
délégation `.journey-pick` posée sur `document`, qui lisait `pick.dataset.row` puis choisissait le
tableau par `pick.closest("table").id`. Un tableau rempli au **rendu** et relu au **clic**, avec ce
que ça suppose — que les deux soient d'accord.

Chaque îlot reçoit désormais un rappel (`choisirTrajet`, `choisirBoucle`) et son bouton est fermé
sur **sa** ligne. La question ne se pose plus.

Partent avec la délégation :
- le `closest("table").id` et son `TypeError` si un ▶ naissait hors table — c'est pour l'éviter que
  `#manifestToJourney` avait son propre écouteur ;
- le `else` fourre-tout, qui faisait retomber **toute** table inconnue sur `shownRoutes` ;
- la garde `isMultiRoutes()`, qui rattrapait le mode déjà changé au moment du clic (#25) ;
- les attributs `data-row` — dont **trois sur six** n'avaient déjà plus aucun lecteur.

### Le piège, nommé avant d'écrire

`propsLignesSimples()` est étalée aux **deux** sites de `vueTrajets` (`#rows` et `#enrouteRows`),
donc le rappel posé là sert les deux d'un coup. Mais elle n'est **pas** étalée dans le mode multi,
qui doit recevoir le sien explicitement. Un rappel posé au seul site de `#rows` ferait taire le ▶
d'« En route » — la sur-suppression de #116 en négatif.

`choisirBoucle` relit `journeyEnd(JOURNEY)` **dans le corps de la flèche**, donc au clic. Le
remplacer par `hereArrival` (calculé plus haut, au rendu) est la seule régression que ce lot puisse
introduire ; le commentaire le dit à cet endroit précis.

## Vérification

**`node --test` → 483 tests, 483 pass, 0 fail.**
**`npx playwright test` → 224 passed, 2 skipped, 0 failed** (1,6 min ; les 2 `skip` sont
conditionnels au jeu de données et préexistants).
**`npx tsc --noEmit` → silencieux.**

**Trois caractérisations écrites avant le code**, sur les branches qu'aucun test ne visait : sur les
**28** clics `.journey-pick` que comptait la suite, aucun ne visait le mode multi ni « En route », et
aucun ne recliquait après un tri.

Elles ont été vues rouges **deux fois**, et la seconde compte plus que la première :

| mutation | ce qui tombe |
|---|---|
| rang décalé d'un cran (ancienne architecture) | les trois |
| rappel posé au seul site de `#rows` | **« En route » seul** — les deux autres restent verts |
| rappel du mode multi rendu inerte | le cas multi |

La deuxième ligne est le vrai résultat : c'est le piège nommé ci-dessus, et le test discrimine
exactement le bon cas.

## Ce que la relecture a corrigé, et qu'il vaut mieux dire

Une revue adverse de ce lot a trouvé six défauts réels que j'avais laissés passer, tous corrigés
ici :

- **le test du mode multi ne gardait pas le mode multi** : il attendait `.journey-pick`, que les
  lignes **simples** satisfont aussi — une régression laissant les lignes mono sous le mode multi
  (#25) l'aurait laissé vert. Il attend maintenant `.route-toggle`, propre à `LigneComposee` ;
- **le test de tri n'assertait pas sa mise en scène** : rien n'était capturé avant les clics de tri,
  donc on pouvait les supprimer sans le faire tomber. Il vérifie désormais que le tri a bien changé
  la première ligne ;
- **le test « En route » n'avait pas de garde de données** : le jeu de données est régénéré chaque
  jour et ce terminal peut n'avoir aucun fret rentable. Il saute maintenant, plutôt que de faire
  lire une régression de données comme une régression du ▶ ;
- **un commentaire affirmait que le ▶ était la dernière lecture par rang du dépôt** — faux : le
  motif survit dans la soute, le fil d'étapes, la carte du parcours et surtout l'autocomplétion
  (`matches[Number(li.dataset.i)]`). La phrase est bornée aux tables de trajets ;
- **le commentaire de `#manifestToJourney`** justifiait encore son écouteur séparé par le
  `closest("table").id` que ce lot supprime ;
- **« 29 clics »** était faux (28, mesuré), et deux commentaires étaient restés orphelins de leur
  déclaration supprimée. Une prop `i` morte traînait dans `LigneSimple`.

## Ce qui n'est pas couvert

- **Le rang survit ailleurs**, sous exactement la même forme « tableau rempli au rendu, relu au
  clic » : soute (`retirerLot`), fil d'étapes, carte du parcours, autocomplétion. Ce lot ne traite
  que les tables de trajets, et les commentaires le disent sans exagérer.
- **`VueTrajets` garde `key={i}`**, et c'est un défaut réel mais **pré-existant** : l'état de
  `ValeurEditable` reste ancré au rang, donc une correction ouverte pendant un re-tri peut s'écrire
  sur une autre commodité. Même mécanisme que #125, sous une autre forme. Ouvert en **#128** plutôt
  que corrigé ici — il ne relève pas de la délégation d'événements mais de la réconciliation React.
- Les trois tests sont des **caractérisations** : verts sur `v2/main` comme ici, rouges seulement
  sous mutation injectée. C'est le contrat correct pour un refactor, pas un test rouge-avant-vert.
- Aucun relevé DOM ici : le rendu ne change pas (seul un attribut `data-row` mort disparaît), et le
  contrat est comportemental — c'est ce que gardent les trois tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
