### PR TITLE
feat(voyage): etat.ts — le socle de l'état, et la propagation devient explicite

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,6 +27,7 @@ import {
 // Tournée, et RIEN d'autre ne change : app.js reste le seul écrivain de l'état, refresh() reste
 // l'unique notification. Voir pont.js pour pourquoi il n'y a ni magasin ni abonnement.
 import { peindre } from "./pont.js";
+import { notifier } from "./etat.ts";
 import { vueTournee, messageSouteVide, messageChargement, messageOuEsTu } from "./vues/tournee.tsx";
 import { vueBoucles } from "./vues/boucles.tsx";
 import { vueChaine, indiceDepart, indiceSoute, indiceAucune } from "./vues/chaine.tsx";
@@ -2277,6 +2278,10 @@ function refresh() {
   // quand il n'y a rien : les deux sortent tout de suite en masquant leur carte.
   else { renderSoute(); renderEntrepots(); }
   saveState();
+  // La propagation vers `etat.ts` (ADR-011). Elle est APPELÉE, jamais déclenchée par une écriture :
+  // des références vives sortent de l'état et sont mutées dehors (`legIntent`), et `logic.ts` mute
+  // `OVERRIDES` en place pendant le rendu — aucun accesseur ne les verrait. Voir l'en-tête d'etat.ts.
+  notifier();
 }
 const refreshDebounced = debounce(refresh);
 
@@ -2340,6 +2345,7 @@ function setupSort() {
       applySortIndicators(); // classes ET aria-sort, pour les deux tables
       render();
       saveState();
+      notifier(); // rendu CIBLÉ : il ne passe pas par `refresh()`, il propage lui-même
     });
   });
 }
@@ -2353,6 +2359,7 @@ function setupLoopSort() {
       applySortIndicators();
       renderLoops();
       saveState();
+      notifier(); // idem : hors `refresh()`
     });
   });
 }
@@ -2900,6 +2907,7 @@ function setCommSort(key) {
   }
   renderCommodities();
   saveState();
+  notifier(); // idem : hors `refresh()`
 }
 
 // Palier de couleur d'une tuile, RELATIF à la meilleure marge de la liste (heatmap :
@@ -2965,6 +2973,7 @@ function setCommBoard(board) {
   commBoard = board;
   renderCommodities(); // la sélection courante est revalidée par le rendu (elle peut disparaître)
   saveState();
+  notifier(); // idem : hors `refresh()`
 }
 
 // La grille, peinte à part : la sélection d'une tuile la repeint SANS tout recalculer. Avant React,
@@ -3090,6 +3099,7 @@ async function init() {
     peindreGrilleCommodites();
     paintCommodityDetail();
     saveState();
+    notifier(); // idem : hors `refresh()`
   });
   // Contrôles « En route ». Ces champs de terminal sont eux aussi à SAISIE LIBRE (datalist, mais
   // rien n'oblige à choisir dans la liste) : même debounce que ci-dessus. Sans lui, chaque frappe

--- a/docs/superpowers/specs/2026-08-16-demontage-app-js-adr.md
+++ b/docs/superpowers/specs/2026-08-16-demontage-app-js-adr.md
@@ -25,7 +25,7 @@ Posée à chaque fichier du dépôt, elle donne une réponse que « migrer vue p
 | `logic.ts` | 2 609 | **Oui.** Calcul pur, 483 tests en 415 ms. C'est le cœur, et il est déjà à sa place. |
 | `types.ts` | 1 011 | **Oui.** |
 | `vues/*.tsx` | 3 033 | **Oui, mais pas ainsi** — voir plus bas : ce sont des gabarits, pas des composants. |
-| `app.js` | 3 454 | **Non.** La coquille impérative : 63 globales, `refresh()`, 41 `peindre()`, 56 écouteurs, 180 accès `$("id")`. |
+| `app.js` | 3 454 | **Non.** La coquille impérative : 53 globales, `refresh()`, 41 `peindre()`, 56 écouteurs, 180 accès `$("id")`. |
 | `index.html` | 441 | **Non, pas sous cette forme.** 114 balises de structure qui seraient des composants ; il resterait un `<head>` et un `<div id="root">`. |
 | `style.css` | 1 529 | **Non à cette taille** — mais **pas pour la raison qu'on croit** (voir « la tentation Tailwind »). |
 | `pont.js` | 25 | **Non.** Un pont entre deux mondes. De zéro : un `createRoot`, une fois. |
@@ -89,7 +89,7 @@ L'objection qui avait fait refuser un magasin (ADR-008, `pont.js:7`) était just
 le point de propagation **unique et prouvé complet** — 17 écritures de `SOUTE`, 8 de `JOURNEY`, 5
 d'`OVERRIDES`. Lui donner un rival créerait deux vérités.
 
