### PR TITLE
docs(doc): ADR-011 — finir la refonte, ce qu'on n'aurait pas écrit

### DIFF
--- a/docs/superpowers/specs/2026-08-16-demontage-app-js-adr.md
+++ b/docs/superpowers/specs/2026-08-16-demontage-app-js-adr.md
@@ -1,20 +1,19 @@
-# ADR-011 : Démonter `app.js` — par la persistance, pas par l'état
+# ADR-011 : `app.js` disparaît — une seule racine React, un seul état
 
 **Statut :** Proposé
 **Date :** 2026-08-16
 **Décideur :** 0xKestrelNova (propriétaire du dépôt)
 **Issue :** #96 · **Jalon :** v2.0.0
+**Amende :** ADR-008 §4 (le corollaire « verte en permanence »)
 
 ## Contexte
 
 Treize îlots React ont remplacé le rendu de toutes les vues et cartes (#109 → #127), la dernière
-lecture par rang des tables de trajets a disparu (#129), et le code mort laissé derrière a été
-retiré (#130). Le carnet de route disait alors, en toutes lettres, que les tableaux indexés par rang
-étaient « **le préalable à la suppression d'`app.js`** ».
+lecture par rang des tables de trajets a disparu (#129), et le code mort a été retiré (#130).
 
-**C'était faux, et il vaut mieux l'écrire que le contourner.** Sortir le rang a retiré une
-soixantaine de lignes. Retirer tout le code mort en a retiré 123 de plus. `app.js` fait encore
-**3 454 lignes**.
+Le carnet de route disait que les tableaux indexés par rang étaient « le préalable à la suppression
+d'`app.js` ». Mesuré : sortir le rang a retiré une soixantaine de lignes, le code mort 123 de plus,
+et le fichier fait encore **3 454 lignes**.
 
 ### Ce qui reste dedans, mesuré le 2026-08-16 (pas supposé)
 
@@ -23,200 +22,193 @@ soixantaine de lignes. Retirer tout le code mort en a retiré 123 de plus. `app.
 | Lignes | 3 454 |
 | Fonctions de premier niveau | 159 |
 | **dont touchant le DOM ou une globale mutable** | **135 — 3 110 lignes** |
-| dont pures | **24 — 295 lignes** |
+| dont pures | 24 — 295 lignes |
 | Globales **mutables** | 63 |
 | Écouteurs (`document` / élément) | 56 (6 / 50) |
 | Appels à `peindre()` | 41 |
 | `innerHTML` restants | 9, tous légitimes (datalists, `#meta`, `#railStatus`…) |
 
-Les fonctions « pures » ne sont pas une réserve à extraire : les plus grosses de cette liste étaient
-précisément le **code mort** retiré en #130. Ce qui reste de pur est fait de formateurs de trois
-lignes, déjà à leur place.
-
 > **Comment c'est compté**, pour que le chiffre soit rejouable et critiquable : une fonction est
 > dite « liée » si son corps contient `$(`, `document.`, `window.`, `localStorage`,
-> `addEventListener`, `.innerHTML`, `peindre(`, ou le nom d'une des globales mutables. La mesure est
-> donc **grossière et par excès** — une fonction qui ne fait que *lire* `MARKET` y tombe comme celle
-> qui l'écrit. Elle suffit à l'ordre de grandeur, qui est ce que cet ADR utilise ; elle ne suffirait
-> pas à décider quoi extraire ligne à ligne.
+> `addEventListener`, `.innerHTML`, `peindre(`, ou le nom d'une globale mutable. La mesure est donc
+> **grossière et par excès** — lire `MARKET` y compte comme l'écrire. Elle suffit à l'ordre de
+> grandeur, pas à décider ligne à ligne.
 
-**`app.js` n'est pas un résidu de migration : c'est la coquille de l'application.** Il porte l'état
-partagé (`ROUTES`, `MARKET`, `JOURNEY`, `SOUTE`, `OVERRIDES`, `STARMAP`, la vue courante, les clés
-de tri…), le chargement des données, la persistance et les permaliens, l'orchestration du rendu par
-`refresh()`, le câblage des 56 écouteurs et l'amorçage. Rien de tout cela ne « part dans un îlot ».
+`app.js` porte l'état partagé, le chargement des données, la persistance, l'orchestration du rendu
+par `refresh()`, le câblage des 56 écouteurs et l'amorçage. **Ce n'est pas un résidu de migration :
+c'est la coquille de l'application.**
 
-### Les six blocs, par taille
+### L'erreur que cet ADR corrige
 
-| lignes | bloc |
-|---:|---|
-| 576 | Vue « Commodités » — **inclut le câblage complet et l'amorçage** (la dernière section court jusqu'à la fin du fichier) |
-| 417 | Édition inline des manifestes de jambe (persistée en `localStorage`, hors lien) |
-| 377 | Plan de vol |
-| 359 | Le chargement qu'on compose à la main (#19) |
-| 303 | Frais d'autoload |
-| 245 | La soute |
-| 223 | **Persistance & permaliens** |
-| 191 | « En route » |
-| … | le reste, par tranches de 12 à 156 |
+Sa première rédaction concluait : ne pas supprimer `app.js`, l'alléger par les bords, ne pas toucher
+à l'état ni à `refresh()`. Le raisonnement s'appuyait, sans le dire, sur une exigence de **livrable
+à chaque étape**.
 
-### Quatre contraintes que tout découpage doit respecter
+**Cette exigence n'a pas lieu d'être ici.** `v2/main` n'est pas déployée — c'est la raison d'être de
+la branche longue (ADR-008 §3) : `main` sert la v1 pendant toute la refonte. Rien de visible ne
+casse si `v2/main` est rouge quelques jours.
 
-1. **`refresh()` est le point de propagation UNIQUE et prouvé complet.** C'est l'atout qui a permis
-   la cohabitation React sans magasin : `pont.js` le dit, et l'ADR-008 s'y adosse. Toute mutation
-   d'état partagé finit par l'appeler dans la même pile — vérifié sur les 17 écritures de `SOUTE`,
-   les 8 de `JOURNEY`, les 5 d'`OVERRIDES`. Lui ajouter un rival crée deux vérités à tenir
-   d'accord, ce que la refonte cherchait justement à supprimer.
+Le « une branche longue n'est tenable que si elle est verte en permanence » de l'ADR-008 §4 est le
+**corollaire de la migration vue par vue** — une phase désormais terminée. Le **critère de fusion**,
+lui, n'a jamais été par commit : « tous les tests collectés passent, aucun échec », mesuré **à la
+bascule**.
+
+Appliquée à la coquille, l'exigence de livrable écarte mécaniquement la seule option qui atteigne
+l'objectif, et laisse ~2 500 lignes de JavaScript non typé. Ce serait un refactor prudent, pas la
+refonte que l'ADR-008 a décidée.
+
+### Trois contraintes qui, elles, restent entières
+
+1. **Le contrat de sélecteurs ne bouge pas** — ids, classes, attributs `data-*` (ADR-008 §4). C'est
+   ce qui fait des 226 e2e un **harnais** : c'est parce qu'ils ne changent pas qu'un rouge
+   transitoire est lisible, et qu'un vert final prouve quelque chose. **Cette contrainte est ce qui
+   rend le rouge acceptable, pas ce qui l'interdit.**
 2. **Des tests lisent `app.js` comme du TEXTE.** `logic.test.mjs:116` en fait un `readFileSync` puis
    cherche `function fiabiliteCell(` ; `scripts/jetons.test.mjs:131` y cherche des littéraux de
-   couleur. Déplacer ou renommer une fonction ancrée ainsi **casse un test unitaire** sans
-   qu'aucun type ni aucun e2e ne prévienne. C'est délibéré : c'est le seul moyen qu'a `node --test`
-   de garder une règle qui vit hors de `logic.ts`.
-3. **Le nom du fichier est une API.** `index.html:434`, `sw.js:14` et `.github/workflows/
-   update-data.yml:71` le nomment ; `vite.config.mjs` réécrit le `SHELL` de `sw.js` avec ce que le
-   build a réellement émis, précisément parce que ces noms sont écrits à la main quelque part.
-4. **Le contrat e2e ne bouge pas** : ids, classes et attributs `data-*` restent (ADR-008 §4). Un
-   découpage qui les touche perd le harnais qui le valide.
+   couleur. Ces ancres suivront le code à la main — rien ne les avertira.
+3. **Le nom du fichier est écrit ailleurs** : `index.html:434`, `sw.js:14`,
+   `update-data.yml:71` ; `vite.config.mjs` réécrit déjà le `SHELL` de `sw.js` avec ce que le build
+   émet réellement.
 
-### Un obstacle voisin, découvert en mesurant (issue #131)
+### Un obstacle voisin, découvert en mesurant — issue #131
 
-`update-data.yml` copie encore les sources à la main — dont `logic.mjs`, **qui n'existe plus depuis
-#106** — et ne lance aucun build. Le workflow ne tourne que sur `main`, donc rien n'est cassé
-aujourd'hui ; il le sera à la seconde de la bascule. **Ce n'est pas `app.js` qui sépare la v2 de la
-production.** À traiter avant, et indépendamment de cet ADR.
+`update-data.yml:71` copie encore les sources à la main — dont `logic.mjs`, **qui n'existe plus
+depuis #106** — et ne lance aucun build. Le workflow ne tourne que sur `main` : rien n'est cassé
+aujourd'hui, tout le sera à la seconde de la bascule. **Ce n'est pas `app.js` qui sépare la v2 de la
+production.** À traiter en premier, indépendamment de cet ADR.
 
 ## Décision
 
-**On ne « supprime » pas `app.js`. On l'allège par les BORDS, en commençant par la persistance, et
-on ne touche ni à l'état ni à `refresh()` tant qu'un ADR distinct ne l'aura pas tranché.**
+**`app.js` disparaît pour de bon.** L'application passe à **une seule racine React** possédant la
+page, et à **un seul état** que React observe. `refresh()`, les 41 `peindre()` et les 56 écouteurs
+disparaissent avec le fichier.
 
-Concrètement, dans cet ordre :
+Et, ce qui débloque le reste : **`v2/main` a le droit d'être rouge pendant cette phase.** Le critère
+reste celui de l'ADR-008 §4 — tous les tests collectés passent, aucun échec — **mesuré à la
+bascule**, pas à chaque commit. Cet ADR amende explicitement le corollaire « verte en permanence »,
+qui visait la migration vue par vue et n'a plus d'objet.
 
-1. **`persistance.ts`** — les 223 lignes de « Persistance & permaliens » (`collectState`,
-   `applyState`, `saveState`, la liste blanche, le hash d'URL, `localStorage`). C'est le seul bloc
-   qui soit à la fois gros, cohérent, **déjà couvert par des tests de permalien**, et sans état
-   propre : il lit et écrit des champs par id, il n'en possède aucun.
-2. **`frais.ts`** — la part calculatoire des frais d'autoload (303 l.), après avoir séparé ce qui
-   lit `AUTOLOAD_K` de ce qui ne fait que calculer. Le calcul rejoint `logic.ts` et passe alors sous
-   les 483 tests unitaires (415 ms) au lieu de dépendre de Playwright.
-3. **`manifestes-jambe.ts`** — les 417 lignes de l'édition inline, qui ont leur propre persistance.
-4. **Puis on s'arrête et on réévalue.** L'état et `refresh()` ne bougent pas dans cette séquence.
+### Le mécanisme, et pourquoi il ne crée pas deux vérités
 
-Chaque étape est **une PR, avec sa mesure avant/après**, et laisse la suite verte.
+L'objection qui avait fait refuser un magasin (ADR-008, `pont.js`) était juste : `refresh()` est le
+point de propagation **unique et prouvé complet** — vérifié sur les 17 écritures de `SOUTE`, les 8
+de `JOURNEY`, les 5 d'`OVERRIDES` (`pont.js:7`). Lui donner un rival créerait deux vérités.
+
+Elle ne s'applique pas ici, parce qu'on ne lui donne pas de rival : **on le renomme.** Les globales
+deviennent un module d'état ordinaire, mutable, qui reste la seule source de vérité ; `refresh()`
+devient sa notification ; React s'y abonne par **`useSyncExternalStore`** (React 19, déjà en place).
+Aucun état n'est dupliqué, aucun cadre externe n'est introduit — le point de propagation unique
+change de nom, pas de nature.
+
+C'est ce qui fait de C une opération **mécanique**, et non une réécriture de l'état.
 
 ## Options considérées
 
-### Option A — Ne rien faire
+### Option A — Alléger par les bords (la première rédaction de cet ADR)
 
 | Dimension | Évaluation |
 |---|---|
-| Risque | Nul |
-| Coût | Nul |
-| Ce qu'on garde | Un fichier dense mais densément commenté, couvert par 224 e2e |
+| Risque | Faible |
+| Ce qu'on atteint | ~2 500 lignes de JS non typé, indéfiniment |
 
-**Pour :** aucune régression possible ; le fichier n'est pas illisible, il est long.
-**Contre :** 3 454 lignes de JavaScript **hors du périmètre de `tsc`** (`tsconfig.json` exclut
-`app.js` à dessein) ; 63 globales mutables que rien ne vérifie ; le fichier reste le point de
-contention de toute session, et le jalon v2.0.0 promettait TypeScript.
+**Pour :** chaque PR est relisible et la branche reste verte.
+**Contre :** on ne finit jamais. Trois extractions retirent au mieux 950 lignes sur 3 454, et les
+plus grosses tranches restantes (l'état, l'orchestration, le câblage) sont justement celles que
+l'option s'interdit de toucher. **C'est un refactor, pas une refonte** — et le jalon v2.0.0 promet
+TypeScript et React, pas « un peu moins de JavaScript ».
 
-### Option B — Renommer en `app.ts` d'un bloc, sans découper
-
-| Dimension | Évaluation |
-|---|---|
-| Risque | Élevé, et concentré sur un seul commit |
-| Coût | Une PR énorme, impossible à relire |
-| Gain | `tsc` couvre enfin 3 454 lignes et 63 globales |
-
-**Pour :** le plus gros gain de sûreté par ligne changée ; c'est la marche que `logic.ts` a montée
-avec succès en #106.
-**Contre :** `logic.ts` faisait 2 584 lignes de **fonctions pures** — annoter n'y changeait aucun
-comportement. Ici, 135 fonctions sur 159 touchent le DOM ou une globale : les annotations
-révéleraient des dizaines d'erreurs vraies (nullabilité de `$()`, unions de `MARKET | null`) au
-milieu d'artefacts de réglage, dans une PR que personne ne peut relire. Et le renommage casse
-`logic.test.mjs:116` (`new URL("./app.js")`), `sw.js:14`, `index.html:434` et le `cp` de
-`update-data.yml` **le même jour**.
-
-### Option C — Découper en modules ES, `refresh()` préservé (retenue)
+### Option B — Renommer en `app.ts` d'un bloc, sans changer l'architecture
 
 | Dimension | Évaluation |
 |---|---|
-| Risque | Faible par étape, mesurable |
-| Coût | Plusieurs PR, étalées |
-| Gain | Chaque module extrait entre dans `tsconfig.include` et devient typé |
+| Risque | Moyen |
+| Ce qu'on atteint | 3 454 lignes typées, mêmes 63 globales, même `refresh()` |
 
-**Pour :** l'unité de travail est la PR, pas le fichier ; chaque étape se juge sur son propre
-avant/après ; on peut s'arrêter à tout moment sans laisser un chantier ouvert.
-**Contre, et c'est le vrai obstacle technique :** les liaisons ES sont **vivantes en lecture, mais
-non réassignables depuis l'extérieur**. Un module qui importe `MARKET` le voit changer ; il ne peut
-pas écrire `MARKET = …`. Donc tout bloc extrait qui **écrit** une globale a besoin d'un accesseur —
-c'est-à-dire d'un embryon de magasin. **C'est pourquoi l'ordre commence par la persistance :** elle
-lit l'état et écrit des champs du DOM, elle ne réassigne aucune globale. Elle est la seule grosse
-tranche à passer sans rien inventer.
+**Pour :** `tsc` couvre enfin la coquille, pour un diff mécanique.
+**Contre :** on type l'architecture qu'on voulait remplacer. Les 41 `peindre()` et les 56 écouteurs
+restent ; les îlots restent des îlots pilotés de l'extérieur. C'est une étape possible **à
+l'intérieur** de C, pas une destination.
 
-### Option D — Introduire un magasin et dissoudre l'état
+### Option C — Une racine, un état, `app.js` disparaît (retenue)
 
 | Dimension | Évaluation |
 |---|---|
-| Risque | Le plus élevé du lot |
-| Coût | Une refonte dans la refonte |
-| Gain | L'architecture « propre » |
+| Risque | Élevé, mais **borné et mesurable** : le contrat de sélecteurs est inchangé |
+| Ce qu'on atteint | L'objectif de l'ADR-008 : plus de coquille, tout en TypeScript |
 
-**Pour :** c'est la fin logique du chemin, et ça rendrait les 63 globales explicites.
-**Contre :** l'ADR-008 et `pont.js` ont **explicitement refusé** un magasin, avec un argument qui n'a
-pas changé — `refresh()` est déjà le point de propagation unique et prouvé complet. Le remplacer
-n'est pas un découpage : c'est changer la vérité de l'application, en une fois, sur une branche
-longue. À décider dans son propre ADR, si un besoin le justifie un jour. Le confort de lecture n'en
-est pas un.
+**Pour :** les îlots cessent d'être des îlots ; le rendu redevient une fonction de l'état, ce que
+41 `peindre()` appelés à la main imitent péniblement. Le câblage disparaît dans le JSX. C'est la
+seule option après laquelle il n'y a plus rien à démonter.
+**Contre :** la branche sera rouge entre le début et la fin de la phase. C'est le coût, et il est
+payable **parce que la branche n'est pas déployée** et que les sélecteurs ne changent pas — donc le
+retour au vert est un critère net, pas une impression.
+
+### Option D — Repartir d'une page blanche
+
+**Pour :** le résultat le plus propre en théorie.
+**Contre :** on jetterait `logic.ts` (2 584 lignes, 483 tests) et le contrat de sélecteurs, c'est-à-
+dire les deux seules choses qui rendent cette refonte vérifiable. Écartée sans hésitation.
 
 ## Analyse des arbitrages
 
-**B contre C.** B maximise le gain de typage par ligne changée ; C maximise la relisibilité. Le
-départage n'est pas esthétique : `logic.ts` a réussi parce que **470 tests en 385 ms** (ADR-008 §5)
-disaient si une annotation avait changé un comportement. `app.js` n'a pas d'équivalent — ce qui le
-couvre, ce sont **224 e2e à 1,4 min**, qui ne disent rien tant que l'application ne démarre pas. Une
-PR de 3 454 lignes s'y débogue par bissection manuelle. **C gagne parce que le harnais de
-vérification est lent, pas parce que le code serait plus beau.**
+**A contre C.** A minimise le risque par PR ; C minimise le risque **total**, parce qu'il est le
+seul à finir. Une refonte qui s'arrête à mi-chemin laisse deux architectures à entretenir en même
+temps — l'état impératif et les îlots — ce qui est plus coûteux que l'une ou l'autre. **Le vrai
+danger de cette étape n'est pas de casser la branche, c'est de ne jamais la terminer.**
 
-**C contre D.** Les deux finissent au même endroit si on va au bout. C peut s'arrêter en chemin sans
-rien laisser d'incohérent ; D est indivisible. Sur une branche longue qui doit rester verte en
-permanence, l'indivisible est le vrai coût.
+**B contre C.** B est une bonne première marche *dans* C : typer avant de déplacer rend chaque
+déplacement vérifiable par `tsc` plutôt que par Playwright. Le plan ci-dessous la garde à ce titre,
+sans en faire une destination.
 
-**Ce qui pourrait faire changer d'avis.** Si l'extraction de la persistance montre que le typage
-révèle des bugs réels (et non du bruit), la marche B redevient intéressante pour le reste : on
-saurait alors que le rapport signal/bruit est bon. **Cette première PR est donc aussi une mesure.**
+**Ce qui pourrait faire changer d'avis.** Si l'étape 1 (l'état sous `useSyncExternalStore`) montre
+que le nombre de re-rendus explose — la garde existe déjà : `smoke.pw.mjs` plafonne à **2 lots de
+rendu de `#rows` par frappe** —, alors le modèle d'abonnement est à revoir avant d'aller plus loin.
+C'est une mesure, pas une opinion, et elle arrive tôt.
 
 ## Conséquences
 
 **Ce qui devient plus facile**
-- Chaque bloc extrait entre dans `tsconfig.include` et gagne `tsc` — la seule vérification rapide
-  dont dispose ce dépôt hors des tests unitaires.
-- La persistance, une fois isolée, devient testable par `node --test` au lieu d'un aller-retour
-  Playwright sur un permalien.
-- `app.js` rétrécit sans qu'aucune session ait à le relire en entier.
+- Le rendu redevient une fonction de l'état : plus de `render*()` à appeler dans le bon ordre, plus
+  de drapeau `synchrone` à propager à la main (le contrat de mesure d'`ajusterRangeeVoyage`, la
+  panne de focus de `#holdAddName`, le `flushSync` de l'édition — trois symptômes du même mal).
+- Tout passe sous `tsc`, y compris les 63 globales, aujourd'hui vérifiées par rien.
+- `strictNullChecks` et `noImplicitAny` deviennent atteignables : ils échouaient sur du JS invisible
+  au compilateur.
 
 **Ce qui devient plus difficile**
-- **Une frontière de plus à traverser** pour lire un chemin de bout en bout. Aujourd'hui tout est
-  dans un fichier ; demain il faudra savoir dans lequel regarder.
-- Les tests qui lisent `app.js` comme du texte devront suivre chaque déplacement, **à la main** :
-  rien ne les avertira.
-- Le nom `app.js` reste, et reste écrit dans `sw.js` et le déploiement. Tant qu'il subsiste, la
-  situation est *hybride* — c'est le prix assumé de ne pas tout renommer d'un coup.
+- **La branche sera rouge**, et il faut l'assumer sans le banaliser : un rouge qui dure cesse d'être
+  informatif. D'où un garde-fou explicite ci-dessous.
+- Les tests qui lisent `app.js` comme du texte devront suivre à la main.
+- Le diff sera gros. La relecture se fera sur le **résultat** (la suite au vert, le relevé DOM),
+  pas sur le patch — c'est le mode de vérification qui change, pas son exigence.
 
 **Ce qu'il faudra revisiter**
-- Le sort de l'état et de `refresh()`, quand les bords seront partis. C'est là que se pose la vraie
-  question du magasin, et elle mérite son ADR.
-- Le découpage du bundle, que `scripts/coquille.test.mjs:31` renvoie explicitement à « quand la
-  migration sera finie et `app.js` retiré ». Cet ADR remplace cette formule : il n'y aura pas de
-  moment où `app.js` disparaît d'un coup.
+- Le découpage du bundle, que `scripts/coquille.test.mjs:31` renvoie à « quand la migration sera
+  finie et `app.js` retiré » — cette fois, ce moment existera vraiment.
+- Le plafond de coquille (620 000 o), à re-mesurer une fois `app.js` parti.
 
 ## Points d'action
 
-1. [ ] Corriger le déploiement de la bascule — **issue #131**, indépendante et prioritaire sur tout
-       le reste : c'est elle qui sépare la v2 de la production, pas `app.js`.
-2. [ ] **PR 1 — `persistance.ts`** : extraire les 223 lignes, entrer dans `tsconfig.include`,
-       mesurer avant/après (lignes, erreurs `tsc`, temps de suite). Rapporter si le typage a révélé
-       des bugs **réels** — c'est la mesure qui commande la suite.
-3. [ ] **PR 2 — la part calculatoire des frais d'autoload** vers `logic.ts`, avec ses tests
-       unitaires.
-4. [ ] **PR 3 — `manifestes-jambe.ts`**.
-5. [ ] Réévaluer. Ne pas enchaîner sur l'état sans un nouvel ADR.
-6. [ ] Corriger la formule périmée de `scripts/coquille.test.mjs:31` quand cet ADR sera accepté.
+1. [ ] **#131, le déploiement** — avant tout le reste : c'est lui qui sépare la v2 de la production.
+2. [ ] **Étape 1 — `etat.ts`** : les 63 globales dans un module d'état mutable, `refresh()` devenu
+       sa notification, React abonné par `useSyncExternalStore`. `app.js` importe et continue de
+       tourner : **la branche reste verte** ici, et la mesure des re-rendus se fait à ce moment.
+3. [ ] **Étape 2 — une racine unique** : les 41 `peindre()` fusionnent en un arbre. **La branche
+       peut passer au rouge.**
+4. [ ] **Étape 3 — le câblage** : les 56 écouteurs deviennent des props JSX ; la persistance et le
+       chargement des données deviennent des modules TypeScript.
+5. [ ] **Étape 4 — `app.js` est supprimé**, `index.html` charge `main.tsx`. Les ancres textuelles de
+       `logic.test.mjs` et `scripts/jetons.test.mjs` sont repointées. **Retour au vert exigé ici.**
+6. [ ] **Étape 5** — `strictNullChecks`, puis `noImplicitAny`, chacun dans sa PR.
+7. [ ] Corriger la formule périmée de `scripts/coquille.test.mjs:31`.
+
+### Le garde-fou du rouge
+
+Le droit d'être rouge n'est pas un droit d'être aveugle. Pendant les étapes 2 à 4 :
+
+- l'état de la suite est **relevé et écrit dans la PR à chaque poussée** (« 118/226, les 108 échecs
+  sont tous dans `smoke` et `plan` ») — un rouge non chiffré est un rouge qu'on ne contrôle plus ;
+- **aucune fusion vers `v2/main` tant que la suite n'est pas revenue au vert** : le rouge vit dans
+  la branche de travail, jamais dans la branche d'intégration ;
+- si le vert n'est pas retrouvé au bout de **deux étapes**, on s'arrête et on rouvre cet ADR plutôt
+  que de continuer à l'aveugle.

--- a/docs/superpowers/specs/2026-08-16-demontage-app-js-adr.md
+++ b/docs/superpowers/specs/2026-08-16-demontage-app-js-adr.md
@@ -1,0 +1,222 @@
+# ADR-011 : Démonter `app.js` — par la persistance, pas par l'état
+
+**Statut :** Proposé
+**Date :** 2026-08-16
+**Décideur :** 0xKestrelNova (propriétaire du dépôt)
+**Issue :** #96 · **Jalon :** v2.0.0
+
+## Contexte
+
+Treize îlots React ont remplacé le rendu de toutes les vues et cartes (#109 → #127), la dernière
+lecture par rang des tables de trajets a disparu (#129), et le code mort laissé derrière a été
+retiré (#130). Le carnet de route disait alors, en toutes lettres, que les tableaux indexés par rang
+étaient « **le préalable à la suppression d'`app.js`** ».
+
+**C'était faux, et il vaut mieux l'écrire que le contourner.** Sortir le rang a retiré une
+soixantaine de lignes. Retirer tout le code mort en a retiré 123 de plus. `app.js` fait encore
+**3 454 lignes**.
+
+### Ce qui reste dedans, mesuré le 2026-08-16 (pas supposé)
+
+| | |
+|---|---|
+| Lignes | 3 454 |
+| Fonctions de premier niveau | 159 |
+| **dont touchant le DOM ou une globale mutable** | **135 — 3 110 lignes** |
+| dont pures | **24 — 295 lignes** |
+| Globales **mutables** | 63 |
+| Écouteurs (`document` / élément) | 56 (6 / 50) |
+| Appels à `peindre()` | 41 |
+| `innerHTML` restants | 9, tous légitimes (datalists, `#meta`, `#railStatus`…) |
+
+Les fonctions « pures » ne sont pas une réserve à extraire : les plus grosses de cette liste étaient
+précisément le **code mort** retiré en #130. Ce qui reste de pur est fait de formateurs de trois
+lignes, déjà à leur place.
+
+> **Comment c'est compté**, pour que le chiffre soit rejouable et critiquable : une fonction est
+> dite « liée » si son corps contient `$(`, `document.`, `window.`, `localStorage`,
+> `addEventListener`, `.innerHTML`, `peindre(`, ou le nom d'une des globales mutables. La mesure est
+> donc **grossière et par excès** — une fonction qui ne fait que *lire* `MARKET` y tombe comme celle
+> qui l'écrit. Elle suffit à l'ordre de grandeur, qui est ce que cet ADR utilise ; elle ne suffirait
+> pas à décider quoi extraire ligne à ligne.
+
+**`app.js` n'est pas un résidu de migration : c'est la coquille de l'application.** Il porte l'état
+partagé (`ROUTES`, `MARKET`, `JOURNEY`, `SOUTE`, `OVERRIDES`, `STARMAP`, la vue courante, les clés
+de tri…), le chargement des données, la persistance et les permaliens, l'orchestration du rendu par
+`refresh()`, le câblage des 56 écouteurs et l'amorçage. Rien de tout cela ne « part dans un îlot ».
+
+### Les six blocs, par taille
+
+| lignes | bloc |
+|---:|---|
+| 576 | Vue « Commodités » — **inclut le câblage complet et l'amorçage** (la dernière section court jusqu'à la fin du fichier) |
+| 417 | Édition inline des manifestes de jambe (persistée en `localStorage`, hors lien) |
+| 377 | Plan de vol |
+| 359 | Le chargement qu'on compose à la main (#19) |
+| 303 | Frais d'autoload |
+| 245 | La soute |
+| 223 | **Persistance & permaliens** |
+| 191 | « En route » |
+| … | le reste, par tranches de 12 à 156 |
+
+### Quatre contraintes que tout découpage doit respecter
+
+1. **`refresh()` est le point de propagation UNIQUE et prouvé complet.** C'est l'atout qui a permis
+   la cohabitation React sans magasin : `pont.js` le dit, et l'ADR-008 s'y adosse. Toute mutation
+   d'état partagé finit par l'appeler dans la même pile — vérifié sur les 17 écritures de `SOUTE`,
+   les 8 de `JOURNEY`, les 5 d'`OVERRIDES`. Lui ajouter un rival crée deux vérités à tenir
+   d'accord, ce que la refonte cherchait justement à supprimer.
+2. **Des tests lisent `app.js` comme du TEXTE.** `logic.test.mjs:116` en fait un `readFileSync` puis
+   cherche `function fiabiliteCell(` ; `scripts/jetons.test.mjs:131` y cherche des littéraux de
+   couleur. Déplacer ou renommer une fonction ancrée ainsi **casse un test unitaire** sans
+   qu'aucun type ni aucun e2e ne prévienne. C'est délibéré : c'est le seul moyen qu'a `node --test`
+   de garder une règle qui vit hors de `logic.ts`.
+3. **Le nom du fichier est une API.** `index.html:434`, `sw.js:14` et `.github/workflows/
+   update-data.yml:71` le nomment ; `vite.config.mjs` réécrit le `SHELL` de `sw.js` avec ce que le
+   build a réellement émis, précisément parce que ces noms sont écrits à la main quelque part.
+4. **Le contrat e2e ne bouge pas** : ids, classes et attributs `data-*` restent (ADR-008 §4). Un
+   découpage qui les touche perd le harnais qui le valide.
+
+### Un obstacle voisin, découvert en mesurant (issue #131)
+
+`update-data.yml` copie encore les sources à la main — dont `logic.mjs`, **qui n'existe plus depuis
+#106** — et ne lance aucun build. Le workflow ne tourne que sur `main`, donc rien n'est cassé
+aujourd'hui ; il le sera à la seconde de la bascule. **Ce n'est pas `app.js` qui sépare la v2 de la
+production.** À traiter avant, et indépendamment de cet ADR.
+
+## Décision
+
+**On ne « supprime » pas `app.js`. On l'allège par les BORDS, en commençant par la persistance, et
+on ne touche ni à l'état ni à `refresh()` tant qu'un ADR distinct ne l'aura pas tranché.**
+
+Concrètement, dans cet ordre :
+
+1. **`persistance.ts`** — les 223 lignes de « Persistance & permaliens » (`collectState`,
+   `applyState`, `saveState`, la liste blanche, le hash d'URL, `localStorage`). C'est le seul bloc
+   qui soit à la fois gros, cohérent, **déjà couvert par des tests de permalien**, et sans état
+   propre : il lit et écrit des champs par id, il n'en possède aucun.
+2. **`frais.ts`** — la part calculatoire des frais d'autoload (303 l.), après avoir séparé ce qui
+   lit `AUTOLOAD_K` de ce qui ne fait que calculer. Le calcul rejoint `logic.ts` et passe alors sous
+   les 483 tests unitaires (415 ms) au lieu de dépendre de Playwright.
+3. **`manifestes-jambe.ts`** — les 417 lignes de l'édition inline, qui ont leur propre persistance.
+4. **Puis on s'arrête et on réévalue.** L'état et `refresh()` ne bougent pas dans cette séquence.
+
+Chaque étape est **une PR, avec sa mesure avant/après**, et laisse la suite verte.
+
+## Options considérées
+
+### Option A — Ne rien faire
+
+| Dimension | Évaluation |
+|---|---|
+| Risque | Nul |
+| Coût | Nul |
+| Ce qu'on garde | Un fichier dense mais densément commenté, couvert par 224 e2e |
+
+**Pour :** aucune régression possible ; le fichier n'est pas illisible, il est long.
+**Contre :** 3 454 lignes de JavaScript **hors du périmètre de `tsc`** (`tsconfig.json` exclut
+`app.js` à dessein) ; 63 globales mutables que rien ne vérifie ; le fichier reste le point de
+contention de toute session, et le jalon v2.0.0 promettait TypeScript.
+
+### Option B — Renommer en `app.ts` d'un bloc, sans découper
+
+| Dimension | Évaluation |
+|---|---|
+| Risque | Élevé, et concentré sur un seul commit |
+| Coût | Une PR énorme, impossible à relire |
+| Gain | `tsc` couvre enfin 3 454 lignes et 63 globales |
+
+**Pour :** le plus gros gain de sûreté par ligne changée ; c'est la marche que `logic.ts` a montée
+avec succès en #106.
+**Contre :** `logic.ts` faisait 2 584 lignes de **fonctions pures** — annoter n'y changeait aucun
+comportement. Ici, 135 fonctions sur 159 touchent le DOM ou une globale : les annotations
+révéleraient des dizaines d'erreurs vraies (nullabilité de `$()`, unions de `MARKET | null`) au
+milieu d'artefacts de réglage, dans une PR que personne ne peut relire. Et le renommage casse
+`logic.test.mjs:116` (`new URL("./app.js")`), `sw.js:14`, `index.html:434` et le `cp` de
+`update-data.yml` **le même jour**.
+
+### Option C — Découper en modules ES, `refresh()` préservé (retenue)
+
+| Dimension | Évaluation |
+|---|---|
+| Risque | Faible par étape, mesurable |
+| Coût | Plusieurs PR, étalées |
+| Gain | Chaque module extrait entre dans `tsconfig.include` et devient typé |
+
+**Pour :** l'unité de travail est la PR, pas le fichier ; chaque étape se juge sur son propre
+avant/après ; on peut s'arrêter à tout moment sans laisser un chantier ouvert.
+**Contre, et c'est le vrai obstacle technique :** les liaisons ES sont **vivantes en lecture, mais
+non réassignables depuis l'extérieur**. Un module qui importe `MARKET` le voit changer ; il ne peut
+pas écrire `MARKET = …`. Donc tout bloc extrait qui **écrit** une globale a besoin d'un accesseur —
+c'est-à-dire d'un embryon de magasin. **C'est pourquoi l'ordre commence par la persistance :** elle
+lit l'état et écrit des champs du DOM, elle ne réassigne aucune globale. Elle est la seule grosse
+tranche à passer sans rien inventer.
+
+### Option D — Introduire un magasin et dissoudre l'état
+
+| Dimension | Évaluation |
+|---|---|
+| Risque | Le plus élevé du lot |
+| Coût | Une refonte dans la refonte |
+| Gain | L'architecture « propre » |
+
+**Pour :** c'est la fin logique du chemin, et ça rendrait les 63 globales explicites.
+**Contre :** l'ADR-008 et `pont.js` ont **explicitement refusé** un magasin, avec un argument qui n'a
+pas changé — `refresh()` est déjà le point de propagation unique et prouvé complet. Le remplacer
+n'est pas un découpage : c'est changer la vérité de l'application, en une fois, sur une branche
+longue. À décider dans son propre ADR, si un besoin le justifie un jour. Le confort de lecture n'en
+est pas un.
+
+## Analyse des arbitrages
+
+**B contre C.** B maximise le gain de typage par ligne changée ; C maximise la relisibilité. Le
+départage n'est pas esthétique : `logic.ts` a réussi parce que **470 tests en 385 ms** (ADR-008 §5)
+disaient si une annotation avait changé un comportement. `app.js` n'a pas d'équivalent — ce qui le
+couvre, ce sont **224 e2e à 1,4 min**, qui ne disent rien tant que l'application ne démarre pas. Une
+PR de 3 454 lignes s'y débogue par bissection manuelle. **C gagne parce que le harnais de
+vérification est lent, pas parce que le code serait plus beau.**
+
+**C contre D.** Les deux finissent au même endroit si on va au bout. C peut s'arrêter en chemin sans
+rien laisser d'incohérent ; D est indivisible. Sur une branche longue qui doit rester verte en
+permanence, l'indivisible est le vrai coût.
+
+**Ce qui pourrait faire changer d'avis.** Si l'extraction de la persistance montre que le typage
+révèle des bugs réels (et non du bruit), la marche B redevient intéressante pour le reste : on
+saurait alors que le rapport signal/bruit est bon. **Cette première PR est donc aussi une mesure.**
+
+## Conséquences
+
+**Ce qui devient plus facile**
+- Chaque bloc extrait entre dans `tsconfig.include` et gagne `tsc` — la seule vérification rapide
+  dont dispose ce dépôt hors des tests unitaires.
+- La persistance, une fois isolée, devient testable par `node --test` au lieu d'un aller-retour
+  Playwright sur un permalien.
+- `app.js` rétrécit sans qu'aucune session ait à le relire en entier.
+
+**Ce qui devient plus difficile**
+- **Une frontière de plus à traverser** pour lire un chemin de bout en bout. Aujourd'hui tout est
+  dans un fichier ; demain il faudra savoir dans lequel regarder.
+- Les tests qui lisent `app.js` comme du texte devront suivre chaque déplacement, **à la main** :
+  rien ne les avertira.
+- Le nom `app.js` reste, et reste écrit dans `sw.js` et le déploiement. Tant qu'il subsiste, la
+  situation est *hybride* — c'est le prix assumé de ne pas tout renommer d'un coup.
+
+**Ce qu'il faudra revisiter**
+- Le sort de l'état et de `refresh()`, quand les bords seront partis. C'est là que se pose la vraie
+  question du magasin, et elle mérite son ADR.
+- Le découpage du bundle, que `scripts/coquille.test.mjs:31` renvoie explicitement à « quand la
+  migration sera finie et `app.js` retiré ». Cet ADR remplace cette formule : il n'y aura pas de
+  moment où `app.js` disparaît d'un coup.
+
+## Points d'action
+
+1. [ ] Corriger le déploiement de la bascule — **issue #131**, indépendante et prioritaire sur tout
+       le reste : c'est elle qui sépare la v2 de la production, pas `app.js`.
+2. [ ] **PR 1 — `persistance.ts`** : extraire les 223 lignes, entrer dans `tsconfig.include`,
+       mesurer avant/après (lignes, erreurs `tsc`, temps de suite). Rapporter si le typage a révélé
+       des bugs **réels** — c'est la mesure qui commande la suite.
+3. [ ] **PR 2 — la part calculatoire des frais d'autoload** vers `logic.ts`, avec ses tests
+       unitaires.
+4. [ ] **PR 3 — `manifestes-jambe.ts`**.
+5. [ ] Réévaluer. Ne pas enchaîner sur l'état sans un nouvel ADR.
+6. [ ] Corriger la formule périmée de `scripts/coquille.test.mjs:31` quand cet ADR sera accepté.

--- a/docs/superpowers/specs/2026-08-16-demontage-app-js-adr.md
+++ b/docs/superpowers/specs/2026-08-16-demontage-app-js-adr.md
@@ -1,6 +1,6 @@
 # ADR-011 : Finir la refonte — ce qu'on n'aurait pas écrit
 
-**Statut :** Proposé
+**Statut :** Accepté
 **Date :** 2026-08-16
 **Décideur :** 0xKestrelNova (propriétaire du dépôt)
 **Issue :** #96 · **Jalon :** v2.0.0

--- a/docs/superpowers/specs/2026-08-16-demontage-app-js-adr.md
+++ b/docs/superpowers/specs/2026-08-16-demontage-app-js-adr.md
@@ -1,4 +1,4 @@
-# ADR-011 : `app.js` disparaît — une seule racine React, un seul état
+# ADR-011 : Finir la refonte — ce qu'on n'aurait pas écrit
 
 **Statut :** Proposé
 **Date :** 2026-08-16
@@ -9,206 +9,191 @@
 ## Contexte
 
 Treize îlots React ont remplacé le rendu de toutes les vues et cartes (#109 → #127), la dernière
-lecture par rang des tables de trajets a disparu (#129), et le code mort a été retiré (#130).
+lecture par rang des tables de trajets a disparu (#129), le code mort a été retiré (#130).
 
-Le carnet de route disait que les tableaux indexés par rang étaient « le préalable à la suppression
-d'`app.js` ». Mesuré : sortir le rang a retiré une soixantaine de lignes, le code mort 123 de plus,
-et le fichier fait encore **3 454 lignes**.
+La question posée à cet ADR n'est pas « faut-il supprimer `app.js` ». Elle est :
 
-### Ce qui reste dedans, mesuré le 2026-08-16 (pas supposé)
+> **Si on avait écrit cette application depuis le début en React + Vite + Tailwind + TypeScript,
+> aurait-on écrit ce fichier ?**
 
-| | |
+Posée à chaque fichier du dépôt, elle donne une réponse que « migrer vue par vue » ne donnait pas.
+
+### Le verdict, fichier par fichier
+
+| Fichier | lignes | L'aurait-on écrit ? |
+|---|---:|---|
+| `logic.ts` | 2 609 | **Oui.** Calcul pur, 483 tests en 415 ms. C'est le cœur, et il est déjà à sa place. |
+| `types.ts` | 1 011 | **Oui.** |
+| `vues/*.tsx` | 3 033 | **Oui, mais pas ainsi** — voir plus bas : ce sont des gabarits, pas des composants. |
+| `app.js` | 3 454 | **Non.** La coquille impérative : 63 globales, `refresh()`, 41 `peindre()`, 56 écouteurs, 180 accès `$("id")`. |
+| `index.html` | 441 | **Non, pas sous cette forme.** 114 balises de structure qui seraient des composants ; il resterait un `<head>` et un `<div id="root">`. |
+| `style.css` | 1 529 | **Non à cette taille** — mais **pas pour la raison qu'on croit** (voir « la tentation Tailwind »). |
+| `pont.js` | 25 | **Non.** Un pont entre deux mondes. De zéro : un `createRoot`, une fois. |
+| `rail.js` | 28 | **Non.** Un script classique séparé pour éviter un flash au chargement — un symptôme, pas une pièce. |
+
+### L'écart entre la pile annoncée et le code, mesuré
+
+L'ADR-008 s'intitule « Vite + React + **TypeScript** + **shadcn/ui** », et la PR #108 a installé
+Tailwind 4.3.3. Sur le code d'aujourd'hui :
+
+| | mesure |
 |---|---|
-| Lignes | 3 454 |
-| Fonctions de premier niveau | 159 |
-| **dont touchant le DOM ou une globale mutable** | **135 — 3 110 lignes** |
-| dont pures | 24 — 295 lignes |
-| Globales **mutables** | 63 |
-| Écouteurs (`document` / élément) | 56 (6 / 50) |
-| Appels à `peindre()` | 41 |
-| `innerHTML` restants | 9, tous légitimes (datalists, `#meta`, `#railStatus`…) |
+| Classes distinctes écrites dans les 3 033 lignes de TSX | **279** |
+| dont adossées à une règle de `style.css` | **276** |
+| dont **utilitaires Tailwind** | **0** |
+| Traces de shadcn/ui | **aucune** |
+| Hooks React dans les 12 composants | **13 au total** — 5 `useRef`, 4 `useState`, 4 `useEffect` |
+| `useMemo` · `useContext` · `useSyncExternalStore` | **0 · 0 · 0** |
+| `esc()` (échappement HTML à la main) restants dans `app.js` | **17** |
+| Accès `$("id")` dans `app.js` | **180** |
 
-> **Comment c'est compté**, pour que le chiffre soit rejouable et critiquable : une fonction est
-> dite « liée » si son corps contient `$(`, `document.`, `window.`, `localStorage`,
-> `addEventListener`, `.innerHTML`, `peindre(`, ou le nom d'une globale mutable. La mesure est donc
-> **grossière et par excès** — lire `MARKET` y compte comme l'écrire. Elle suffit à l'ordre de
-> grandeur, pas à décider ligne à ligne.
+**Deux des quatre piliers annoncés sont absents du code.** Tailwind est installé, configuré (11
+directives dans `style.css`) et utilisé par **personne** : sur les 279 classes que les vues
+écrivent, 276 pointent une règle maison et aucune n'est un utilitaire. shadcn n'existe nulle part.
 
-`app.js` porte l'état partagé, le chargement des données, la persistance, l'orchestration du rendu
-par `refresh()`, le câblage des 56 écouteurs et l'amorçage. **Ce n'est pas un résidu de migration :
-c'est la coquille de l'application.**
+Et treize hooks pour douze composants dit le reste : `vues/*.tsx` ne contient pas des composants
+React autonomes, mais des **fabriques d'éléments** pilotées de l'extérieur. On a migré la *syntaxe*
+du rendu, pas l'architecture. C'est exactement la « dette technique colossale » qu'une refonte est
+censée éviter, et elle vient d'avoir été créée par la refonte elle-même.
 
-### L'erreur que cet ADR corrige
+### Ce qui rend le travail faisable
 
-Sa première rédaction concluait : ne pas supprimer `app.js`, l'alléger par les bords, ne pas toucher
-à l'état ni à `refresh()`. Le raisonnement s'appuyait, sans le dire, sur une exigence de **livrable
-à chaque étape**.
+`v2/main` **n'est pas déployée** : c'est une branche de développement, `main` sert la v1 (ADR-008
+§3). Le « verte en permanence » de l'ADR-008 §4 était le corollaire de la migration **vue par vue**,
+une phase terminée ; le critère de fusion se mesure **à la bascule** (« tous les tests collectés
+passent, aucun échec »).
 
-**Cette exigence n'a pas lieu d'être ici.** `v2/main` n'est pas déployée — c'est la raison d'être de
-la branche longue (ADR-008 §3) : `main` sert la v1 pendant toute la refonte. Rien de visible ne
-casse si `v2/main` est rouge quelques jours.
+Et surtout : **le contrat de sélecteurs ne bouge pas** (ids, classes, `data-*`). C'est ce qui fait
+des 226 e2e un harnais — donc ce qui rend un rouge transitoire *lisible* et un vert final
+*probant*. C'est la contrainte qui autorise l'audace, pas celle qui l'interdit.
 
-Le « une branche longue n'est tenable que si elle est verte en permanence » de l'ADR-008 §4 est le
-**corollaire de la migration vue par vue** — une phase désormais terminée. Le **critère de fusion**,
-lui, n'a jamais été par commit : « tous les tests collectés passent, aucun échec », mesuré **à la
-bascule**.
+### Un obstacle voisin — issue #131
 
-Appliquée à la coquille, l'exigence de livrable écarte mécaniquement la seule option qui atteigne
-l'objectif, et laisse ~2 500 lignes de JavaScript non typé. Ce serait un refactor prudent, pas la
-refonte que l'ADR-008 a décidée.
-
-### Trois contraintes qui, elles, restent entières
-
-1. **Le contrat de sélecteurs ne bouge pas** — ids, classes, attributs `data-*` (ADR-008 §4). C'est
-   ce qui fait des 226 e2e un **harnais** : c'est parce qu'ils ne changent pas qu'un rouge
-   transitoire est lisible, et qu'un vert final prouve quelque chose. **Cette contrainte est ce qui
-   rend le rouge acceptable, pas ce qui l'interdit.**
-2. **Des tests lisent `app.js` comme du TEXTE.** `logic.test.mjs:116` en fait un `readFileSync` puis
-   cherche `function fiabiliteCell(` ; `scripts/jetons.test.mjs:131` y cherche des littéraux de
-   couleur. Ces ancres suivront le code à la main — rien ne les avertira.
-3. **Le nom du fichier est écrit ailleurs** : `index.html:434`, `sw.js:14`,
-   `update-data.yml:71` ; `vite.config.mjs` réécrit déjà le `SHELL` de `sw.js` avec ce que le build
-   émet réellement.
-
-### Un obstacle voisin, découvert en mesurant — issue #131
-
-`update-data.yml:71` copie encore les sources à la main — dont `logic.mjs`, **qui n'existe plus
-depuis #106** — et ne lance aucun build. Le workflow ne tourne que sur `main` : rien n'est cassé
-aujourd'hui, tout le sera à la seconde de la bascule. **Ce n'est pas `app.js` qui sépare la v2 de la
-production.** À traiter en premier, indépendamment de cet ADR.
+`update-data.yml:71` copie encore les sources à la main, dont `logic.mjs` **disparu depuis #106**,
+et ne lance aucun build. Rien n'est cassé tant que `v2/main` n'est pas fusionnée dans `main` ; tout
+le sera à la seconde où elle le sera. **Ce n'est pas `app.js` qui sépare la v2 de la production.**
 
 ## Décision
 
-**`app.js` disparaît pour de bon.** L'application passe à **une seule racine React** possédant la
-page, et à **un seul état** que React observe. `refresh()`, les 41 `peindre()` et les 56 écouteurs
-disparaissent avec le fichier.
+**On finit la refonte, on ne l'arrête pas à mi-chemin.** `app.js`, `pont.js` et `rail.js`
+disparaissent ; `index.html` se réduit à sa coquille ; l'état devient un module observé par React ;
+le câblage devient du JSX.
 
-Et, ce qui débloque le reste : **`v2/main` a le droit d'être rouge pendant cette phase.** Le critère
-reste celui de l'ADR-008 §4 — tous les tests collectés passent, aucun échec — **mesuré à la
-bascule**, pas à chaque commit. Cet ADR amende explicitement le corollaire « verte en permanence »,
-qui visait la migration vue par vue et n'a plus d'objet.
+**`v2/main` a le droit d'être rouge pendant cette phase**, et on peut y retirer temporairement ce
+qu'on sait ne pas encore fonctionner. Cet ADR amende le corollaire « verte en permanence » de
+l'ADR-008 §4, qui visait une phase terminée.
 
-### Le mécanisme, et pourquoi il ne crée pas deux vérités
+### Le mécanisme de l'état, et pourquoi il ne crée pas deux vérités
 
-L'objection qui avait fait refuser un magasin (ADR-008, `pont.js`) était juste : `refresh()` est le
-point de propagation **unique et prouvé complet** — vérifié sur les 17 écritures de `SOUTE`, les 8
-de `JOURNEY`, les 5 d'`OVERRIDES` (`pont.js:7`). Lui donner un rival créerait deux vérités.
+L'objection qui avait fait refuser un magasin (ADR-008, `pont.js:7`) était juste : `refresh()` est
+le point de propagation **unique et prouvé complet** — 17 écritures de `SOUTE`, 8 de `JOURNEY`, 5
+d'`OVERRIDES`. Lui donner un rival créerait deux vérités.
 
-Elle ne s'applique pas ici, parce qu'on ne lui donne pas de rival : **on le renomme.** Les globales
-deviennent un module d'état ordinaire, mutable, qui reste la seule source de vérité ; `refresh()`
-devient sa notification ; React s'y abonne par **`useSyncExternalStore`** (React 19, déjà en place).
-Aucun état n'est dupliqué, aucun cadre externe n'est introduit — le point de propagation unique
-change de nom, pas de nature.
+**On ne lui donne pas de rival : on le renomme.** Les 63 globales deviennent un module d'état
+mutable qui reste la seule source de vérité ; `refresh()` devient sa notification ; React s'y abonne
+par **`useSyncExternalStore`** (React 19, déjà présent). Aucun état dupliqué, aucun cadre externe.
+Le point de propagation change de nom, pas de nature — ce qui rend l'opération mécanique.
 
-C'est ce qui fait de C une opération **mécanique**, et non une réécriture de l'état.
+### La tentation Tailwind, et où il faut être critique dans l'autre sens
+
+« Comme si on avait codé avec Tailwind » ne veut pas dire « convertir 1 529 lignes de CSS en
+utilitaires ». Deux choses s'y opposent, et elles sont mesurées :
+
+- **L'identité du site est une palette, pas des espacements.** Le HUD ambre, les 18 opacités, les
+  teintes par système et par famille de commodité — c'est du CSS de thème, et une application
+  écrite de zéro avec Tailwind l'aurait écrit… en CSS de thème (`@theme`), exactement comme
+  aujourd'hui. Le convertir en utilitaires ne rendrait pas le code plus idiomatique, il rendrait le
+  design illisible.
+- **15 règles de `style.css` sont adressées par des classes construites par interpolation**
+  (`` `k-${kind}` ``, `"sys-" + system`) : invisibles à toute analyse statique, donc **élaguées**
+  par une couche Tailwind qui croirait les voir inutilisées. L'ADR-008 l'avait déjà relevé ; c'est
+  toujours vrai.
+
+**Ce qu'une application écrite de zéro aurait fait, et qu'on n'a pas :** la *mise en page* et
+l'*espacement* dans les composants (`flex`, `gap-*`, `p-*`, `grid`), le *thème* en CSS. Aujourd'hui
+la mise en page est aussi dans `style.css`, par classes nommées — c'est **cette moitié-là** qui
+n'aurait pas été écrite. La cible n'est donc pas « `style.css` disparaît », mais « `style.css` ne
+garde que ce qui est de l'identité ».
+
+**shadcn/ui n'est pas un objectif en soi.** L'ADR-008 le nommait comme un moyen ; le dépôt n'a
+aucun composant assez complexe pour le justifier aujourd'hui (pas de dialogue, pas de menu, pas de
+combobox — les `<datalist>` natives font le travail). L'introduire pour tenir un titre serait la
+même erreur que d'avoir installé Tailwind sans s'en servir. Et son CLI redéfinirait `--muted`, qui
+est une **surface** chez lui et un **texte gris** chez nous — **98 références** dans `style.css`.
 
 ## Options considérées
 
-### Option A — Alléger par les bords (la première rédaction de cet ADR)
+### Option A — Alléger par les bords (première rédaction de cet ADR)
 
-| Dimension | Évaluation |
-|---|---|
-| Risque | Faible |
-| Ce qu'on atteint | ~2 500 lignes de JS non typé, indéfiniment |
-
-**Pour :** chaque PR est relisible et la branche reste verte.
+**Pour :** chaque PR relisible, branche toujours verte.
 **Contre :** on ne finit jamais. Trois extractions retirent au mieux 950 lignes sur 3 454, et les
-plus grosses tranches restantes (l'état, l'orchestration, le câblage) sont justement celles que
-l'option s'interdit de toucher. **C'est un refactor, pas une refonte** — et le jalon v2.0.0 promet
-TypeScript et React, pas « un peu moins de JavaScript ».
+tranches restantes — l'état, l'orchestration, le câblage — sont celles que l'option s'interdit de
+toucher. On garderait **deux architectures à entretenir**, ce qui coûte plus cher que l'une ou
+l'autre. **Écartée.**
 
-### Option B — Renommer en `app.ts` d'un bloc, sans changer l'architecture
+### Option B — Renommer `app.js` en `app.ts`, architecture inchangée
 
-| Dimension | Évaluation |
-|---|---|
-| Risque | Moyen |
-| Ce qu'on atteint | 3 454 lignes typées, mêmes 63 globales, même `refresh()` |
+**Pour :** `tsc` couvre la coquille, diff mécanique.
+**Contre :** on type l'architecture qu'on voulait remplacer. Les 41 `peindre()` et les 180 `$("id")`
+restent. Étape possible *dans* C, pas destination.
 
-**Pour :** `tsc` couvre enfin la coquille, pour un diff mécanique.
-**Contre :** on type l'architecture qu'on voulait remplacer. Les 41 `peindre()` et les 56 écouteurs
-restent ; les îlots restent des îlots pilotés de l'extérieur. C'est une étape possible **à
-l'intérieur** de C, pas une destination.
+### Option C — Finir : une racine, un état, le câblage en JSX (retenue)
 
-### Option C — Une racine, un état, `app.js` disparaît (retenue)
-
-| Dimension | Évaluation |
-|---|---|
-| Risque | Élevé, mais **borné et mesurable** : le contrat de sélecteurs est inchangé |
-| Ce qu'on atteint | L'objectif de l'ADR-008 : plus de coquille, tout en TypeScript |
-
-**Pour :** les îlots cessent d'être des îlots ; le rendu redevient une fonction de l'état, ce que
-41 `peindre()` appelés à la main imitent péniblement. Le câblage disparaît dans le JSX. C'est la
-seule option après laquelle il n'y a plus rien à démonter.
-**Contre :** la branche sera rouge entre le début et la fin de la phase. C'est le coût, et il est
-payable **parce que la branche n'est pas déployée** et que les sélecteurs ne changent pas — donc le
-retour au vert est un critère net, pas une impression.
+**Pour :** c'est la seule option après laquelle il ne reste rien à démonter, et la seule qui réponde
+« oui » à la question posée en tête de cet ADR.
+**Contre :** la branche sera rouge entre le début et la fin. Payable **parce que la branche n'est
+pas déployée** et que les sélecteurs ne changent pas.
 
 ### Option D — Repartir d'une page blanche
 
-**Pour :** le résultat le plus propre en théorie.
-**Contre :** on jetterait `logic.ts` (2 584 lignes, 483 tests) et le contrat de sélecteurs, c'est-à-
-dire les deux seules choses qui rendent cette refonte vérifiable. Écartée sans hésitation.
-
-## Analyse des arbitrages
-
-**A contre C.** A minimise le risque par PR ; C minimise le risque **total**, parce qu'il est le
-seul à finir. Une refonte qui s'arrête à mi-chemin laisse deux architectures à entretenir en même
-temps — l'état impératif et les îlots — ce qui est plus coûteux que l'une ou l'autre. **Le vrai
-danger de cette étape n'est pas de casser la branche, c'est de ne jamais la terminer.**
-
-**B contre C.** B est une bonne première marche *dans* C : typer avant de déplacer rend chaque
-déplacement vérifiable par `tsc` plutôt que par Playwright. Le plan ci-dessous la garde à ce titre,
-sans en faire une destination.
-
-**Ce qui pourrait faire changer d'avis.** Si l'étape 1 (l'état sous `useSyncExternalStore`) montre
-que le nombre de re-rendus explose — la garde existe déjà : `smoke.pw.mjs` plafonne à **2 lots de
-rendu de `#rows` par frappe** —, alors le modèle d'abonnement est à revoir avant d'aller plus loin.
-C'est une mesure, pas une opinion, et elle arrive tôt.
+**Contre :** on jetterait `logic.ts` (2 609 lignes, 483 tests) et le contrat de sélecteurs — les
+deux seules choses qui rendent cette refonte *vérifiable*. Écartée sans hésitation. Une refonte
+n'est pas une réécriture : ce qui est déjà idiomatique se garde.
 
 ## Conséquences
 
 **Ce qui devient plus facile**
-- Le rendu redevient une fonction de l'état : plus de `render*()` à appeler dans le bon ordre, plus
-  de drapeau `synchrone` à propager à la main (le contrat de mesure d'`ajusterRangeeVoyage`, la
-  panne de focus de `#holdAddName`, le `flushSync` de l'édition — trois symptômes du même mal).
-- Tout passe sous `tsc`, y compris les 63 globales, aujourd'hui vérifiées par rien.
-- `strictNullChecks` et `noImplicitAny` deviennent atteignables : ils échouaient sur du JS invisible
-  au compilateur.
+- Le rendu redevient une fonction de l'état. Disparaissent avec `refresh()` : le drapeau `synchrone`
+  propagé à la main, le contrat de mesure d'`ajusterRangeeVoyage`, le `flushSync` de l'édition, la
+  panne de focus de `#holdAddName` — quatre symptômes du même mal.
+- `data-i`, `data-row`, `data-leg` cessent d'être un **canal de données** : une fermeture remplace
+  un aller-retour par le DOM. #125 et #128 sont deux instances de ce défaut ; il n'y en aura plus.
+- Les 17 `esc()` disparaissent : React échappe.
+- Tout passe sous `tsc`, y compris les 63 globales que rien ne vérifie aujourd'hui.
 
 **Ce qui devient plus difficile**
-- **La branche sera rouge**, et il faut l'assumer sans le banaliser : un rouge qui dure cesse d'être
-  informatif. D'où un garde-fou explicite ci-dessous.
-- Les tests qui lisent `app.js` comme du texte devront suivre à la main.
-- Le diff sera gros. La relecture se fera sur le **résultat** (la suite au vert, le relevé DOM),
-  pas sur le patch — c'est le mode de vérification qui change, pas son exigence.
-
-**Ce qu'il faudra revisiter**
-- Le découpage du bundle, que `scripts/coquille.test.mjs:31` renvoie à « quand la migration sera
-  finie et `app.js` retiré » — cette fois, ce moment existera vraiment.
-- Le plafond de coquille (620 000 o), à re-mesurer une fois `app.js` parti.
+- **La branche sera rouge**, et un rouge qui dure cesse d'informer — d'où le garde-fou ci-dessous.
+- Les tests qui lisent `app.js` **comme du texte** (`logic.test.mjs:116`,
+  `scripts/jetons.test.mjs:131`) devront suivre à la main : rien ne les avertira.
+- La relecture se fera sur le **résultat** — suite au vert, relevé DOM — et non sur le patch.
 
 ## Points d'action
 
-1. [ ] **#131, le déploiement** — avant tout le reste : c'est lui qui sépare la v2 de la production.
-2. [ ] **Étape 1 — `etat.ts`** : les 63 globales dans un module d'état mutable, `refresh()` devenu
-       sa notification, React abonné par `useSyncExternalStore`. `app.js` importe et continue de
-       tourner : **la branche reste verte** ici, et la mesure des re-rendus se fait à ce moment.
-3. [ ] **Étape 2 — une racine unique** : les 41 `peindre()` fusionnent en un arbre. **La branche
-       peut passer au rouge.**
-4. [ ] **Étape 3 — le câblage** : les 56 écouteurs deviennent des props JSX ; la persistance et le
-       chargement des données deviennent des modules TypeScript.
-5. [ ] **Étape 4 — `app.js` est supprimé**, `index.html` charge `main.tsx`. Les ancres textuelles de
-       `logic.test.mjs` et `scripts/jetons.test.mjs` sont repointées. **Retour au vert exigé ici.**
-6. [ ] **Étape 5** — `strictNullChecks`, puis `noImplicitAny`, chacun dans sa PR.
-7. [ ] Corriger la formule périmée de `scripts/coquille.test.mjs:31`.
+1. [ ] **#131, le déploiement** — avant tout : c'est lui qui sépare la v2 de la production.
+2. [ ] **`etat.ts`** — les 63 globales en module d'état, `refresh()` en notification, abonnement
+       `useSyncExternalStore`. `app.js` importe et continue de tourner : **la branche reste verte**,
+       et c'est là qu'on mesure les re-rendus contre `smoke.pw.mjs:2182` (≤ 2 lots de rendu de
+       `#rows` pour 8 frappes). Si ce compteur explose, on s'arrête et on rouvre cet ADR.
+3. [ ] **Une racine unique** — `index.html` se réduit à `<head>` + `<div id="root">`, ses 114
+       balises deviennent des composants, les 41 `peindre()` fusionnent en un arbre. `pont.js` et
+       `rail.js` disparaissent. **Rouge permis.**
+4. [ ] **Le câblage** — les 56 écouteurs deviennent des props JSX ; persistance et chargement des
+       données deviennent des modules TypeScript qui lisent l'**état**, plus le DOM.
+5. [ ] **`app.js` supprimé**, `index.html` charge `main.tsx`, ancres textuelles repointées.
+       **Retour au vert exigé ici.**
+6. [ ] **La moitié « mise en page » de `style.css`** passe en utilitaires dans les composants. Le
+       thème et les 15 règles interpolées **restent en CSS, hors couche élaguable**.
+7. [ ] `strictNullChecks`, puis `noImplicitAny`, chacun dans sa PR.
+8. [ ] shadcn/ui : **seulement si** un composant à venir le justifie. Ne pas l'introduire pour
+       tenir un titre.
 
 ### Le garde-fou du rouge
 
-Le droit d'être rouge n'est pas un droit d'être aveugle. Pendant les étapes 2 à 4 :
+Le droit d'être rouge n'est pas un droit d'être aveugle. Pendant les étapes 3 et 4 :
 
-- l'état de la suite est **relevé et écrit dans la PR à chaque poussée** (« 118/226, les 108 échecs
-  sont tous dans `smoke` et `plan` ») — un rouge non chiffré est un rouge qu'on ne contrôle plus ;
+- l'état de la suite est **relevé et chiffré dans la PR à chaque poussée** (« 118/226, les 108
+  échecs sont tous dans `smoke` et `plan` ») ;
 - **aucune fusion vers `v2/main` tant que la suite n'est pas revenue au vert** : le rouge vit dans
-  la branche de travail, jamais dans la branche d'intégration ;
+  la branche de travail, jamais dans la branche d'intégration, jamais sur `main` ;
 - si le vert n'est pas retrouvé au bout de **deux étapes**, on s'arrête et on rouvre cet ADR plutôt
   que de continuer à l'aveugle.


### PR DESCRIPTION
## Ce que ça change

Un ADR, aucun code. Il reformule la question posée à cette étape, et la réponse va plus loin que
« démonter `app.js` ».

## La question

> **Si on avait écrit cette application depuis le début en React + Vite + Tailwind + TypeScript,
> aurait-on écrit ce fichier ?**

Posée à chaque fichier — et non au seul `app.js` — elle donne ceci :

| Fichier | lignes | L'aurait-on écrit ? |
|---|---:|---|
| `logic.ts` | 2 609 | **Oui.** Calcul pur, 483 tests en 415 ms. Déjà à sa place. |
| `types.ts` | 1 011 | **Oui.** |
| `vues/*.tsx` | 3 033 | **Oui, mais pas ainsi** — 13 hooks pour 12 composants. |
| `app.js` | 3 454 | **Non.** 63 globales, `refresh()`, 41 `peindre()`, 56 écouteurs, 180 `$("id")`. |
| `index.html` | 441 | **Non sous cette forme.** 114 balises de structure ; il resterait `<head>` + `<div id="root">`. |
| `style.css` | 1 529 | **Non à cette taille** — mais pas pour la raison qu'on croit. |
| `pont.js` · `rail.js` | 25 · 28 | **Non.** Un pont entre deux mondes, et un script séparé contre un flash. |

## L'écart entre la pile annoncée et le code, mesuré

| | |
|---|---|
| Classes distinctes écrites dans les 3 033 lignes de TSX | **279** |
| dont adossées à une règle de `style.css` | **276** |
| dont **utilitaires Tailwind** | **0** |
| Traces de **shadcn/ui** | **aucune** |
| Hooks React dans les 12 composants | **13** — 5 `useRef`, 4 `useState`, 4 `useEffect` |
| `useMemo` · `useContext` · `useSyncExternalStore` | **0 · 0 · 0** |
| `esc()` restants dans `app.js` | **17** |

**Deux des quatre piliers de l'ADR-008 sont absents du code.** Tailwind est installé, configuré (11
directives) et utilisé par personne ; shadcn n'existe nulle part. Treize hooks pour douze composants
dit le reste : `vues/*.tsx` ne contient pas des composants autonomes mais des **fabriques d'éléments
pilotées de l'extérieur**.

**On a migré la syntaxe du rendu, pas l'architecture.** C'est la dette qu'une refonte devait éviter,
et elle vient d'être créée par la refonte elle-même.

## La décision

On finit. `app.js`, `pont.js` et `rail.js` disparaissent ; `index.html` se réduit à sa coquille ;
l'état devient un module observé par React ; le câblage devient du JSX.

**`v2/main` a le droit d'être rouge** — c'est une branche de dev, `main` sert la v1. L'ADR amende
le corollaire « verte en permanence » de l'ADR-008 §4, qui visait la migration vue par vue, une
phase terminée. Le critère de fusion, lui, se mesure **à la bascule** et ne change pas.

**Sur l'état** : l'objection historique au magasin (`refresh()` est le point de propagation unique et
prouvé complet — `pont.js:7`) tient toujours. On ne lui donne pas de rival : **on le renomme.** Les
63 globales deviennent un module mutable qui reste la seule source de vérité, `refresh()` devient sa
notification, React s'abonne par `useSyncExternalStore`. Aucun état dupliqué.

## Critique dans l'autre sens — une refonte se rate aussi par excès de zèle

- **La moitié « identité » de `style.css` reste.** Le HUD ambre, les 18 opacités, les teintes par
  système : une app écrite de zéro avec Tailwind l'aurait **aussi** écrite en CSS de thème. Seule
  la moitié **mise en page** passe en utilitaires.
- **15 règles sont adressées par des classes construites par interpolation** (`` `k-${kind}` ``,
  `"sys-" + system`) : invisibles à l'analyse statique, donc **élaguées** par une couche Tailwind
  qui les croirait mortes.
- **shadcn n'est pas un objectif.** Aucun composant ne le justifie aujourd'hui (les `<datalist>`
  natives font le travail), et son CLI redéfinirait `--muted` — **98 références**, surface chez lui,
  texte gris chez nous. L'introduire pour tenir un titre répéterait l'erreur de Tailwind.
- **`logic.ts` et le contrat de sélecteurs ne se touchent pas.** Ce sont les deux seules choses qui
  rendent cette refonte *vérifiable*. Une refonte n'est pas une réécriture.

## Vérification

**`node --test` → 483 tests, 483 pass, 0 fail.** (Aucun code touché.)

Chiffres mesurés sur l'état d'après #130. **Une correction en route** : ma première mesure annonçait
« 2 utilitaires Tailwind » — c'était un faux positif de mon propre grep. Le relevé exact des 279
classes distinctes en donne **0**, ce qui rend l'argument à la fois plus juste et plus net. De même
`--muted` : 98 références mesurées, non les 92 dont je me souvenais.

## Ce qui n'est pas couvert

- **Statut « Proposé »** : les ADR de ce dépôt portent un décideur nommé.
- L'ADR ne dit pas *comment* les 41 `peindre()` fusionnent en un arbre : ce serait de la conception
  sans mesure. C'est le travail de l'étape 3.
- Le plafond de coquille (620 000 o) devra être re-mesuré une fois `app.js` parti.
- **#131 reste en tête des points d'action** : c'est le déploiement, pas `app.js`, qui sépare
  aujourd'hui la v2 de la production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
