### PR TITLE
fix(ci): le déploiement construit le site au lieu de recopier les sources

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -50,6 +50,10 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: 24
+          # Cache du registre npm : l'assemblage passe désormais par `vite build`, donc ce job
+          # installe. `node --test` ci-dessous n'en a toujours pas besoin (Node 24 exécute le TS en
+          # effaçant les annotations) et tourne AVANT l'installation, comme avant.
+          cache: npm
 
       - name: Tests
         run: node --test
@@ -64,13 +68,28 @@ jobs:
           FORCE: ${{ github.event_name != 'schedule' && '1' || '' }}
         run: node scripts/build-data.mjs
 
+      # L'assemblage passe par le BUILD, et plus par une liste de fichiers écrite à la main.
+      #
+      # Celle-ci nommait encore `logic.mjs`, qui n'existe plus depuis son passage en TypeScript : le
+      # `cp` aurait échoué à la première mise en ligne de la v2. Et même le nom corrigé, elle aurait
+      # publié les SOURCES — `logic.ts`, `vues/*.tsx`, un `index.html` chargeant des modules qu'aucun
+      # navigateur n'exécute. Rien de tout ça ne se voyait : le cron ne tourne que sur la branche par
+      # défaut, et la CI e2e sert `dist/`, jamais `_site/`.
+      #
+      # `vite build` émet un site complet dans `dist/` : bundles hachés, `sw.js` dont le plugin de
+      # précache réécrit le SHELL avec ce qui a RÉELLEMENT été produit, et `data/*.json` recopiés à
+      # la fin du build — donc les données que l'étape précédente vient de régénérer.
+      - name: Construire le site
+        if: steps.build.outputs.changed != 'false'
+        run: |
+          npm ci --no-audit --no-fund
+          npm run build:site
+
       - name: Assembler le site
         if: steps.build.outputs.changed != 'false'
         run: |