-**On ne lui donne pas de rival : on le renomme.** Les 63 globales deviennent un module d'état
+**On ne lui donne pas de rival : on le renomme.** Les 53 globales deviennent un module d'état
 mutable qui reste la seule source de vérité ; `refresh()` devient sa notification ; React s'y abonne
 par **`useSyncExternalStore`** (React 19, déjà présent). Aucun état dupliqué, aucun cadre externe.
 Le point de propagation change de nom, pas de nature — ce qui rend l'opération mécanique.
@@ -159,7 +159,7 @@ n'est pas une réécriture : ce qui est déjà idiomatique se garde.
 - `data-i`, `data-row`, `data-leg` cessent d'être un **canal de données** : une fermeture remplace
   un aller-retour par le DOM. #125 et #128 sont deux instances de ce défaut ; il n'y en aura plus.
 - Les 17 `esc()` disparaissent : React échappe.
-- Tout passe sous `tsc`, y compris les 63 globales que rien ne vérifie aujourd'hui.
+- Tout passe sous `tsc`, y compris les 53 globales que rien ne vérifie aujourd'hui.
 
 **Ce qui devient plus difficile**
 - **La branche sera rouge**, et un rouge qui dure cesse d'informer — d'où le garde-fou ci-dessous.
@@ -170,7 +170,7 @@ n'est pas une réécriture : ce qui est déjà idiomatique se garde.
 ## Points d'action
 
 1. [ ] **#131, le déploiement** — avant tout : c'est lui qui sépare la v2 de la production.
-2. [ ] **`etat.ts`** — les 63 globales en module d'état, `refresh()` en notification, abonnement
+2. [ ] **`etat.ts`** — les globales en module d'état, `refresh()` en notification, abonnement
        `useSyncExternalStore`. `app.js` importe et continue de tourner : **la branche reste verte**,
        et c'est là qu'on mesure les re-rendus contre `smoke.pw.mjs:2182` (≤ 2 lots de rendu de
        `#rows` pour 8 frappes). Si ce compteur explose, on s'arrête et on rouvre cet ADR.
@@ -186,6 +186,23 @@ n'est pas une réécriture : ce qui est déjà idiomatique se garde.
 7. [ ] `strictNullChecks`, puis `noImplicitAny`, chacun dans sa PR.
 8. [ ] shadcn/ui : **seulement si** un composant à venir le justifie. Ne pas l'introduire pour
        tenir un titre.
+
+### Amendement du 2026-08-16 (PR `etat.ts`) — deux chiffres et une affirmation corrigés
+
+Trois corrections, toutes **mesurées** au moment d'écrire `etat.ts` :
+
+- **53 globales mutables, et non 63.** Le premier décompte découpait les déclarations sur les
+  virgules, y compris à l'intérieur des littéraux et des commentaires. Le compte exact :
+  47 lignes `^let `, dont trois en déclarent plusieurs → 53.
+- **`refresh()` N'EST PAS le point de propagation unique**, contrairement à ce que dit `pont.js:6-7`
+  et à ce que cet ADR répétait. Mesuré sur six gestes, avec un compteur dans `notifier()` : **trier
+  une colonne et basculer le board Commodités ne propageaient RIEN** — ils appellent leur rendu
+  ciblé puis `saveState()`, sans passer par `refresh()`. Cinq sites sont dans ce cas. Ils propagent
+  désormais, et chaque geste mesuré propage exactement une fois.
+- **Le garde-fou annoncé au point d'action 2 donnait un FAUX VERT.** `e2e/smoke.pw.mjs:2182` compte
+  des mutations DOM sur `#rows` pour 8 frappes ; `#search` est un champ du DOM, pas une globale
+  déménagée, et une mutation DOM n'est pas une propagation. La mesure qui tranche est le compteur
+  de `notifier()`, geste par geste, avant et après.
 
 ### Le garde-fou du rouge
 

