### PR TITLE
refactor(voyage): les index du marché et la résolution de station sortent d'app.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -31,6 +31,7 @@ import { etat, notifier } from "./etat.ts";
 import { fmt, fmtVol, fmtFee, signe, TEXTE_CAPACITE_INCONNUE } from "./format.ts";
 import { readFilters } from "./filtres.ts";
 import { effVals, loadOverrides, ovCount, relevePerimees, resetOverrides, saveOverrides, setOverride } from "./corrections.ts";
+import { construireIndex, libellesOrigines, libellesStations, originMap, resolveStationLabel, stationMap, termByName } from "./marche.ts";
 import { vueTournee, messageSouteVide, messageChargement, messageOuEsTu } from "./vues/tournee.tsx";
 import { vueBoucles } from "./vues/boucles.tsx";
 import { vueChaine, indiceDepart, indiceSoute, indiceAucune } from "./vues/chaine.tsx";
@@ -510,12 +511,9 @@ function renderLoops() {
 
 // ---------- Mode « En route » (trajet dirigé) + manifeste multi-commodité ----------
 let enrouteReady = false;     // datalist/destSystem peuplés une seule fois
-let originMap = new Map();    // libellé « Nom — Système » -> index terminal (achat uniquement)
-let stationMap = new Map();   // libellé -> index, TOUS les terminaux (pour la vue Corrections)
 // Nom de terminal -> terminal de market.json. Pont indispensable aux frais d'autoload : routes.json
 // et loops.json ne portent QUE des noms, et les noms sont déjà la clé métier du dépôt (corrections
 // locales, jambes de voyage). Peuplée en même temps que stationMap.
-let termByName = new Map();
 let enrouteOrigin = null;     // index du terminal de départ sélectionné
 let stationSel = null;        // index de la station sélectionnée (vue Corrections)
 // Signature du panneau de frais déjà peint : tant qu'elle ne bouge pas, on ne le réécrit pas, et
@@ -590,26 +588,11 @@ function ensureFeeMarket(f, then) {
 // Peuple la liste des terminaux de départ (ceux où l'on peut acheter). Idempotent.
 function setupEnRoute() {
   if (enrouteReady) return;
-  const seen = new Set();
-  const opts = [];
-  etat.MARKET.commodities.forEach((c) => c.buys.forEach((b) => {
-    if (!seen.has(b[0])) {
-      seen.add(b[0]);
-      const t = etat.MARKET.terminals[b[0]];
-      const label = stationLabel(t.name, t.system);
-      originMap.set(label, b[0]);
-      opts.push(label);
-    }
-  }));
-  opts.sort((a, b) => a.localeCompare(b, "fr"));
-  $("originList").innerHTML = opts.map((l) => `<option value="${esc(l)}"></option>`).join("");
-
+  // Les trois index viennent de `marche.ts` ; ici on ne fait plus que peindre les listes.
+  construireIndex(etat.MARKET);
+  $("originList").innerHTML = libellesOrigines().map((l) => `<option value="${esc(l)}"></option>`).join("");
   // Datalist de TOUTES les stations (achat ou vente) pour la vue Corrections.
-  const stations = etat.MARKET.terminals.map((t, i) => ({ label: stationLabel(t.name, t.system), i }));
-  stations.forEach((s) => stationMap.set(s.label, s.i));
-  etat.MARKET.terminals.forEach((t) => termByName.set(t.name, t)); // pont nom -> terminal (frais d'autoload)
-  stations.sort((a, b) => a.label.localeCompare(b.label, "fr"));
-  $("stationList").innerHTML = stations.map((s) => `<option value="${esc(s.label)}"></option>`).join("");
+  $("stationList").innerHTML = libellesStations().map((l) => `<option value="${esc(l)}"></option>`).join("");
 
   // Datalist de TOUTES les commodités (pour l'ajout libre au manifeste).
   $("commodityList").innerHTML = etat.MARKET.commodities
@@ -1815,14 +1798,6 @@ function emptyLeg(fromIdx, toIdx) {
   return { from: ft.name, fromSystem: ft.system, to: tt.name, toSystem: tt.system, commodity: "", buyPrice: 0, sellPrice: 0, margin: 0 };
 }
 // Résout un terminal depuis le texte : libellé exact « Nom — Système », sinon par nom seul.
-function resolveStationLabel(input) {
-  const v = (input || "").trim();
-  if (!v) return null;
-  if (stationMap.has(v)) return stationMap.get(v);
-  const lc = v.toLowerCase();
-  for (const [label, idx] of stationMap) if (parseStationLabel(label).name.toLowerCase() === lc) return idx;
-  return null;
-}
 // Suggestions d'arrêts : meilleures destinations rentables depuis la fin du parcours (top 4).
 function journeyStopSuggestions() {
   const fromIdx = journeyEndIndex();

--- a/marche.ts
+++ b/marche.ts
@@ -1,0 +1,81 @@
+// Les index dérivés du marché (ADR-011).
+//
+// Trois tables construites UNE FOIS à l'arrivée de `market.json`, et consultées partout : le champ
+// de départ d'« En route », le sélecteur de station des Corrections, les frais d'autoload, la
+// résolution d'un nom de terminal en objet.
+//
+// **Elles sont exportées telles quelles, et c'est légitime ici** — contrairement aux 27 globales
+// parties dans `etat.ts` avec le déménagement (#135). Une liaison ES est vivante en lecture mais non
+// réassignable de l'extérieur ; or ces trois-là ne sont JAMAIS réassignées, seulement remplies par
+// `.set()`. C'était déjà le constat de l'inventaire : elles étaient les seules des 53 globales
+// qu'un `import` nu pouvait partager sans accesseur. Elles n'avaient donc rien à faire dans l'état.
+
+import { parseStationLabel, stationLabel } from "./logic.ts";
+import type { Marche, Terminal } from "./types.ts";
+
+/** Libellé « Nom — Système » → index du terminal, ACHAT uniquement (le départ d'« En route »). */
+export const originMap = new Map<string, number>();
+
+/** Libellé → index, TOUS les terminaux (achat ou vente) — c'est la vue Corrections qui l'exige. */
+export const stationMap = new Map<string, number>();
+
+/** Nom de terminal → le terminal lui-même. Le pont qu'utilisent les frais d'autoload. */
+export const termByName = new Map<string, Terminal>();
+
+let construits = false;
+
+/**
+ * Remplit les trois index depuis le marché. IDEMPOTENT : le rappeler ne refait rien.
+ *
+ * Séparé du remplissage des `<datalist>` qui l'accompagnait dans `app.js` : construire un index et
+ * peindre une liste déroulante ne sont pas le même métier, et seul le premier est réutilisable.
+ */
+export function construireIndex(marche: Marche): void {
+  if (construits) return;
+
+  const vus = new Set<number>();
+  for (const c of marche.commodities) {
+    for (const b of c.buys) {
+      const i = b[0] as number;
+      if (vus.has(i)) continue;
+      vus.add(i);
+      const t = marche.terminals[i];
+      originMap.set(stationLabel(t.name, t.system), i);
+    }
+  }
+
+  marche.terminals.forEach((t, i) => {
+    stationMap.set(stationLabel(t.name, t.system), i);
+    termByName.set(t.name, t);
+  });
+
+  construits = true;
+}
+
+/** Les libellés d'origine, triés — ce que la `<datalist>` de départ affiche. */
+export const libellesOrigines = (): string[] =>
+  [...originMap.keys()].sort((a, b) => a.localeCompare(b, "fr"));
+
+/** Les libellés de toutes les stations, triés. */
+export const libellesStations = (): string[] =>
+  [...stationMap.keys()].sort((a, b) => a.localeCompare(b, "fr"));
+
+/**
+ * Un libellé saisi → l'index du terminal, ou `null`.
+ *
+ * DEUX passes, et l'ordre compte : d'abord l'égalité EXACTE sur le libellé complet
+ * (« Nom — Système »), qui est ce que la `<datalist>` propose et ce que le permalien transporte ;
+ * seulement ensuite le repli sur le nom seul, insensible à la casse, pour ce que l'utilisateur tape
+ * à la main. Inverser les deux ferait gagner un homonyme d'un autre système contre la valeur exacte.
+ */
+export function resolveStationLabel(input: string | null | undefined): number | null {
+  const v = (input || "").trim();
+  if (!v) return null;
+  const exact = stationMap.get(v);
+  if (exact != null) return exact;
+  const lc = v.toLowerCase();
+  for (const [label, idx] of stationMap) {
+    if (parseStationLabel(label).name.toLowerCase() === lc) return idx;
+  }
+  return null;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,5 +36,5 @@
     "verbatimModuleSyntax": true,
     "jsx": "react-jsx"
   },
-  "include": ["logic.ts", "types.ts", "etat.ts", "format.ts", "filtres.ts", "corrections.ts", "vues/**/*.tsx"]
+  "include": ["logic.ts", "types.ts", "etat.ts", "format.ts", "filtres.ts", "corrections.ts", "marche.ts", "vues/**/*.tsx"]
 }


### PR DESCRIPTION
## Ce que ça change

Rien à l'écran. `marche.ts` porte les trois tables construites à l'arrivée de `market.json` —
`originMap`, `stationMap`, `termByName` —, leur construction, et `resolveStationLabel`.

`app.js` : **3 363 → 3 346 lignes**, **21 lignes de globales** (elles étaient 47 avant #135).

## Pourquoi ces trois-là sont exportées telles quelles

Les 27 globales de #135 ont dû passer par un objet d'état parce qu'une liaison ES est vivante en
**lecture** mais non réassignable de l'extérieur, et qu'elles sont réaffectées.

**Celles-ci ne le sont jamais** — seulement remplies par `.set()`. C'était déjà le constat de
l'inventaire : les seules des 53 qu'un `import` nu pouvait partager sans accesseur. Elles n'avaient
donc rien à faire dans `etat.ts`, et elles n'y sont pas allées.

## La ligne de découpe

`setupEnRoute` faisait **deux métiers** dans la même fonction : construire des index depuis le
marché, et peindre trois `<datalist>`. Seul le premier est réutilisable.

Le module prend la construction — idempotente, comme avant —, `app.js` garde la peinture et lui
demande des libellés triés. C'est la même séparation qu'en #137 entre la donnée et le message.

`resolveStationLabel` suit, parce qu'il ne dépend que de `stationMap` et de `logic.ts`.

Son commentaire dit désormais ce que le code taisait : **l'ordre des deux passes est porteur.**
L'égalité **exacte** sur le libellé complet d'abord — c'est ce que la datalist propose et ce que le
permalien transporte — et seulement ensuite le repli sur le nom seul, insensible à la casse.
Inversées, un homonyme d'un autre système gagnerait contre la valeur exacte.

## Vérification

**`node --test` → 484 tests, 484 pass, 0 fail.**
**`npx playwright test` → 224 passed, 2 skipped, 0 failed** (1,8 min).
**`npx tsc --noEmit` → silencieux** — `marche.ts` est dans `tsconfig.include`, donc typé.
**`npm run build:site` → OK**, précache à 20 entrées.

Diff relu ligne à ligne, suppressions comprises.

Une équivalence à signaler parce qu'elle n'est pas littérale : `if (stationMap.has(v)) return
stationMap.get(v)` est devenu `const exact = stationMap.get(v); if (exact != null) return exact`.
Les deux se comportent pareil ici — l'index `0` est un terminal valide et `0 != null` est vrai —
mais c'est une réécriture, pas un déplacement, et elle mérite d'être dite.

## Ce qui n'est pas couvert

- **`stationCourante` et `feeResolver` restent dans `app.js`.** La première lit `enrouteOrigin`, la
  seconde passe par `kFor` — toutes deux dérivent du DOM. Elles partiront avec le module des frais
  d'autoload, qui est la tranche suivante (303 lignes, la plus grosse encore en place).
- **Aucun test ne garde l'ordre des deux passes de `resolveStationLabel`**, alors que c'est
  exactement ce que le commentaire signale comme fragile. Le comportement est reproduit à
  l'identique ; le garder demanderait une fixture à deux terminaux homonymes dans des systèmes
  différents, ce qui relève d'un test de `logic.ts` — hors de cette PR.
- `construireIndex` garde sa propre idempotence (`construits`), distincte de l'`enrouteReady`
  d'`app.js` qui garde aussi les datalists. Deux verrous pour deux périmètres, là où il n'y en avait
  qu'un : c'est voulu, mais ça fait un état de plus à connaître.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