-          mkdir -p _site/data _site/fonts
-          cp index.html app.js rail.js logic.mjs style.css manifest.webmanifest sw.js icon.svg _site/
-          cp fonts/* _site/fonts/
-          cp data/*.json _site/data/
+          mkdir -p _site
+          cp -r dist/. _site/
 
       - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b  # v5
         if: steps.build.outputs.changed != 'false'

--- a/scripts/csp.test.mjs
+++ b/scripts/csp.test.mjs
@@ -53,13 +53,31 @@ test("aucun <script> inline dans index.html : script-src 'self' le bloquerait", 
   assert.deepEqual(inlines, []);
 });
 
-test("tout script d'index.html est précaché (sw.js) ET copié à l'assemblage (update-data.yml)", () => {
+test("tout script d'index.html est précaché (sw.js)", () => {
   const srcs = [...html.matchAll(/<script[^>]*\ssrc="([^"]+)"/g)].map((m) => m[1]);
   assert.ok(srcs.includes("rail.js"), "ancre : la bascule du rail est bien devenue un fichier");
   const shell = lire("sw.js").match(/const SHELL = \[([^\]]+)\]/)[1];
-  const cp = lire(".github", "workflows", "update-data.yml").match(/^ *cp (.*) _site\/$/m)[1].split(/\s+/);
   for (const src of srcs) {
     assert.ok(shell.includes(`"./${src}"`), `${src} manque à SHELL : hors-ligne, il ne serait pas servi`);
-    assert.ok(cp.includes(src), `${src} manque au cp de l'assemblage : 404 sur le site publié`);
   }
+});
+
+// La seconde moitié de ce test vérifiait que chaque script figurait dans la ligne `cp` de
+// l'assemblage. Elle CHANGE DE CIBLE plutôt que de disparaître (ADR-008 §7) : il n'y a plus de
+// liste à la main, donc plus rien à comparer nom par nom — mais le risque qu'elle couvrait, lui,
+// AUGMENTE avec un build. Un site publié depuis les sources ne casse rien de visible en CI : les
+// e2e servent `dist/`, jamais `_site/`.
+//
+// Ce que garde ce test, c'est donc l'INVARIANT : l'assemblage passe par le build. C'est
+// exactement ce qui manquait quand la liste nommait encore `logic.mjs`, disparu depuis son passage
+// en TypeScript (#131).
+test("l'assemblage du site passe par le BUILD, jamais par une liste de fichiers à la main (#131)", () => {
+  const wf = lire(".github", "workflows", "update-data.yml");
+  assert.match(wf, /npm ci/, "l'assemblage doit installer avant de construire");
+  assert.match(wf, /npm run build:site/, "l'assemblage doit lancer le build Vite");
+  assert.match(wf, /cp -r dist\/\. _site\//, "l'assemblage doit publier `dist/`, le site réellement produit");
+  assert.ok(
+    !/^ *cp +index\.html/m.test(wf),
+    "la liste de fichiers à la main est revenue : elle publierait les SOURCES, et se périme en silence"
+  );
 });


### PR DESCRIPTION
## Ce que ça change

Le déploiement assemble désormais le site avec `vite build`, au lieu de copier huit fichiers nommés
à la main. **C'est ce qui séparait la v2 de la production.**

## Pourquoi

`update-data.yml` faisait :

```yaml
cp index.html app.js rail.js logic.mjs style.css manifest.webmanifest sw.js icon.svg _site/
```

Deux défauts, et le premier suffit à tout bloquer :

1. **`logic.mjs` n'existe plus** — il est devenu `logic.ts` en #106. `cp` sort en erreur, l'étape
   échoue, rien n'est déployé.
2. **Aucun build n'était lancé.** Même le nom corrigé, `_site/` aurait reçu les **sources** :
   `logic.ts`, `vues/*.tsx`, un `index.html` chargeant des modules qu'aucun navigateur n'exécute.

**Rien de tout ça ne se voyait** : le workflow ne tourne que sur `push: branches: [main]` et sur le
cron — jamais sur `v2/main` — et la CI e2e sert `dist/`, jamais `_site/`. Le défaut était invisible
des deux côtés jusqu'à la seconde où il aurait bloqué la bascule.

C'est exactement ce que l'ADR-008 §7 prévoyait (« le `cp` de huit fichiers devient `npm ci` +
`npm run build` + copie de `dist/` ») et qui n'avait jamais été fait.

## Le test change de cible, il ne disparaît pas

`scripts/csp.test.mjs` vérifiait que chaque `<script src>` d'`index.html` figurait **et** dans le
`SHELL` de `sw.js`, **et** dans la ligne `cp`. Il n'y a plus de liste à comparer nom par nom — mais
le risque qu'il couvrait **augmente** avec un build, pas l'inverse.

Il garde donc l'invariant : l'assemblage passe par le build (`npm ci`, `npm run build:site`,
`cp -r dist/. _site/`), et **la liste à la main ne peut pas revenir**. La moitié « précache » est
inchangée. C'est le « ces tests ne disparaissent pas, ils changent de cible » de l'ADR-008 §7.

## Vérification

**`node --test` → 484 tests, 484 pass, 0 fail** (483 avant, +1 : le nouvel invariant).

Le nouveau test a été **vu rouge** en restaurant l'ancienne étape d'assemblage :

```
✖ l'assemblage du site passe par le BUILD, jamais par une liste de fichiers à la main (#131)
  AssertionError: l'assemblage doit installer avant de construire
```

**Et surtout, l'assemblage a été reproduit à la main**, exactement comme le fera le workflow
(`npm run build:site` puis `cp -r dist/. _site/`) :

- `_site/` contient `assets/`, `data/`, `icon.svg`, `index.html`, `manifest.webmanifest`,
  `rail.js`, `sw.js` ;
- les deux `<script src>` de l'`index.html` publié — `./assets/index-DuaX4Wi4.js` et `rail.js` —
  pointent des fichiers qui **existent** dans `_site/` ;
- le `SHELL` du `sw.js` publié compte **20 entrées, toutes présentes** (`caches.addAll` est
  atomique : une seule manquante ferait disparaître le mode hors-ligne, en silence) ;
- `data/` contient les six JSON, ceux que l'étape précédente vient de régénérer — le build les
  recopie **à la fin**, donc après `build-data.mjs`.

## Ce qui n'est pas couvert

- **Le workflow lui-même n'a pas été exécuté.** Il ne se déclenche que sur `main` et sur le cron ;
  la seule façon de l'éprouver en vrai est la bascule. Ce que je peux affirmer est reproduit
  localement, étape par étape, pas observé en CI.
- `node-version` reste à 24 sur cette branche, contre 20 sur `main` : l'écart se résorbera à la
  bascule, il n'est pas traité ici.
- Le `cache: npm` ajouté au job accélère l'installation ; son effet n'est pas mesuré.
- `sw.js` garde sa liste v1 en clair dans le source (le plugin la réécrit au build) : elle nommera
  encore `app.js` jusqu'à ce que l'ADR-011 le fasse disparaître.

Closes #131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