--- a/etat.ts
+++ b/etat.ts
@@ -1,0 +1,70 @@
+// L'ÉTAT PARTAGÉ (ADR-011, point d'action 2).
+//
+// Première étape du démontage d'`app.js` : les globales mutables déménagent ici, et `refresh()`
+// gagne une notification. `app.js` continue de tourner par-dessus — la branche reste verte à cette
+// étape, et rien ne s'abonne encore.
+//
+// ── POURQUOI UN OBJET, ET PAS CINQUANTE ACCESSEURS ────────────────────────────────────────────
+// Les liaisons ES sont vivantes en LECTURE mais NON RÉASSIGNABLES depuis l'extérieur : un module
+// qui importe `MARKET` le voit changer, il ne peut pas écrire `MARKET = …`. Or **50 des 53
+// globales d'app.js sont réaffectées** (seules `originMap`, `stationMap` et `termByName` ne le sont
+// jamais — elles n'ont donc aucun besoin d'être ici). Écrire une PROPRIÉTÉ (`etat.MARKET = …`) ne
+// réassigne aucune liaison : le déménagement reste mécanique, et app.js continue d'écrire comme
+// avant.
+//
+// ── POURQUOI LA NOTIFICATION RESTE EXPLICITE ──────────────────────────────────────────────────
+// C'est le point qui décide de tout le reste, et ce n'est pas de la prudence : un magasin qui
+// notifierait à l'écriture est ICI IMPOSSIBLE, pas seulement risqué.
+//
+//   1. Des RÉFÉRENCES VIVES sortent de l'état et sont mutées dehors. `legIntent()` (app.js) rend
+//      `JOURNEY_EDITS[k]` tel quel, et l'appelant fait `intent[li].units = …`. Aucun proxy, aucun
+//      accesseur, aucun compteur ne voit cette écriture. Même fuite pour `CHARGEMENTS[k]`,
+//      `MANIFEST_EDIT.lines` et `currentManifest.lines[i].units`.
+//   2. `logic.ts` MUTE `OVERRIDES` EN PLACE, pendant le rendu, à quatre endroits (`effFromStore`,
+//      `setInStore`, `migrerCorrections`, `groupOverridesByTerminal`). On n'y touche pas : 483
+//      tests en dépendent.
+//   3. Trois chemins écrivent l'état PENDANT le rendu (`renderCommodities` revalide `commSelected`,
+//      `legEffectiveLines` réécrit `JOURNEY_EDITS`, `compositionEnCours` réécrit `MANIFEST_EDIT`).
+//      Sous notification automatique, chacun devient une boucle rendu → écriture → rendu.
+//   4. `editLegQty` finit par un `setTimeout(renderJourney, 0)` DÉLIBÉRÉ — « le blur précède le
+//      mouseup d'un clic en cours ». Notifier à l'écriture rejouerait ce bug.
+//
+// Donc : à cette étape, ce module est un DÉMÉNAGEMENT plus un canal de notification appelé à la
+// main. Le magasin réactif, s'il vient, viendra avec la racine unique.
+//
+// ── LE SNAPSHOT EST UN COMPTEUR, JAMAIS L'OBJET ───────────────────────────────────────────────
+// `useSyncExternalStore` compare par `Object.is`. Un objet muté en place rend toujours la même
+// référence : React ne re-rendrait JAMAIS. D'où `version`, incrémentée par `notifier()`.
+
+/** L'état partagé. Une propriété par globale déménagée d'`app.js`. */
+export const etat: Record<string, unknown> = {};
+
+let version = 0;
+const abonnes = new Set<() => void>();
+
+/**
+ * La propagation. C'est `refresh()` renommé — pas un rival : `app.js` l'appelle À LA FIN de son
+ * `refresh()`, et aux rendus ciblés qui ne passent pas par lui.
+ *
+ * `__notifs` est le compteur de MESURE de cette étape (cf. la PR). Il n'existe que si un test l'a
+ * armé, donc il ne coûte rien en production. Il compte les PROPAGATIONS, là où
+ * `e2e/smoke.pw.mjs:2182` compte des mutations DOM sur `#rows` — ce dernier resterait vert quoi
+ * qu'il arrive ici, et donnerait un faux vert.
+ */
+export function notifier(): void {
+  version++;
+  const g = globalThis as { __notifs?: number };
+  if (g.__notifs != null) g.__notifs++;
+  for (const f of abonnes) f();
+}
+
+/** S'abonner aux propagations. Rend la fonction de désabonnement (contrat `useSyncExternalStore`). */
+export function subscribe(f: () => void): () => void {
+  abonnes.add(f);
+  return () => { abonnes.delete(f); };
+}
+
+/** L'instantané comparé par React. Un nombre, jamais l'objet — voir l'en-tête. */
+export function getSnapshot(): number {
+  return version;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,5 +36,5 @@
     "verbatimModuleSyntax": true,
     "jsx": "react-jsx"
   },
-  "include": ["logic.ts", "types.ts", "vues/**/*.tsx"]
+  "include": ["logic.ts", "types.ts", "etat.ts", "vues/**/*.tsx"]
 }


### PR DESCRIPTION
## Ce que ça change

Rien à l'écran. Premier point d'action de l'**ADR-011** : `etat.ts` porte l'objet d'état, un
compteur de version, un `subscribe` au contrat `useSyncExternalStore`, et `notifier()` — qui est
`refresh()` **renommé**, pas un rival.

Aucune globale n'a encore déménagé. Ce commit pose le canal, et surtout il le **mesure**.

