### PR TITLE
refactor(voyage): les filtres et les corrections sortent d'app.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,7 +5,7 @@ import {
   tripMinutes, ageDays, pairAge,
   scoreBarWidth, bySort, addableUnits, scuBoxes, cargoBoxes, bestChain,
   AUTOLOAD, autoloadFee, autoloadPoint, lineHaulFee, lineNet, kFromReading, kPlausible,
-  ovKey, effFromStore, setInStore, DUREE_VOL, groupOverridesByTerminal, safeKey, encodeState, decodeState,
+  ovKey, DUREE_VOL, groupOverridesByTerminal, safeKey, encodeState, decodeState,
   routePasses, loopPasses,
   routeMetrics, loopMetrics, enRouteDeals, bestManifest, buildChainAdjacency, suggestionsFrom, netMarginRoi,
   commoditySummaries, commodityPoints, compactValue, valueTiers, resolveCommodity, ambiguousCodes,
@@ -29,6 +29,8 @@ import {
 import { peindre } from "./pont.js";
 import { etat, notifier } from "./etat.ts";
 import { fmt, fmtVol, fmtFee, signe, TEXTE_CAPACITE_INCONNUE } from "./format.ts";
+import { readFilters } from "./filtres.ts";
+import { effVals, loadOverrides, ovCount, relevePerimees, resetOverrides, saveOverrides, setOverride } from "./corrections.ts";
 import { vueTournee, messageSouteVide, messageChargement, messageOuEsTu } from "./vues/tournee.tsx";
 import { vueBoucles } from "./vues/boucles.tsx";
 import { vueChaine, indiceDepart, indiceSoute, indiceAucune } from "./vues/chaine.tsx";
@@ -114,48 +116,7 @@ const SELL_STATUS = { 1: ["Forte demande", "green"], 2: ["Bonne demande", "green
 // L'utilisateur peut corriger un prix ou un volume (stock à l'achat / demande à la vente)
 // quand le relevé UEX est faux. Stocké UNIQUEMENT en local (localStorage), jamais partagé
 // ni dans l'URL. Clé : « commodité|terminal|side » (side = "buy" | "vol"… non : "buy"/"sell").
-const OV_KEY = "best-hauling-overrides";
-// { "Commodité|Terminal|buy": { price?, vol?, base }, ... }
-// base = date UEX (updated) du point AU MOMENT de la correction : la correction vaut
-// « contre cet export ». Elle n'est périmée que si UEX republie ce point plus récemment.
-let supersededKeys = new Set(); // corrections périmées par UEX pendant le rendu courant (pour le flash)
-let expiredVolKeys = new Set(); // volumes périmés par l'ÂGE pendant le rendu courant (autre cause, autre message)
-
 const nowSec = () => Math.floor(Date.now() / 1000);
-
-function loadOverrides() {
-  try { etat.OVERRIDES = JSON.parse(localStorage.getItem(OV_KEY)) || {}; } catch { etat.OVERRIDES = {}; }
-  // Mise à niveau des corrections déjà posées (logic.mjs) : `ts` devient `base`, et AUCUNE date de
-  // saisie n'est inventée pour les prix d'avant `saisiPrix` — ils s'exportent « date inconnue ».
-  // On n'écrit que s'il y avait vraiment quelque chose à normaliser.
-  if (migrerCorrections(etat.OVERRIDES).migres) saveOverrides();
-}
-function saveOverrides() {
-  try { localStorage.setItem(OV_KEY, JSON.stringify(etat.OVERRIDES)); } catch {}
-}
-const ovCount = () => Object.keys(etat.OVERRIDES).length; // ovKey vient de logic.mjs
-
-// Renvoie prix/volume effectifs (corrigés si une correction locale existe) + drapeaux.
-// « Intelligent » : si le relevé UEX du point (dataUpdated) est PLUS RÉCENT que celui
-// contre lequel la correction a été faite (base), la correction est périmée -> on la
-// supprime et on revient à la valeur UEX (comptée pour le flash de notification).
-function effVals(commodity, terminal, side, price, vol, dataUpdated) {
-  const k = ovKey(commodity, terminal, side);
-  const r = effFromStore(etat.OVERRIDES, k, price, vol, dataUpdated); // décision + suppression périmée (logic.mjs)
-  // effets de bord app : persistance + flash. `staleVol` est l'autre cause — le volume a dépassé sa
-  // durée de vie (DUREE_VOL) et le prix, s'il y en avait un, est resté.
-  if (r.stale) { saveOverrides(); supersededKeys.add(k); }
-  else if (r.staleVol) { saveOverrides(); expiredVolKeys.add(k); }
-  return r;
-}
-
-// Enregistre (ou efface) une correction. field = "price"|"vol". value null/"" = efface ce champ.
-// baseUpdated = date UEX du point corrigé (l'état de l'export au moment de la correction).
-function setOverride(commodity, terminal, side, field, value, baseUpdated) {
-  setInStore(etat.OVERRIDES, ovKey(commodity, terminal, side), field, value, baseUpdated); // logic.mjs
-  saveOverrides();
-}
-function resetOverrides() { etat.OVERRIDES = {}; saveOverrides(); }
 
 // ---------- Frais d'autoload : tarif par station + contexte de calcul ----------
 // Le calcul est PUR et vit dans logic.mjs (autoloadFee / autoloadPoint / haulFee). app.js n'y
@@ -300,10 +261,11 @@ function showToast(msg) {
 // Si les deux tombent dans le même rendu, la mise à jour UEX passe en premier — c'est un fait
 // extérieur, l'autre est une simple horloge.
 function notifySuperseded() {
-  const nUex = supersededKeys.size, nAge = expiredVolKeys.size;
+  // Le RELEVÉ vide les compteurs : appeler deux fois de suite ne redit rien. La donnée vit dans
+  // `corrections.ts`, le message reste ici — c'est ce qui permet à `effVals` d'être appelée trente
+  // fois au fond du rendu sans traîner `showToast` derrière elle.
+  const { uex: nUex, age: nAge } = relevePerimees();
   if (!nUex && !nAge) return;
-  supersededKeys = new Set();
-  expiredVolKeys = new Set();
   updateOvBadge();
   const s = (n) => (n > 1 ? "s" : "");
   if (nUex) showToast(`✎ ${nUex} correction${s(nUex)} périmée${s(nUex)} par une mise à jour UEX`);
@@ -367,26 +329,6 @@ function fiabiliteCell(f, age, part) {
 // l'application n'échappe à React, ce qui est la condition de cette suppression.
 
 // Lit l'état de tous les contrôles de filtre (partagé par les deux vues).
-function readFilters() {
-  return {
-    cargo: Math.max(0, Number($("cargo").value) || 0),
-    budget: Math.max(0, Number($("budget").value) || 0),
-    capStock: $("capStock").checked,
-    useCargo: $("useCargo").checked,
-    useBudget: $("useBudget").checked,
-    sameOnly: $("sameSystem").checked,
-    noOutpost: $("noOutpost").checked,
-    legalOnly: $("legalOnly").checked,
-    sysFilter: $("system").value,
-    maxAge: Number($("freshness").value) || 0,
-    q: $("search").value.trim().toLowerCase(),
-    multi: $("multiCommodity").checked,
-    // « avec les simples » : les chargements à UNE commodité rentrent dans le même classement que
-    // les combinés. Par défaut ils en sont exclus — ils sont déjà dans la vue « Trajets » normale.
-    multiAll: $("multiMode").value === "all",
-    autoload: $("autoload").checked,
-  };
-}
 
 
 // Message de #empty tel qu'il est écrit dans index.html. Le <p> est PARTAGÉ par les vues Trajets /

--- a/corrections.ts
+++ b/corrections.ts
@@ -1,0 +1,106 @@
+// Les corrections locales de prix et de volume (ADR-011).
+//
+// L'utilisateur peut corriger un prix ou un volume — stock à l'achat, demande à la vente — quand le
+// relevé UEX est faux. Stocké UNIQUEMENT en local (`localStorage`), jamais partagé ni mis dans
+// l'URL. La clé est « commodité|terminal|côté », et `base` y est la date UEX du point AU MOMENT de
+// la correction : une correction vaut « contre cet export », et n'est périmée que si UEX republie ce
+// point plus récemment.
+//
+// Ce module porte la DONNÉE ; `app.js` garde le MESSAGE. La séparation n'est pas cosmétique :
+// `effVals` est appelée trente fois, au fond du rendu, et elle a des effets de bord (elle persiste
+// et signale). Les deux ensembles de clés périmées vivent donc ici, et l'interface vient les
+// relever par `relevePerimees()` — c'est ce qui permet à la fonction de rester appelable depuis
+// n'importe où sans traîner `showToast` derrière elle.
+
+import { DUREE_VOL, effFromStore, migrerCorrections, ovKey, setInStore } from "./logic.ts";
+import type { ChampCorrection, CoteMarche, ValeurEffective } from "./types.ts";
+import { etat } from "./etat.ts";
+
+const CLE_STOCKAGE = "best-hauling-overrides";
+
+// Périmées PENDANT le rendu courant, et pour deux raisons différentes : une republication UEX d'un
+// côté, le simple vieillissement du volume de l'autre. Deux causes, deux messages — dire « mise à
+// jour UEX » à propos d'un volume qui a juste vieilli enverrait chercher un changement de données
+// qui n'a pas eu lieu.
+let perimeesUex = new Set<string>();
+let perimeesAge = new Set<string>();
+
+export function loadOverrides(): void {
+  try {
+    etat.OVERRIDES = JSON.parse(localStorage.getItem(CLE_STOCKAGE) || "") || {};
+  } catch {
+    etat.OVERRIDES = {};
+  }
+  // Mise à niveau des corrections déjà posées : `ts` devient `base`, et AUCUNE date de saisie n'est
+  // inventée pour les prix d'avant — ils s'exportent « date inconnue ». On n'écrit que s'il y avait
+  // vraiment quelque chose à normaliser.
+  if (migrerCorrections(etat.OVERRIDES).migres) saveOverrides();
+}
+
+export function saveOverrides(): void {
+  try {
+    localStorage.setItem(CLE_STOCKAGE, JSON.stringify(etat.OVERRIDES));
+  } catch {}
+}
+
+export const ovCount = (): number => Object.keys(etat.OVERRIDES).length;
+
+/**
+ * Prix et volume EFFECTIFS — corrigés si une correction locale existe — avec ses drapeaux.
+ *
+ * « Intelligent » : si le relevé UEX du point est plus récent que celui contre lequel la correction
+ * a été faite, la correction est périmée. `effFromStore` la supprime et rend la valeur UEX ; ici on
+ * persiste la suppression et on note la clé, pour que l'interface puisse le dire une fois.
+ */
+export function effVals(
+  commodity: string,
+  terminal: string,
+  side: CoteMarche,
+  price: number,
+  vol: number,
+  dataUpdated: number,
+): ValeurEffective {
+  const k = ovKey(commodity, terminal, side);
+  const r = effFromStore(etat.OVERRIDES, k, price, vol, dataUpdated);
+  if (r.stale) { saveOverrides(); perimeesUex.add(k); }
+  else if (r.staleVol) { saveOverrides(); perimeesAge.add(k); }
+  return r;
+}
+
+/**
+ * Enregistre ou efface une correction. `value` à `null` ou `""` efface ce champ.
+ * `baseUpdated` est la date UEX du point corrigé — l'état de l'export au moment de la correction.
+ */
+export function setOverride(
+  commodity: string,
+  terminal: string,
+  side: CoteMarche,
+  field: ChampCorrection,
+  value: string | number | null | undefined,
+  baseUpdated: number,
+): void {
+  setInStore(etat.OVERRIDES, ovKey(commodity, terminal, side), field, value, baseUpdated);
+  saveOverrides();
+}
+
+export function resetOverrides(): void {
+  etat.OVERRIDES = {};
+  saveOverrides();
+}
+
+/**
+ * Combien de corrections ont péri pendant le rendu qui vient de finir, et pourquoi — puis remet les
+ * compteurs à zéro. C'est un RELEVÉ : appeler deux fois de suite rend zéro la seconde fois, ce qui
+ * est exactement ce qu'on veut d'une notification.
+ */
+export function relevePerimees(): { uex: number; age: number } {
+  const releve = { uex: perimeesUex.size, age: perimeesAge.size };
+  if (releve.uex || releve.age) {
+    perimeesUex = new Set();
+    perimeesAge = new Set();
+  }
+  return releve;
+}
+
+/** La durée de vie d'un volume corrigé, réexportée pour le message qui l'annonce. */
+export { DUREE_VOL };

--- a/filtres.ts
+++ b/filtres.ts
@@ -1,0 +1,43 @@
+// La barre de filtres (ADR-011).
+//
+// `readFilters()` fabrique l'objet que TOUTES les vues consultent : les quatorze contrôles du haut,
+// lus au moment où on en a besoin. Il vivait dans `app.js` et y était appelé 22 fois ; il n'y avait
+// aucune raison qu'il y reste — il ne touche ni à l'état partagé ni au rendu, il lit le DOM et rend
+// un objet.
+//
+// **Il lit le DOM, et c'est délibéré.** Les quatorze champs sont la vérité de ces réglages : les
+// recopier dans `etat.ts` créerait une seconde vérité à tenir d'accord, sur les valeurs les plus
+// lues de l'application. Ils entreront dans l'état avec leur composant, pas avant — c'est la
+// décision prise avec le déménagement des globales (#135).
+
+import type { Filtres } from "./types.ts";
+
+const $ = (id: string) => document.getElementById(id) as HTMLInputElement | HTMLSelectElement | null;
+
+/** La valeur d'un champ, `""` si l'élément a disparu (aucune vue ne le suppose, mais rien ne le garantit). */
+const val = (id: string): string => $(id)?.value ?? "";
+
+/** L'état d'une case. */
+const coche = (id: string): boolean => !!($(id) as HTMLInputElement | null)?.checked;
+
+/** Les quatorze contrôles de la barre, lus d'un coup. */
+export function readFilters(): Filtres {
+  return {
+    cargo: Math.max(0, Number(val("cargo")) || 0),
+    budget: Math.max(0, Number(val("budget")) || 0),
+    capStock: coche("capStock"),
+    useCargo: coche("useCargo"),
+    useBudget: coche("useBudget"),
+    sameOnly: coche("sameSystem"),
+    noOutpost: coche("noOutpost"),
+    legalOnly: coche("legalOnly"),
+    sysFilter: val("system"),
+    maxAge: Number(val("freshness")) || 0,
+    q: val("search").trim().toLowerCase(),
+    multi: coche("multiCommodity"),
+    // « avec les simples » : les chargements à UNE commodité rentrent dans le même classement que
+    // les combinés. Par défaut ils en sont exclus — ils sont déjà dans la vue « Trajets » normale.
+    multiAll: val("multiMode") === "all",
+    autoload: coche("autoload"),
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,5 +36,5 @@
     "verbatimModuleSyntax": true,
     "jsx": "react-jsx"
   },
-  "include": ["logic.ts", "types.ts", "etat.ts", "format.ts", "vues/**/*.tsx"]
+  "include": ["logic.ts", "types.ts", "etat.ts", "format.ts", "filtres.ts", "corrections.ts", "vues/**/*.tsx"]
 }


### PR DESCRIPTION
## Ce que ça change

Rien à l'écran. Deux modules TypeScript de plus, et `app.js` passe de **3 421 à 3 363 lignes** —
avec **deux globales de moins**.

## Pourquoi ces deux-là

C'est la suite du préalable à la racine unique, constaté en essayant au tour précédent : un
composant ne peut pas remplacer un `render*()` tant que les aides dont il a besoin ne sortent pas
d'`app.js`. `readFilters` et `effVals` sont les deux plus appelées — 22 et 30 fois.

### `filtres.ts`

`readFilters()` ne touchait ni à l'état partagé ni au rendu : elle lit les quatorze contrôles de la
barre du haut et rend un objet. Aucune raison qu'elle reste dans la coquille.

**Elle continue de lire le DOM, et c'est délibéré.** Ces quatorze champs sont *la vérité* de ces
réglages ; les recopier dans `etat.ts` créerait une seconde vérité à tenir d'accord, sur les valeurs
les plus lues de l'application. C'est la décision prise avec #135, et elle ne change pas ici : ils
entreront dans l'état avec leur composant, pas avant.

### `corrections.ts` — et ce n'est pas qu'un déménagement

Le store local des corrections : `loadOverrides`, `saveOverrides`, `ovCount`, `effVals`,
`setOverride`, `resetOverrides`.

Les deux ensembles de clés périmées (`supersededKeys`, `expiredVolKeys`) vivaient en **globales**
d'`app.js`, écrites par `effVals` et lues par `notifySuperseded` — qui fait de l'**interface**
(`showToast`, `updateOvBadge`). Les déménager tels quels aurait traîné l'interface derrière une
fonction appelée trente fois au fond du rendu.

Le module garde donc la **donnée**, `app.js` garde le **message** : `relevePerimees()` rend les deux
comptes **et** remet à zéro. Appeler deux fois de suite ne redit rien — c'est exactement ce qu'on
veut d'une notification. **Deux globales de plus disparaissent** au passage.

Deux imports de `logic.ts` (`effFromStore`, `setInStore`) sont devenus morts dans `app.js` et
partent avec.

## Vérification

**`node --test` → 484 tests, 484 pass, 0 fail.**
**`npx playwright test` → 224 passed, 2 skipped, 0 failed** (1,6 min).
**`npx tsc --noEmit` → silencieux** — les deux modules sont dans `tsconfig.include`, donc typés,
alors qu'ils étaient du JavaScript non vérifié.
**`npm run build:site` → OK**, précache à 20 entrées.

Le diff a été **relu ligne à ligne**, y compris les suppressions — c'est la leçon de #136, où une
regex avait silencieusement recâblé une prop sans qu'aucun des quatre outils ne le voie. Ici la
sortie est un déplacement de blocs entiers, pas une substitution, ce qui réduit d'autant la surface
d'erreur.

## Ce qui n'est pas couvert

- **`relevePerimees()` change la forme, pas le comportement** — mais rien ne le garde : aucun test
  ne vérifie les deux messages de péremption. Le comportement est reproduit à l'identique (mêmes
  conditions, même ordre, même remise à zéro), et je le dis plutôt que de le laisser supposer.
- **`nowSec` reste dans `app.js`** : il était déclaré dans le bloc des corrections mais sert
  ailleurs (6 usages). Le sortir serait un autre découpage.
- Les aides qui **bloquent encore** la racine unique : `feeResolver`, `stationCourante`,
  `resolveStationLabel`, et les trois index dérivés de `MARKET` (`originMap`, `stationMap`,
  `termByName`) dont elles dépendent. C'est le morceau suivant, et il est plus enchevêtré que
  ces deux-ci.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
