### PR TITLE
refactor(voyage): les formateurs s'importent au lieu de traverser onze composants

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,6 +28,7 @@ import {
 // l'unique notification. Voir pont.js pour pourquoi il n'y a ni magasin ni abonnement.
 import { peindre } from "./pont.js";
 import { etat, notifier } from "./etat.ts";
+import { fmt, fmtVol, fmtFee, signe, TEXTE_CAPACITE_INCONNUE } from "./format.ts";
 import { vueTournee, messageSouteVide, messageChargement, messageOuEsTu } from "./vues/tournee.tsx";
 import { vueBoucles } from "./vues/boucles.tsx";
 import { vueChaine, indiceDepart, indiceSoute, indiceAucune } from "./vues/chaine.tsx";
@@ -77,12 +78,9 @@ let showShipCard = () => {};
 const STATE_KEY = "best-hauling-state";
 
 const $ = (id) => document.getElementById(id);
-const fmt = (n) => (n == null || !isFinite(n) ? "—" : Math.round(n).toLocaleString("fr-FR"));
 // Volume dont le null veut dire « capacité non communiquée par UEX » et non « zéro » :
 // `scu_sell` n'est renseigné que sur une minorité de points de vente. Un « — » s'y lisait
 // « aucune demande » alors qu'aucun plafond n'est appliqué dans ce cas — d'où « n.c. ».
-const fmtVol = (n) => (n == null ? "n.c." : fmt(n));
-const VOL_UNKNOWN_HINT = "Capacité non communiquée par UEX : aucun plafond de volume n'est appliqué";
 
 // Échappe toute chaîne insérée dans innerHTML. Les données UEX sont communautaires
 // (nicknames de terminaux, etc. potentiellement soumis par des utilisateurs) : on les
@@ -223,7 +221,6 @@ const feeResolver = (f) => (f.autoload ? (t) => autoloadPoint(t, kFor(t && t.nam
 // Un montant qui incorpore des frais d'autoload est une ESTIMATION : la formule colle aux 18
 // relevés à 2,8 % près, et `k` varie de 40 % entre les deux seules stations mesurées. Le « ≈ » le
 // dit, partout où le chiffre a été amputé.
-const fmtFee = (n, fees) => (fees > 0 ? "≈ " + fmt(n) : fmt(n));
 const kFmt = (k) => k.toLocaleString("fr-FR", { maximumFractionDigits: 3 });
 const kText = (e) => `×${kFmt(e.k)} ${e.measured ? "(relevé)" : "(k global)"}`;
 function feeEndText(e) {
@@ -277,7 +274,6 @@ function feeCell(ctx, fees, what, bounded) {
 // manifeste optimal), pas un détail de rendu. Signe compris — un net négatif se dit.
 // Préfixe un montant de son signe RÉEL. Un « + » posé d'office écrivait « +-1 234 » dès que les
 // frais mangeaient la marge, en vert, sur le seul chiffre qui disait de ne pas charger la ligne.
-const signe = (n, texte) => (n < 0 ? texte : "+" + texte);
 // Texte de la cellule « profit » d'une ligne de manifeste. Partagé par le premier rendu et par la
 // mise à jour en direct : deux conventions différentes et éditer une quantité changerait le sens
 // de la cellule. Une ligne « vend ailleurs » n'a pas de profit sur ce trajet — elle a quand même
@@ -403,9 +399,7 @@ const EMPTY_DEFAULT = "Aucune route ne correspond aux filtres.";
 // jambes déjà planifiées, et `#empty` reste écrit ici (il est partagé par trois vues).
 function propsTrajetsCommunes() {
   return {
-    fmt, fmtVol, fmtFee,
     avecTexteFrais: (base, cell) => (cell.text ? `${base} · ${cell.text}` : base),
-    texteCapaciteInconnue: VOL_UNKNOWN_HINT,
     legendeAchat: BUY_STATUS,
     legendeVente: SELL_STATUS,
     corriger: (commodite, terminal, cote, champ, valeur, releve) => {
@@ -559,9 +553,7 @@ function renderLoops() {
   // câblés par setupLoopSort. React ne possède que le corps du tableau.
   peindre($("loopRows"), vueBoucles({
     lignes: rows,
-    fmt,
     celluleFrais: (l) => feeCell(l.feeInfo, l.fees, () => `${fmt(l.unitsOut)} + ${fmt(l.unitsBack)} SCU, 4 opérations (charge et décharge à chaque bout)`, l.units > 0),
-    fmtFee,
     avecTexteFrais: (base, cell) => (cell.text ? `${base} · ${cell.text}` : base),
     // On entre dans le cycle par la FIN du parcours : la boucle l'étend au lieu de le remplacer.
     // `journeyEnd(JOURNEY)` est relu DANS le corps de la flèche, donc au clic — et surtout PAS
@@ -942,12 +934,10 @@ function paintManifest() {
     parcours: etat.JOURNEY,
     suggestions: suggestionsFor(m),
     restant: manifestRemaining(m),
-    fmt, fmtVol, fmtFee, signe,
     libelleCaisses: (units) => scuBoxesLabel(units, m.origin.maxBox),
     texteBoutFrais: feeEndText,
     minutesTrajet: tripMinutes(0, m.cross),
     estCorrige: isOv,
-    texteCapaciteInconnue: VOL_UNKNOWN_HINT,
     corriger: (commodite, terminal, cote, champ, valeur, releve) => {
       if (champ === "vol") pinLegsForVolume(commodite, terminal, cote);
       setOverride(commodite, terminal, cote, champ, valeur === "" ? null : valeur, Number(releve) || 0);
@@ -1157,8 +1147,6 @@ function renderChain() {
     chaine: chain,
     cargo: f.cargo,
     terminal: (idx) => etat.MARKET.terminals[idx],
-    fmt,
-    fmtFee,
     celluleFrais: (lignes, fee, a, b, scu, fees) =>
       feeCell(feeCtx(f, a.name, b.name, a, b), fees, () => feeCargoText(lignes, a.maxBox), scu > 0),
     texteProfitLigne: lineProfitText,
@@ -1391,7 +1379,6 @@ function renderEntrepots(synchrone = false) {
     })),
     scuTotal: holdScu(tous),
     invest: holdByCommodity(tous).reduce((s, g) => s + g.invest, 0),
-    fmt,
   }), { synchrone });
 }
 
@@ -1534,7 +1521,6 @@ function renderSoute(synchrone = false) {
     // Le `kind` n'est pas persisté dans le lot : c'est une propriété de la commodité, pas de la
     // transaction. On le relit au marché quand il est là, et on s'en passe sinon.
     kindDe: (nom) => { const c = etat.MARKET && findCommodity(nom); return c ? c.kind : null; },
-    fmt,
   }), { synchrone });
 }
 
@@ -2029,7 +2015,7 @@ function renderJourney({ frappe = false } = {}) {
       texteTotal, nombreTotal,
       suggestions: sctx ? {
         suggestions: suggestionsFor(sctx), restant: manifestRemaining(sctx), frais: sctx.fee,
-        fmt, fmtVol, attributsAjout: { "data-leg": i },
+        attributsAjout: { "data-leg": i },
       } : null,
     };
   });
@@ -2041,7 +2027,6 @@ function renderJourney({ frappe = false } = {}) {
     jambes,
     suggestionsArret: etat.MARKET ? journeyStopSuggestions() : null,
     generation: journeyGen,
-    fmt, signe,
   }), { synchrone: true });
 
   renderJourneyRecap({ n, totalProfit, totalScu, totalFees, systems: new Set(stations.map((s) => s.system)).size });
@@ -2064,7 +2049,6 @@ function renderJourneyRecap({ n, totalProfit, totalScu, totalFees, systems }) {
     n, totalProfit, totalScu, totalFees, systems,
     materials: etat.MARKET ? journeyCarriedCommodities().size : 0,
     marchePret: !!etat.MARKET,
-    fmt, signe,
   }), { synchrone: true });
 }
 