## Ce que la mesure a trouvé

Un compteur dans `notifier()`, six gestes joués **deux fois** — avant et après, avec la **même
sonde** des deux côtés :

| geste | avant | après |
|---|---:|---:|
| 8 frappes dans `#search` | 1 | 1 |
| **trier une colonne** | **0** | **1** |
| **basculer le board Commodités** | **0** | **1** |
| poser un voyage (▶) | 1 | 1 |
| déclarer du fret | 1 | 1 |
| sélectionner une tuile | *non mesuré* | *non mesuré* |

### `refresh()` n'est pas le point de propagation unique

`pont.js:6-7` l'affirme depuis le premier îlot — « toute mutation d'état partagé finit par appeler
`refresh()` dans la même pile, vérifié sur les 17 écritures de `SOUTE`… » — et **l'ADR-011 le
répétait**. C'est faux.

Cinq rendus **ciblés** appellent leur `render*()` puis `saveState()` sans passer par `refresh()` :
les deux tris, les deux gestes du board Commodités, la sélection de tuile. **Si un îlot s'était
abonné aujourd'hui, trier une colonne ne l'aurait pas re-rendu.** Les cinq propagent désormais, et
aucun geste ne propage plus d'une fois.

C'est le genre de chose qu'une lecture ne donne pas : les cinq sites appellent bien un rendu, ils
ont juste l'air de faire ce que fait `refresh()`.

### Le garde-fou inscrit dans l'ADR donnait un faux vert

L'ADR annonçait de mesurer contre `e2e/smoke.pw.mjs:2182` (≤ 2 lots de rendu de `#rows` pour
8 frappes). Ce test compte des **mutations DOM**, pas des propagations, et `#search` est un champ du
DOM, pas une globale déménagée : il serait resté vert quoi qu'il arrive ici. La mesure qui tranche
est le compteur de `notifier()`, geste par geste.

### 53 globales mutables, et non 63

Mon premier décompte découpait les déclarations sur les virgules, y compris à l'intérieur des
littéraux et des commentaires. Exact : 47 lignes `^let `, dont trois en déclarent plusieurs → **53**.
L'ADR est corrigé par un **amendement daté** plutôt que réécrit en silence.

## Pourquoi la notification reste explicite

Ce n'est pas de la prudence : un magasin qui notifierait à l'écriture est **ici impossible**.

- **`legIntent()` rend une référence vive** — `JOURNEY_EDITS[k]`, que l'appelant mute en
  `intent[li].units = …`. Aucun proxy, aucun accesseur, aucun compteur ne voit cette écriture. Même
  fuite pour `CHARGEMENTS[k]`, `MANIFEST_EDIT.lines`, `currentManifest.lines[i].units`.
- **`logic.ts` mute `OVERRIDES` en place**, pendant le rendu, à quatre endroits. On n'y touche pas :
  483 tests en dépendent.
- **Trois chemins écrivent l'état pendant le rendu** (`renderCommodities` revalide `commSelected`,
  `legEffectiveLines` réécrit `JOURNEY_EDITS`, `compositionEnCours` réécrit `MANIFEST_EDIT`). Sous
  notification automatique, chacun devient une boucle rendu → écriture → rendu.
- **`editLegQty` diffère son rendu par un `setTimeout` délibéré** — « le blur précède le mouseup
  d'un clic en cours ». Notifier à l'écriture rejouerait ce bug.

Tout cela est écrit en tête d'`etat.ts`, avec les ancrages, pour que le prochain passage ne
« simplifie » pas.

## Vérification

**`node --test` → 483 tests, 483 pass, 0 fail.**
**`npx playwright test` → 224 passed, 2 skipped, 0 failed** (1,4 min).
**`npx tsc --noEmit` → silencieux** (`etat.ts` est ajouté à `tsconfig.include`).

## Ce qui n'est pas couvert

- **Le geste « sélectionner une tuile » n'a pas pu être joué** par la sonde : le clic sur une tuile
  de `#commGrid` expire, quelque chose l'intercepte. Je le signale plutôt que de le compter à zéro.
  Son site propage désormais comme les quatre autres, mais **ce n'est pas mesuré**.
- La sonde est un **outil de PR**, non commitée. Ce qui reste au dépôt, c'est le compteur
  `__notifs` dans `notifier()` — inerte tant qu'un test ne l'arme pas.
- **Rien ne s'abonne encore** : `subscribe`/`getSnapshot` sont exposés, pas consommés. Les îlots
  reçoivent toujours leurs props d'`app.js`. C'est l'étape 3 (la racine unique).
- L'objet `etat` est typé `Record<string, unknown>` : il se resserrera quand les globales y
  entreront réellement, au commit suivant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