@@ -2181,7 +2165,7 @@ function renderPlan() {
     base: d.f.useCargo && d.f.cargo > 0 ? d.f.cargo : d.scu,
     marchePret: !!etat.MARKET,
     kindDe: (nom) => { const c = etat.MARKET && findCommodity(nom); return c ? c.kind : null; },
-    fmt, fmtProfit: fmtFee, signe,
+    fmtProfit: fmtFee,
   }));
 }
 
@@ -2838,8 +2822,6 @@ function renderCorrections() {
       tuiles: tuilesStation(stationSel, q),
       filtre: !!q,
       nbCorrections: Object.keys(etat.OVERRIDES).filter((k) => k.split("|")[1] === t.name).length,
-      fmtVol,
-      texteCapaciteInconnue: VOL_UNKNOWN_HINT,
       // L'ÉCRITURE reste à app.js : lui seul sait qu'un VOLUME fige d'abord les jambes planifiées.
       corriger: (commodite, cote, champ, valeur, releve) => {
         if (champ === "vol") pinLegsForVolume(commodite, t.name, cote);
@@ -2919,8 +2901,6 @@ function paintCommodityDetail() {
     points: p,
     nomCommodite: p.name,
     butin: loot,
-    fmt,
-    fmtVol,
     estCorrige: (terminal, cote, champ) => isOv(p.name, terminal, cote, champ),
     // L'ÉCRITURE reste à app.js : lui seul sait qu'un VOLUME doit d'abord figer les jambes déjà
     // planifiées (avant d'écrire, pour capturer les SCU encore en vigueur), qu'un PRIX ne fige
@@ -2933,7 +2913,6 @@ function paintCommodityDetail() {
     },
     legendeAchat: BUY_STATUS,
     legendeVente: SELL_STATUS,
-    texteCapaciteInconnue: VOL_UNKNOWN_HINT,
   }));
 }
 // Reflète le board courant dans les contrôles. « Marge » n'a aucun sens quand l'acquisition est
@@ -2969,7 +2948,6 @@ function peindreGrilleCommodites() {
     // du Butin vient de logic.ts (valeurTiers, par rang). L'îlot ne connaît ni l'une ni l'autre.
     palier: (c) => (etat.commBoard === "loot" ? commTiers.get(c.name) || "t-none" : marginTier(c.margin)),
     valeurCompacte: compactValue,
-    fmt,
   }));
 }
 

--- a/format.ts
+++ b/format.ts
@@ -1,0 +1,33 @@
+// Les formateurs partagés (ADR-011).
+//
+// Ils étaient définis dans `app.js` et INJECTÉS en props : `fmt` traversait onze composants, `fmtVol`
+// et `fmtFee` la moitié. C'est exactement ce qu'une application écrite de zéro n'aurait pas fait —
+// on n'injecte pas un formateur, on l'importe. Trente-six déclarations de props disparaissent avec
+// ce module.
+//
+// Ils sont PURS : `tsc` les couvre, et rien n'oblige plus un composant à recevoir de quoi afficher
+// un nombre.
+
+/** Un entier, séparateurs français. `—` pour ce qui n'est pas un nombre fini. */
+export const fmt = (n: number | null | undefined): string =>
+  n == null || !isFinite(n) ? "—" : Math.round(n).toLocaleString("fr-FR");
+
+/**
+ * Un volume dont le `null` veut dire « capacité non communiquée par UEX », et non « zéro » :
+ * `scu_sell` n'est renseigné que sur une minorité de points de vente. Un « — » s'y lisait
+ * « aucune demande » alors qu'aucun plafond n'est appliqué dans ce cas — d'où « n.c. ».
+ */
+export const fmtVol = (n: number | null | undefined): string => (n == null ? "n.c." : fmt(n));
+
+/** L'infobulle qui accompagne un volume inconnu. */
+export const TEXTE_CAPACITE_INCONNUE =
+  "Capacité non communiquée par UEX : aucun plafond de volume n'est appliqué";
+
+/** Un montant que des frais rendent APPROCHÉ : le « ≈ » dit que le chiffre est une estimation. */
+export const fmtFee = (n: number, fees: number): string => (fees > 0 ? "≈ " + fmt(n) : fmt(n));
+
+/**
+ * Préfixe un montant de son signe RÉEL. Un « + » posé d'office écrivait « +-1 234 » dès que les
+ * frais mangeaient la marge — en vert, sur le seul chiffre qui disait de ne pas charger la ligne.
+ */
+export const signe = (n: number, texte: string): string => (n < 0 ? texte : "+" + texte);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,5 +36,5 @@
     "verbatimModuleSyntax": true,
     "jsx": "react-jsx"
   },
-  "include": ["logic.ts", "types.ts", "etat.ts", "vues/**/*.tsx"]
+  "include": ["logic.ts", "types.ts", "etat.ts", "format.ts", "vues/**/*.tsx"]
 }

--- a/vues/boucles.tsx
+++ b/vues/boucles.tsx
@@ -13,6 +13,7 @@
 // Ce qui reste dans app.js, et doit y rester tant que Trajets n'est pas migrée : l'écriture de
 // `#empty`, le `<p>` de message vide PARTAGÉ par Trajets, Boucles et « En route ». Le déplacer ici
 // le ferait disparaître des deux autres vues.
+import { fmt, fmtFee } from "../format.ts";
 import type { Boucle } from "../types.ts";
 import { BadgeSysteme, TagAvantPoste, TagIllegal, IconeCommodite, PastilleFraicheur, CelluleFiabilite } from "./communs.tsx";
 
@@ -37,19 +38,16 @@ export type BoucleEvaluee = Boucle & {
 
 export type ProprietesBoucles = {
   lignes: BoucleEvaluee[];
-  fmt: Fmt;
   // Les trois fonctions que app.js garde : elles connaissent l'état des frais, que l'îlot ignore.
   celluleFrais: (l: BoucleEvaluee) => CelluleFrais;
-  fmtFee: (n: number, fees: number) => string;
   avecTexteFrais: (base: string, cell: CelluleFrais) => string;
   /** ▶ : ajouter cette boucle au voyage. Reçoit LA boucle, jamais son rang. */
   choisirBoucle: (l: BoucleEvaluee) => void;
 };
 
-function LigneBoucle({ l, fmt, celluleFrais, fmtFee, avecTexteFrais, choisirBoucle }: {
-  l: BoucleEvaluee; fmt: Fmt;
+function LigneBoucle({ l, celluleFrais, avecTexteFrais, choisirBoucle }: {
+  l: BoucleEvaluee;
   celluleFrais: ProprietesBoucles["celluleFrais"];
-  fmtFee: ProprietesBoucles["fmtFee"];
   avecTexteFrais: ProprietesBoucles["avecTexteFrais"];
   choisirBoucle: ProprietesBoucles["choisirBoucle"];
 }) {
@@ -114,11 +112,11 @@ function LigneBoucle({ l, fmt, celluleFrais, fmtFee, avecTexteFrais, choisirBouc
   );
 }
 
-export function VueBoucles({ lignes, fmt, celluleFrais, fmtFee, avecTexteFrais, choisirBoucle }: ProprietesBoucles) {
+export function VueBoucles({ lignes, celluleFrais, avecTexteFrais, choisirBoucle }: ProprietesBoucles) {
   return (
     <>
       {lignes.map((l, i) => (
-        <LigneBoucle key={i} l={l} fmt={fmt} celluleFrais={celluleFrais} fmtFee={fmtFee}
+        <LigneBoucle key={i} l={l} celluleFrais={celluleFrais}
                      avecTexteFrais={avecTexteFrais} choisirBoucle={choisirBoucle} />
       ))}
     </>

--- a/vues/chaine.tsx
+++ b/vues/chaine.tsx
@@ -8,6 +8,7 @@
 //
 // La répartition suit celle des deux vues précédentes : le CALCUL vient de logic.ts (pur, testé),
 // l'ÉTAT reste dans app.js — qui passe ici les seules fonctions dépendant de lui, celles des frais.
+import { fmt, fmtFee } from "../format.ts";
 import { Fragment } from "react";
 import { manifestTotals, tripMinutes, lineNet } from "../logic.ts";
 import type { Chaine, LigneManifeste, PaireFrais, Terminal } from "../types.ts";
@@ -22,8 +23,6 @@ export type ProprietesChaine = {
   // `terminal(i)` résout un index en terminal : c'est MARKET qui les porte, et MARKET est une
   // globale de app.js. L'îlot ne la connaît pas, il reçoit le résolveur.
   terminal: (idx: number) => Terminal;
-  fmt: Fmt;
-  fmtFee: (n: number, fees: number) => string;
   // Les frais dépendent de l'état (interrupteur d'autoload, relevés par station) : app.js les
   // calcule et l'îlot n'en reçoit que le résultat.
   celluleFrais: (lignes: LigneManifeste[], fee: PaireFrais | null, a: Terminal, b: Terminal, scu: number, fees: number) => CelluleFrais;
@@ -32,8 +31,8 @@ export type ProprietesChaine = {
 
 const classeProfit = (n: number) => (n < 0 ? "perte" : "profit");
 
-function LigneDeSaut({ l, fee, fmt, texteProfitLigne }: {
-  l: LigneManifeste; fee: PaireFrais | null; fmt: Fmt;
+function LigneDeSaut({ l, fee, texteProfitLigne }: {
+  l: LigneManifeste; fee: PaireFrais | null;
   texteProfitLigne: ProprietesChaine["texteProfitLigne"];
 }) {
   return (
@@ -53,7 +52,7 @@ function LigneDeSaut({ l, fee, fmt, texteProfitLigne }: {
   );
 }
 
-export function VueChaine({ chaine, cargo, terminal, fmt, fmtFee, celluleFrais, texteProfitLigne }: ProprietesChaine) {
+export function VueChaine({ chaine, cargo, terminal, celluleFrais, texteProfitLigne }: ProprietesChaine) {
   const totaux = chaine.legs.map((leg) => manifestTotals(leg.lines || [], leg.fee));
   const invest = totaux[0] ? totaux[0].invest : 0;
   const totalFees = totaux.reduce((s, t) => s + t.fees, 0);
@@ -111,7 +110,7 @@ export function VueChaine({ chaine, cargo, terminal, fmt, fmtFee, celluleFrais, 
                 </div>
                 <div className="chain-lines">
                   {lignes.map((l, j) => (
-                    <LigneDeSaut key={j} l={l} fee={leg.fee} fmt={fmt} texteProfitLigne={texteProfitLigne} />
+                    <LigneDeSaut key={j} l={l} fee={leg.fee} texteProfitLigne={texteProfitLigne} />
                   ))}
                 </div>
               </div>

--- a/vues/commodites.tsx
+++ b/vues/commodites.tsx
@@ -12,6 +12,7 @@
 //
 // Ce qui passe ici : #commGrid (le gros du rendu, une tuile par commodité) et #commHint (le texte
 // d'aide, qui change avec le board).
+import { TEXTE_CAPACITE_INCONNUE, fmt, fmtVol } from "../format.ts";
 import type { ResumeCommodite } from "../types.ts";
 import { IconeCommodite, TagIllegal, BadgeSysteme } from "./communs.tsx";
 
@@ -30,10 +31,9 @@ export type ProprietesGrille = {
    *  ratio à la marge max en Marché) et l'une des deux lit une globale. */
   palier: (c: ResumeCommodite) => string;
   valeurCompacte: (n: number) => string;
-  fmt: Fmt;
 };
 
-function Tuile({ c, butin, selection, transportees, codesAmbigus, palier, valeurCompacte, fmt }: {
+function Tuile({ c, butin, selection, transportees, codesAmbigus, palier, valeurCompacte }: {
   c: ResumeCommodite;
 } & Omit<ProprietesGrille, "lignes">) {
   const val = butin ? c.bestSell : c.margin;
@@ -120,18 +120,15 @@ export type ProprietesDetail = {
   /** Le nom de la commodité, porté par `data-c` sur chaque valeur éditable. */
   nomCommodite: string;
   butin: boolean;
-  fmt: Fmt;
-  fmtVol: (n: number | null) => string;
   /** Une correction locale porte-t-elle déjà sur ce point ? */
   estCorrige: (terminal: string, cote: "buy" | "sell", champ: "price" | "vol") => boolean;
   /** app.js écrit la correction — il sait figer les jambes, mettre le compteur à jour et re-rendre. */
   corriger: (terminal: string, cote: "buy" | "sell", champ: "price" | "vol", valeur: string, releve: number) => void;
   legendeAchat: Record<number, [string, string]>;
   legendeVente: Record<number, [string, string]>;
-  texteCapaciteInconnue: string;
 };
 
-function LignePoint({ p, cote, ...r }: { p: PointAchatCommodite | PointVenteCommodite; cote: "buy" | "sell" } & Omit<ProprietesDetail, "points" | "butin" | "fmt">) {
+function LignePoint({ p, cote, ...r }: { p: PointAchatCommodite | PointVenteCommodite; cote: "buy" | "sell" } & Omit<ProprietesDetail, "points" | "butin">) {
   // Le champ de volume porte un NOM différent selon le côté — `stock` à l'achat, `demand` à la
   // vente — et c'est voulu : ce ne sont pas la même chose. `demand: null` veut dire « capacité
   // inconnue chez UEX », ni zéro ni illimitée.
@@ -143,8 +140,6 @@ function LignePoint({ p, cote, ...r }: { p: PointAchatCommodite | PointVenteComm
       valeur={valeur ?? null}
       commodite={r.nomCommodite} terminal={p.terminal} cote={cote} champ={champ} releve={p.updated}
       corrige={r.estCorrige(p.terminal, cote, champ)}
-      fmtVol={r.fmtVol}
-      texteCapaciteInconnue={r.texteCapaciteInconnue}
       onCorriger={(v) => r.corriger(p.terminal, cote, champ, v, p.updated)}
     />
   );
@@ -170,7 +165,7 @@ function LignePoint({ p, cote, ...r }: { p: PointAchatCommodite | PointVenteComm
 
 function TablePoints({ lignes, entete, cote, ...r }: {
   lignes: (PointAchatCommodite | PointVenteCommodite)[]; entete: string; cote: "buy" | "sell";
-} & Omit<ProprietesDetail, "points" | "butin" | "fmt">) {
+} & Omit<ProprietesDetail, "points" | "butin">) {
   if (!lignes.length) return <p className="muted">Aucun point.</p>;
   return (
     <table className="comm-points">
@@ -180,7 +175,7 @@ function TablePoints({ lignes, entete, cote, ...r }: {
   );
 }
 
-export function VueDetailCommodite({ points: p, butin, fmt, ...r }: ProprietesDetail) {
+export function VueDetailCommodite({ points: p, butin, ...r }: ProprietesDetail) {
   const meilleur = p.sells[0];
   return (
     <>

--- a/vues/communs.tsx
+++ b/vues/communs.tsx
@@ -11,6 +11,7 @@
 //
 // Ce qu'ils ne font PAS : lire une globale, ni décider. Le calcul reste dans logic.ts (d'où
 // `ageDays` et `scoreBarWidth` viennent), et l'état reste dans app.js.
+import { TEXTE_CAPACITE_INCONNUE, fmtVol } from "../format.ts";
 import { ageDays, scoreBarWidth } from "../logic.ts";
 
 // Le badge de système. Sa classe porte le nom en minuscules — `.sys.pyro`, `.sys.stanton` — et
@@ -115,13 +116,11 @@ export type ProprietesValeurEditable = {
   /** true quand une correction locale porte déjà sur ce point : le ✎ s'affiche. */
   corrige: boolean;
   /** Rend « n.c. » pour une capacité qu'UEX ne publie pas — ni zéro, ni illimitée. */
-  fmtVol: (n: number | null) => string;
   /** Appelé UNIQUEMENT si la valeur a changé. app.js écrit alors la correction et re-rend. */
   onCorriger: (valeur: string) => void;
-  texteCapaciteInconnue: string;
 };
 
-export function ValeurEditable({ valeur, commodite, terminal, cote, champ, releve, corrige, fmtVol, onCorriger, texteCapaciteInconnue }: ProprietesValeurEditable) {
+export function ValeurEditable({ valeur, commodite, terminal, cote, champ, releve, corrige, onCorriger }: ProprietesValeurEditable) {
   const [enEdition, setEnEdition] = useState(false);
   const saisie = useRef<HTMLInputElement>(null);
   const fini = useRef(false);
@@ -190,7 +189,7 @@ export function ValeurEditable({ valeur, commodite, terminal, cote, champ, relev
       data-v={inconnue ? "" : v} data-u={String(Number(releve) || 0)}
       role="button"
       tabIndex={0}
-      title={inconnue ? `${texteCapaciteInconnue}. Clic pour le corriger localement` : "Clic pour corriger localement ce chiffre"}
+      title={inconnue ? `${TEXTE_CAPACITE_INCONNUE}. Clic pour le corriger localement` : "Clic pour corriger localement ce chiffre"}
       onClick={ouvrir}
       onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); ouvrir(); } }}
     >

--- a/vues/corrections.tsx
+++ b/vues/corrections.tsx
@@ -12,6 +12,7 @@
 // repartait à vide au moindre re-rendu — un filtre tapé, une correction ailleurs. React
 // réconcilierait sans doute correctement, mais changer ce garde ET migrer la vue dans la même PR
 // rendrait un échec inexploitable. Il reste donc à app.js, à revoir séparément.
+import { TEXTE_CAPACITE_INCONNUE, fmtVol } from "../format.ts";
 import { Fragment } from "react";
 import type { Terminal } from "../types.ts";
 import { BadgeSysteme, IconeCommodite, TagIllegal, ValeurEditable } from "./communs.tsx";
@@ -73,9 +74,9 @@ function HeroStation({ t, total, filtre, nbCorrections }: {
 // Il ne porte PAS de gestionnaire : la délégation d'app.js le prend déjà par ses `data-*`, et elle
 // sait ce que React ignore — qu'un retour de VOLUME doit d'abord figer les jambes déjà planifiées,
 // et où retrouver la date de base de la correction. Lui ajouter un onClick doublerait l'action.
-function RetourUEX({ commodite, terminal, cote, champ, brut, fmtVol }: {
+function RetourUEX({ commodite, terminal, cote, champ, brut }: {
   commodite: string; terminal: string; cote: "buy" | "sell"; champ: "price" | "vol";
-  brut: number | null; fmtVol: Fmt;
+  brut: number | null;
 }) {
   const quoi = champ === "price" ? "le prix" : cote === "buy" ? "le stock" : "la demande";
   const v = Number.isFinite(Number(brut)) ? Number(brut) : null;
@@ -108,14 +109,12 @@ export type ProprietesStation = {
   tuiles: TuileCommodite[];
   filtre: boolean;
   nbCorrections: number;
-  fmtVol: Fmt;
-  texteCapaciteInconnue: string;
   corriger: (commodite: string, cote: "buy" | "sell", champ: "price" | "vol", valeur: string, releve: number) => void;
 };
 
-function Tuile({ t, terminal, fmtVol, texteCapaciteInconnue, corriger }: {
+function Tuile({ t, terminal, corriger }: {
   t: TuileCommodite; terminal: string;
-} & Pick<ProprietesStation, "fmtVol" | "texteCapaciteInconnue" | "corriger">) {
+} & Pick<ProprietesStation, "corriger">) {
   return (
     <div className={"scomm " + (t.achat ? "achat" : "vente")}>
       <div className="scomm-name">
@@ -131,14 +130,12 @@ function Tuile({ t, terminal, fmtVol, texteCapaciteInconnue, corriger }: {
           <Fragment key={c.cote}>
             <div className="scomm-side">
               <span className="scomm-lbl">{c.libelle}</span>
-              <ValeurEditable valeur={c.prix} corrige={c.prixCorrige} fmtVol={fmtVol}
+              <ValeurEditable valeur={c.prix} corrige={c.prixCorrige}
                               commodite={t.nom} terminal={terminal} cote={c.cote} champ="price" releve={c.releve}
-                              texteCapaciteInconnue={texteCapaciteInconnue}
                               onCorriger={(v) => corriger(t.nom, c.cote, "price", v, c.releve)} />
               {" aUEC · "}{c.unite}{" "}
-              <ValeurEditable valeur={c.volume} corrige={c.volumeCorrige} fmtVol={fmtVol}
+              <ValeurEditable valeur={c.volume} corrige={c.volumeCorrige}
                               commodite={t.nom} terminal={terminal} cote={c.cote} champ="vol" releve={c.releve}
-                              texteCapaciteInconnue={texteCapaciteInconnue}
                               onCorriger={(v) => corriger(t.nom, c.cote, "vol", v, c.releve)} />
             </div>
             {/* Les boutons de retour vivent sur LEUR PROPRE ligne, sous les valeurs. Glissés parmi
@@ -148,7 +145,7 @@ function Tuile({ t, terminal, fmtVol, texteCapaciteInconnue, corriger }: {
               <div className="scomm-undos">
                 {retours.map((r) => (
                   <RetourUEX key={r.champ} commodite={t.nom} terminal={terminal} cote={c.cote}
-                             champ={r.champ} brut={r.brut} fmtVol={fmtVol} />
+                             champ={r.champ} brut={r.brut} />
                 ))}
               </div>
             ) : null}

--- a/vues/manifeste.tsx
+++ b/vues/manifeste.tsx
@@ -18,6 +18,7 @@
 // `value` d'un champ non contrôlé au re-rendu, donc la frappe survit pendant que le profit, les
 // caisses et les totaux se recalculent — le comportement exact de l'ancienne mise à jour en place.
 // Le passer en contrôlé rendrait la valeur au rendu et déplacerait le curseur en fin de champ.
+import { TEXTE_CAPACITE_INCONNUE, fmt, fmtFee, fmtVol, signe } from "../format.ts";
 import { Fragment } from "react";
 import { manifestTotals, lineHaulFee, lineNet, addableUnits, manifestJourneyState } from "../logic.ts";
 import type {
@@ -51,15 +52,10 @@ export type ProprietesManifeste = {
   suggestions: CandidatChargement[];
   /** L'espace et le budget qu'il reste — `manifestRemaining`, qui lit les filtres. */
   restant: RestantManifeste;
-  fmt: Fmt;
-  fmtVol: Fmt;
-  fmtFee: (n: number, fees: number) => string;
-  signe: (n: number, texte: string) => string;
   libelleCaisses: (units: number) => string;
   texteBoutFrais: (bout: unknown) => string;
   minutesTrajet: number;
   estCorrige: (commodite: string, terminal: string, cote: string, champ: string) => boolean;
-  texteCapaciteInconnue: string;
   corriger: (commodite: string, terminal: string, cote: string, champ: string, valeur: string, releve: number) => void;
 };
 
@@ -72,12 +68,10 @@ export type ProprietesSuggestions = {
   suggestions: CandidatChargement[];
   restant: RestantManifeste;
   frais: PaireFrais | null;
-  fmt: Fmt;
-  fmtVol: Fmt;
   attributsAjout?: Record<string, string | number>;
 };
 
-export function Suggestions({ suggestions, restant, frais, fmt, fmtVol, attributsAjout = {} }: ProprietesSuggestions) {
+export function Suggestions({ suggestions, restant, frais, attributsAjout = {} }: ProprietesSuggestions) {
   if (restant.cargoLeft <= 0) return null;
   const retenues = suggestions
     .map((it) => ({ it, u: addableUnits(it, restant) }))
@@ -120,7 +114,7 @@ export function Suggestions({ suggestions, restant, frais, fmt, fmtVol, attribut
 // Les totaux, en une phrase.
 // ---------------------------------------------------------------------------------------------
 function Totaux({ p, totaux }: { p: ProprietesManifeste; totaux: { profit: number; invest: number; scu: number; fees: number } }) {
-  const { m, fmt, fmtFee } = p;
+  const { m } = p;
   const vides = m.cargo - totaux.scu;
   const profitHeure = (totaux.profit * 60) / p.minutesTrajet;
   // Les frais sont exposés à part plutôt que fondus dans le profit : c'est le seul moyen de voir
@@ -229,9 +223,7 @@ function Ligne({ p, l, i }: { p: ProprietesManifeste; l: LigneManifeste; i: numb
       champ={champ}
       releve={releve}
       corrige={p.estCorrige(l.name, terminal, cote, champ)}
-      fmtVol={p.fmtVol}
       onCorriger={(v) => p.corriger(l.name, terminal, cote, champ, v, releve)}
-      texteCapaciteInconnue={p.texteCapaciteInconnue}
     />
   );
 
@@ -240,9 +232,9 @@ function Ligne({ p, l, i }: { p: ProprietesManifeste; l: LigneManifeste; i: numb
   // sans qu'aucune ligne à l'écran ne l'explique.
   const texteProfit = carry
     ? fraisLigne > 0
-      ? p.fmtFee(-fraisLigne, fraisLigne)
+      ? fmtFee(-fraisLigne, fraisLigne)
       : "—"
-    : p.signe(lineNet(l.units, l, m.fee), p.fmtFee(lineNet(l.units, l, m.fee), fraisLigne));
+    : signe(lineNet(l.units, l, m.fee), fmtFee(lineNet(l.units, l, m.fee), fraisLigne));
 
   return (
     <div className={"mline" + (carry ? " carry" : "") + (acq ? " acquired" : "")}>
@@ -354,7 +346,7 @@ export function CarteManifeste(p: ProprietesManifeste) {
         ) : null}
       </div>
       <div id="manifestSuggest" className="manifest-suggest">
-        <Suggestions suggestions={p.suggestions} restant={p.restant} frais={m.fee} fmt={p.fmt} fmtVol={p.fmtVol} />
+        <Suggestions suggestions={p.suggestions} restant={p.restant} frais={m.fee} />
       </div>
     </>
   );

--- a/vues/plan.tsx
+++ b/vues/plan.tsx
@@ -10,6 +10,7 @@
 // La carte SVG du parcours reste HORS de cet îlot : `#journeyMap` vit entre `#planHead` et
 // `#planBody` (et non dedans), parce qu'un élément à écouteurs directs se déménage en FRÈRE, jamais
 // en enfant d'un conteneur réécrit — c'est la leçon de #24, rappelée par l'ADR-004.
+import { fmt, signe } from "../format.ts";
 import { Fragment } from "react";
 import { IconeCommodite } from "./communs.tsx";
 
@@ -39,9 +40,7 @@ export type DonneesPlan = {
   marchePret: boolean;
   /** Le `kind` d'une commodité, pour son icône. app.js le résout : MARKET est une globale. */
   kindDe: (nom: string) => string | null;
-  fmt: Fmt;
   fmtProfit: (n: number, fees: number) => string;
-  signe: (n: number, texte: string) => string;
 };
 
 const classeProfit = (n: number) => (n < 0 ? "perte" : "profit");
@@ -92,18 +91,18 @@ function CarteSoute({ d }: { d: DonneesPlan }) {
                 <span>{g.name}</span>
               </span>
               <span className="plan-hold-bar" aria-hidden="true"><i style={{ width: part.toFixed(1) + "%" }} /></span>
-              <span className="plan-hold-scu"><b>{d.fmt(g.units)}</b> SCU</span>
+              <span className="plan-hold-scu"><b>{fmt(g.units)}</b> SCU</span>
               <span className="plan-hold-paid" title={"Prix payé au SCU" + (g.lots.length > 1 ? " (moyenne des lots)" : "")}>
-                @ {d.fmt(Math.round(g.paidMoyen))}
+                @ {fmt(Math.round(g.paidMoyen))}
               </span>
             </div>
           );
         })}
       </div>
       <div className="plan-card-meta">
-        <b>{d.fmt(d.scu)}</b> SCU à bord
-        {d.libre != null ? <> · <b>{d.fmt(d.libre)}</b> SCU libres</> : null}
-        {" · capital engagé "}<b>{d.fmt(d.invest)}</b> aUEC
+        <b>{fmt(d.scu)}</b> SCU à bord
+        {d.libre != null ? <> · <b>{fmt(d.libre)}</b> SCU libres</> : null}
+        {" · capital engagé "}<b>{fmt(d.invest)}</b> aUEC
       </div>
     </div>
   );
@@ -141,13 +140,13 @@ function CarteParcours({ d }: { d: DonneesPlan }) {
                 <span className="plan-leg-n">{j.i + 1}</span>
                 <span className="plan-leg-route">{j.from} → {j.to}</span>
                 <span className="plan-leg-state">{j.faite ? "faite" : j.courante ? "courante" : "à venir"}{j.chargee ? " · chargée" : ""}</span>
-                <span className={"plan-leg-profit " + classeProfit(j.profit)}>{d.signe(j.profit, d.fmtProfit(j.profit, j.fees))}</span>
+                <span className={"plan-leg-profit " + classeProfit(j.profit)}>{signe(j.profit, d.fmtProfit(j.profit, j.fees))}</span>
               </div>
               <div className="plan-leg-cargo">
                 {j.lines.length
                   ? j.lines.map((l, k) => (
                       <span className="plan-cargo-item" key={k}>
-                        <IconeCommodite kind={l.kind} />{l.name} <b>{d.fmt(l.units)} SCU</b>
+                        <IconeCommodite kind={l.kind} />{l.name} <b>{fmt(l.units)} SCU</b>
                       </span>
                     ))
                   : <span className="plan-muted">aucun fret rentable</span>}
@@ -159,10 +158,10 @@ function CarteParcours({ d }: { d: DonneesPlan }) {
         <p className="plan-muted">Calcul des manifestes…</p>
       )}
       <div className="plan-card-meta">
-        <b>{d.nbSauts}</b> saut{d.nbSauts > 1 ? "s" : ""} · <b>{d.reste}</b> à faire · <b>{d.fmt(d.totalScu)}</b> SCU transportés ·
+        <b>{d.nbSauts}</b> saut{d.nbSauts > 1 ? "s" : ""} · <b>{d.reste}</b> à faire · <b>{fmt(d.totalScu)}</b> SCU transportés ·
         {" profit "}
         {d.marchePret
-          ? <b className={classeProfit(d.totalProfit)}>{d.signe(d.totalProfit, d.fmtProfit(d.totalProfit, d.totalFees))}</b>
+          ? <b className={classeProfit(d.totalProfit)}>{signe(d.totalProfit, d.fmtProfit(d.totalProfit, d.totalFees))}</b>
           : "…"}
         {d.marchePret ? " aUEC" : ""}
       </div>

--- a/vues/soute.tsx
+++ b/vues/soute.tsx
@@ -9,6 +9,7 @@
 // logic.ts et déjà testés. app.js ne passe ici que ce qui dépend de l'état global — la station
 // courante, le point de vente résolu, l'icône d'une commodité (qui se relit au MARCHÉ), et les
 // deux interrupteurs d'affichage (`venteEnCours`, `ecoulerOuvert`).
+import { fmt } from "../format.ts";
 import { Fragment } from "react";
 import type { GroupeSoute, Destination, VenteAuTerminal, Lot, Station } from "../types.ts";
 import { BadgeSysteme, TagAvantPoste, IconeCommodite } from "./communs.tsx";
@@ -38,7 +39,6 @@ export type ProprietesSoute = {
   /** Le `kind` d'une commodité — relu au marché, absent du lot (c'est une propriété de la
    *  commodité, pas de la transaction). */
   kindDe: (nom: string) => string | null;
-  fmt: Fmt;
 };
 
 // ---------------------------------------------------------------------------------------------
@@ -75,13 +75,13 @@ function OuEcouler({ p }: { p: ProprietesSoute }) {
     <div className="hold-ecouler">
       <div className="ec-head">Où écouler — classé par ce que ça rapporte, prix d'achat déduit</div>
       {dest.map((d) => (
-        <LigneEcoulement d={d} fmt={p.fmt} key={d.idx} />
+        <LigneEcoulement d={d} key={d.idx} />
       ))}
     </div>
   );
 }
 
-function LigneEcoulement({ d, fmt }: { d: Destination; fmt: Fmt }) {
+function LigneEcoulement({ d }: { d: Destination }) {
   const cert =
     d.certitude === "connue" ? (
       <span className="ec-sur" title="Capacité publiée par UEX">{`${fmt(d.garanti)} SCU garantis`}</span>
@@ -137,7 +137,6 @@ function LigneEcoulement({ d, fmt }: { d: Destination; fmt: Fmt }) {
 // Une commodité à bord : ce qu'elle est, ce qu'elle a coûté, et les deux sorties (vendre, déposer).
 // ---------------------------------------------------------------------------------------------
 function LigneSoute({ p, g }: { p: ProprietesSoute; g: GroupeSoute }) {
-  const { fmt } = p;
   // Un lot DÉCLARÉ n'a pas de terminal d'achat (`from` vide) : le dire, plutôt qu'afficher « ? »
   // qui laisse croire à une donnée perdue. C'est un fait, pas un trou.
   const ouCharge = (l: Lot) => (l.from ? `Chargé à ${l.from}` : "Déclaré à la main — aucun terminal d'achat");
@@ -232,15 +231,15 @@ export function CarteSoute(p: ProprietesSoute) {
           (mesuré : 410,78 → 408,11 px). Les séparateurs sont donc collés au texte qui les précède,
           et l'espace avant le bouton est explicite. */}
       <div className="hold-meta">
-        <b>{p.fmt(p.scu)}</b>
+        <b>{fmt(p.scu)}</b>
         {p.libre != null ? " SCU à bord · " : " SCU à bord · capital engagé "}
         {p.libre != null ? (
           <>
-            <b>{p.fmt(p.libre)}</b>
+            <b>{fmt(p.libre)}</b>
             {" libres · capital engagé "}
           </>
         ) : null}
-        <b>{p.fmt(p.invest)}</b>
+        <b>{fmt(p.invest)}</b>
         {" aUEC\n       "}
         <button id="holdOffload" className="hold-offload">{p.ecoulerOuvert ? "▾ où écouler ?" : "▸ où écouler ?"}</button>
       </div>
@@ -264,10 +263,9 @@ export type ProprietesEntrepots = {
   stations: StationEntrepot[];
   scuTotal: number;
   invest: number;
-  fmt: Fmt;
 };
 
-export function CarteEntrepots({ stations, scuTotal, invest, fmt }: ProprietesEntrepots) {
+export function CarteEntrepots({ stations, scuTotal, invest }: ProprietesEntrepots) {
   return (
     <>
       {/* Le bouton de sortie vit dans l'en-tête, sur le modèle exact du `⧉ Copier` du manifeste. Il

--- a/vues/tournee.tsx
+++ b/vues/tournee.tsx
@@ -13,6 +13,7 @@
 //
 // Le calcul n'est pas ici : `tourneesEcoulement` vit dans logic.ts, pure et couverte par les tests
 // unitaires. Ce fichier ne fait que présenter.
+import { fmt } from "../format.ts";
 import { Fragment } from "react";
 import type { Tournee, Destination } from "../types.ts";
 
@@ -20,7 +21,7 @@ import type { Tournee, Destination } from "../types.ts";
 // script d'entrée), et le dupliquer ici ferait diverger deux formatages de nombres.
 type Fmt = (n: number) => string;
 
-type ProprietesArret = { a: Destination; rang: number; fmt: Fmt };
+type ProprietesArret = { a: Destination; rang: number };
 
 // Le badge de système. Sa classe porte le nom en minuscules — `.sys.pyro`, `.sys.stanton` — et
 // style.css la teinte via les jetons. C'est l'une des 29 classes que le dépôt n'écrit que par
@@ -31,7 +32,7 @@ const BadgeSysteme = ({ system }: { system: string }) => (
 
 const MAX_LIGNES = 12;
 
-function ArretDeTournee({ a, rang, fmt }: ProprietesArret) {
+function ArretDeTournee({ a, rang }: ProprietesArret) {
   const visibles = a.lignes.slice(0, MAX_LIGNES);
   const reste = a.lignes.length - visibles.length;
 
@@ -92,10 +93,9 @@ export type ProprietesTournee = {
   alternative: Tournee | null;
   systeme: string;
   toutSysteme: boolean;
-  fmt: Fmt;
 };
 
-export function VueTournee({ tournee: t, alternative: alt, systeme, toutSysteme, fmt }: ProprietesTournee) {
+export function VueTournee({ tournee: t, alternative: alt, systeme, toutSysteme }: ProprietesTournee) {
   if (!t.arrets.length && !t.sansDebouche.length) {
     return (
       <div className="tour-vide">
@@ -155,7 +155,7 @@ export function VueTournee({ tournee: t, alternative: alt, systeme, toutSysteme,
       ) : null}
 
       <div className="tour-arrets">
-        {t.arrets.map((a, i) => <ArretDeTournee key={i} a={a} rang={i + 1} fmt={fmt} />)}
+        {t.arrets.map((a, i) => <ArretDeTournee key={i} a={a} rang={i + 1} />)}
       </div>
 
       {/* L'alternative « un arrêt de plus », chiffrée. L'ordre reste lexicographique STRICT : la

--- a/vues/trajets.tsx
+++ b/vues/trajets.tsx
@@ -12,6 +12,7 @@
 //
 // Le `<thead>` et son tri restent eux aussi dans index.html, câblés par `setupSort` : React ne
 // possède que le corps du tableau, comme pour Boucles.
+import { TEXTE_CAPACITE_INCONNUE, fmt, fmtFee, fmtVol } from "../format.ts";
 import { useState } from "react";
 import type { LigneManifeste, PaireFrais, Route } from "../types.ts";
 import { BadgeSysteme, TagAvantPoste, TagIllegal, IconeCommodite, PastilleFraicheur, CelluleFiabilite, ValeurEditable, PastilleStatut } from "./communs.tsx";
@@ -20,11 +21,7 @@ type Fmt = (n: number) => string;
 type CelluleFrais = { attr: string; mark: string; text: string };
 
 export type ProprietesCommunes = {
-  fmt: Fmt;
-  fmtVol: (n: number | null) => string;
-  fmtFee: (n: number, fees: number) => string;
   avecTexteFrais: (base: string, cell: CelluleFrais) => string;
-  texteCapaciteInconnue: string;
   legendeAchat: Record<number, [string, string]>;
   legendeVente: Record<number, [string, string]>;
   corriger: (commodite: string, terminal: string, cote: "buy" | "sell", champ: "price" | "vol", valeur: string, releve: number) => void;
@@ -80,9 +77,8 @@ function LigneSimple({ r, celluleFrais, suspect, libelleCaisses, choisirTrajet, 
     const p = cote === "buy" ? r.buy : r.sell;
     const volume = cote === "buy" ? r.buy.stock : r.sell.demand;
     const editable = (champ: "price" | "vol", valeur: number | null | undefined, corrige: boolean) => (
-      <ValeurEditable valeur={valeur ?? null} corrige={corrige} fmtVol={c.fmtVol}
+      <ValeurEditable valeur={valeur ?? null} corrige={corrige}
                       commodite={r.commodity} terminal={p.terminal} cote={cote} champ={champ} releve={p.updated}
-                      texteCapaciteInconnue={c.texteCapaciteInconnue}
                       onCorriger={(v) => c.corriger(r.commodity, p.terminal, cote, champ, v, p.updated)} />
     );
     return (
@@ -120,16 +116,16 @@ function LigneSimple({ r, celluleFrais, suspect, libelleCaisses, choisirTrajet, 
       {bout("buy")}
       {bout("sell")}
       <td><CelluleFiabilite f={r.fiabilite} age={r.age} part={r.partVolume} /></td>
-      <td className="num" title={titreFrais}>{c.fmtFee(r.margin, r.fees)}</td>
+      <td className="num" title={titreFrais}>{fmtFee(r.margin, r.fees)}</td>
       <td className="num roi-badge" title={titreFrais}>{r.fees > 0 ? "≈ " : ""}{r.roi}%</td>
-      <td className="num" title={caisses ? `Caisses : ${caisses}` : undefined}>{c.fmt(r.units)}</td>
-      <td className="num">{c.fmt(r.investment)}</td>
+      <td className="num" title={caisses ? `Caisses : ${caisses}` : undefined}>{fmt(r.units)}</td>
+      <td className="num">{fmt(r.investment)}</td>
       <td className="num profit" title={titreFrais}>
-        {c.fmtFee(r.profit, r.fees)}
+        {fmtFee(r.profit, r.fees)}
         {fc.mark ? <> <span className="nofee">⊘</span></> : null}
       </td>
       <td className="num profit" title={c.avecTexteFrais(`Estimation ${Math.round(r.minutes)} min/voyage`, fc)}>
-        {c.fmtFee(r.profitHour, r.fees)}
+        {fmtFee(r.profitHour, r.fees)}
       </td>
     </tr>
   );
@@ -200,12 +196,10 @@ const COLONNES = 10;
 // `<tbody>` : React n'en savait rien, ne le déplaçait pas au re-tri et ne l'effaçait pas au
 // changement de mode. Il survivait donc aux rendus en devenant faux (#125). Rendu ici, il n'a plus
 // d'existence propre : il est une conséquence de l'état, comme le reste du tableau.
-function ChargementDeplie({ t, colonnes, texteProfitLigne, libelleCaissesScu, fmt, fmtVol }: {
+function ChargementDeplie({ t, colonnes, texteProfitLigne, libelleCaissesScu }: {
   t: LigneMulti; colonnes: number;
   texteProfitLigne: ProprietesMulti["texteProfitLigne"];
   libelleCaissesScu: ProprietesMulti["libelleCaissesScu"];
-  fmt: Fmt;
-  fmtVol: ProprietesCommunes["fmtVol"];
 }) {
   return (
     <tr className="schema-row">
@@ -243,7 +237,7 @@ function LigneComposee({ t, celluleFrais, libelleCaisses, releveLePlusAncien, te
   const fc = celluleFrais(t);
   const titreFrais = fc.text || undefined;
   const caisses = libelleCaisses(t);
-  const noms = t.lines.map((l) => `${l.name} (${c.fmt(l.units)} SCU)`).join(" · ");
+  const noms = t.lines.map((l) => `${l.name} (${fmt(l.units)} SCU)`).join(" · ");
 
   const bout = (p: LigneMulti["origin"] | LigneMulti["dest"], fraicheur: number | null) => (
     <td className="loc">
@@ -287,22 +281,22 @@ function LigneComposee({ t, celluleFrais, libelleCaisses, releveLePlusAncien, te
       {bout(t.origin, releveLePlusAncien(t))}
       {bout(t.dest, null)}
       <td><CelluleFiabilite f={t.fiabilite} age={t.age} part={t.partVolume} /></td>
-      <td className="num" title={c.avecTexteFrais("Marge moyenne pondérée par SCU chargé", fc)}>{c.fmtFee(t.margin, t.fees)}</td>
+      <td className="num" title={c.avecTexteFrais("Marge moyenne pondérée par SCU chargé", fc)}>{fmtFee(t.margin, t.fees)}</td>
       <td className="num roi-badge" title={titreFrais}>{t.fees > 0 ? "≈ " : ""}{t.roi}%</td>
-      <td className="num" title={caisses ? `Caisses : ${caisses}` : undefined}>{c.fmt(t.units)}</td>
-      <td className="num">{c.fmt(t.investment)}</td>
+      <td className="num" title={caisses ? `Caisses : ${caisses}` : undefined}>{fmt(t.units)}</td>
+      <td className="num">{fmt(t.investment)}</td>
       <td className="num profit" title={titreFrais}>
-        {c.fmtFee(t.profit, t.fees)}
+        {fmtFee(t.profit, t.fees)}
         {fc.mark ? <> <span className="nofee">⊘</span></> : null}
       </td>
       <td className="num profit" title={c.avecTexteFrais(`Estimation ${Math.round(t.minutes)} min/voyage`, fc)}>
-        {c.fmtFee(t.profitHour, t.fees)}
+        {fmtFee(t.profitHour, t.fees)}
       </td>
     </tr>
   );
 
   return deplie
-    ? <>{ligne}<ChargementDeplie t={t} colonnes={COLONNES} texteProfitLigne={texteProfitLigne} libelleCaissesScu={libelleCaissesScu} fmt={c.fmt} fmtVol={c.fmtVol} /></>
+    ? <>{ligne}<ChargementDeplie t={t} colonnes={COLONNES} texteProfitLigne={texteProfitLigne} libelleCaissesScu={libelleCaissesScu} /></>
     : ligne;
 }
 

--- a/vues/voyage.tsx
+++ b/vues/voyage.tsx
@@ -15,6 +15,7 @@
 //     et le détruisait à chaque rendu. La carte étant passée à React, ce détour n'a plus de raison
 //     d'être — et un conteneur peint à part DANS une carte possédée par React est précisément le
 //     piège de #120.
+import { fmt, fmtFee, signe } from "../format.ts";
 import { Fragment } from "react";
 import { PointFraicheur, IconeCommodite, TagIllegal } from "./communs.tsx";
 import { Suggestions, type ProprietesSuggestions } from "./manifeste.tsx";
@@ -74,8 +75,6 @@ export type ProprietesVoyage = {
   suggestionsArret: SuggestionArret[] | null;
   /** Bougée à chaque rendu SAUF pendant la frappe — elle remonte les champs SCU des jambes. */
   generation: number;
-  fmt: Fmt;
-  signe: (n: number, texte: string) => string;
 };
 
 const classeProfit = (n: number) => (n < 0 ? "perte" : "profit");
@@ -190,7 +189,7 @@ function JambeVoyage({ p, j }: { p: ProprietesVoyage; j: Jambe }) {
             {j.chargee ? "⬢ à bord" : "✓ chargé"}
           </button>
         ) : null}
-        <span className={"jleg-profit " + classeProfit(j.nombreTotal)}>{p.signe(j.nombreTotal, j.texteTotal)}</span>
+        <span className={"jleg-profit " + classeProfit(j.nombreTotal)}>{signe(j.nombreTotal, j.texteTotal)}</span>
         <span className="jleg-caret">{j.depliee ? "▾" : "▸"}</span>
       </div>
       <div className="jleg-cargo">
@@ -208,7 +207,7 @@ function JambeVoyage({ p, j }: { p: ProprietesVoyage; j: Jambe }) {
                 <TagIllegal illegal={l.illegal} />
               </span>
               {" "}
-              <b>{`${p.fmt(l.units)} SCU`}</b>
+              <b>{`${fmt(l.units)} SCU`}</b>
             </span>
           ))
         )}
@@ -266,11 +265,11 @@ export function CarteVoyage(p: ProprietesVoyage) {
             <button
               className="jstop-suggest"
               data-label={s.label}
-              title={`Ajouter ${s.terminal} — via ${s.commodity}, +${p.fmt(s.margin)} marge/SCU`}
+              title={`Ajouter ${s.terminal} — via ${s.commodity}, +${fmt(s.margin)} marge/SCU`}
               key={s.label}
             >
               {`+ ${s.terminal} `}
-              <span className="muted">{`+${p.fmt(s.margin)}`}</span>
+              <span className="muted">{`+${fmt(s.margin)}`}</span>
             </button>
           ))}
         </div>
@@ -281,7 +280,7 @@ export function CarteVoyage(p: ProprietesVoyage) {
       )}
       <div className="journey-meta">
         {`${n} saut${n > 1 ? "s" : ""} · marge cumulée `}
-        <b className="profit">{p.fmt(p.margeCumulee)}</b>
+        <b className="profit">{fmt(p.margeCumulee)}</b>
         {" aUEC/SCU"}
       </div>
     </>
@@ -299,8 +298,6 @@ export type ProprietesRecap = {
   systems: number;
   materials: number;
   marchePret: boolean;
-  fmt: Fmt;
-  signe: (n: number, texte: string) => string;
 };
 
 const Kpi = ({ v, lbl }: { v: string | number; lbl: string }) => (
@@ -316,15 +313,15 @@ export function RecapVoyage(p: ProprietesRecap) {
       <div className="recap-head">◈ Résumé du voyage</div>
       <div
         className={"recap-profit " + classeProfit(p.totalProfit)}
-        title={p.totalFees > 0 ? `Frais d'autoload ≈ ${p.fmt(p.totalFees)} aUEC déjà déduits — estimation (±3 %)` : undefined}
+        title={p.totalFees > 0 ? `Frais d'autoload ≈ ${fmt(p.totalFees)} aUEC déjà déduits — estimation (±3 %)` : undefined}
       >
-        {p.marchePret ? p.signe(p.totalProfit, (p.totalFees > 0 ? "≈ " : "") + p.fmt(p.totalProfit)) : "…"}
+        {p.marchePret ? signe(p.totalProfit, (p.totalFees > 0 ? "≈ " : "") + fmt(p.totalProfit)) : "…"}
         {" "}
         <span>aUEC</span>
       </div>
       <div className="recap-kpis">
         <Kpi v={p.n} lbl={"saut" + (p.n > 1 ? "s" : "")} />
-        <Kpi v={p.marchePret ? p.fmt(p.totalScu) : "…"} lbl="SCU" />
+        <Kpi v={p.marchePret ? fmt(p.totalScu) : "…"} lbl="SCU" />
         <Kpi v={p.systems} lbl={"système" + (p.systems > 1 ? "s" : "")} />
         <Kpi v={p.marchePret ? p.materials : "…"} lbl={"matériau" + (p.materials > 1 ? "x" : "")} />
       </div>


### PR DESCRIPTION
## Ce que ça change

Rien à l'écran. `fmt` était **injecté en prop dans onze composants**, `fmtVol`, `fmtFee` et `signe`
dans la moitié : **36 déclarations de props** pour afficher un nombre.

C'est exactement ce qu'une application écrite de zéro en React n'aurait pas fait — on n'injecte pas
un formateur, on l'importe. `format.ts` les porte tous les cinq.

**36 props de formatage → 0.** `app.js` perd 22 lignes de plomberie.

## Pourquoi ça compte au-delà du confort

- Les cinq sont **purs**, donc `tsc` les couvre. Ils étaient jusqu'ici du JavaScript non vérifié
  dans `app.js`.
- **C'est une marche vers la racine unique** : un composant qui importe ce dont il a besoin peut
  vivre dans un arbre. Un composant qui reçoit ses formateurs d'`app.js` ne le peut pas — c'est
  précisément ce qui bloque aujourd'hui, et je l'ai constaté en essayant d'attaquer la racine
  directement (`renderTour` a besoin de `readFilters`, `effVals`, `stationCourante`… qui ne sortent
  pas d'`app.js`).

## Une erreur commise en chemin, et ce qu'elle apprend

Le retrait des props se faisait par expression régulière. Sur la ligne
`fmt, fmtProfit: fmtFee, signe,` elle a mangé la **valeur** d'une prop nommée et laissé
`fmtProfit: signe` — deux fonctions de signatures différentes.

**Rien ne l'a vue** : ni `vite build`, ni `tsc --noEmit`, ni les 484 unitaires, ni les 224 e2e.
`app.js` n'est pas typé, et aucun test ne regarde le format du profit du Plan de vol.

Trouvée en **relisant le diff ligne à ligne**, corrigée, et confirmée par le contrat de
`vues/plan.tsx:43` — `fmtProfit: (n: number, fees: number) => string`, la signature de `fmtFee` et
non celle de `signe`.

La leçon, qui vaut pour la suite du démontage : **une substitution mécanique se relit
intégralement, même quand tout est vert.**

## Vérification

**`node --test` → 484 tests, 484 pass, 0 fail.**
**`npx playwright test` → 224 passed, 2 skipped, 0 failed** (1,4 min).
**`npx tsc --noEmit` → silencieux.**
**`npm run build:site` → OK**, précache à 20 entrées.

Contrôle final : `grep` des cinq noms comme **props** dans `vues/*.tsx` → **0**.

Le typecheck a servi de guide tout du long : chaque prop retirée d'un type faisait apparaître ses
sites d'appel, un par un, jusqu'à zéro erreur. C'est ce que `app.js` ne permet pas — et c'est
l'argument pour continuer à en sortir du code.

## Ce qui n'est pas couvert

- **`esc` reste dans `app.js`** : ses 9 `innerHTML` légitimes en ont encore besoin. Il partira avec
  eux, pas avant.
- Le format du profit du Plan de vol **n'est gardé par aucun test** — c'est ce qui a laissé passer
  l'erreur ci-dessus jusqu'à la relecture. Je le signale plutôt que d'ajouter un test à la hâte dans
  une PR de refactor ; il a sa place avec la migration de cette vue.
- Les autres aides d'`app.js` (`readFilters`, `effVals`, `feeResolver`, `stationCourante`…) **ne
  bougent pas ici**. Ce sont elles qui bloquent la racine unique, et elles ne sont pas pures : elles
  lisent le DOM et l'état. Elles méritent leur propre PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
