### PR TITLE
refactor(voyage): le chargement des données sort d'app.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,6 +34,7 @@ import { effVals, loadOverrides, ovCount, relevePerimees, resetOverrides, saveOv
 import { construireIndex, libellesOrigines, libellesStations, originMap, resolveStationLabel, stationMap, termByName } from "./marche.ts";
 import { alKey, feeCargoText, feeCell, feeCtx, feeEndText, feeLoadText, feeResolver, globalK, kFmt, kFor, lineProfitText, loadAutoloadK, saveAutoloadK } from "./frais.ts";
 import { applyState, loadState, saveState, shareURL } from "./persistance.ts";
+import { brancher, ensureFeeMarket, ensureStarmap, withMarket } from "./donnees.ts";
 import { vueTournee, messageSouteVide, messageChargement, messageOuEsTu } from "./vues/tournee.tsx";
 import { vueBoucles } from "./vues/boucles.tsx";
 import { vueChaine, indiceDepart, indiceSoute, indiceAucune } from "./vues/chaine.tsx";
@@ -407,63 +408,8 @@ let feesRendus = null;
 //     « Chaîne », « Commodités » et « Corrections » pour TOUTE la session — autocomplétion vide,
 //     0 tuile, « aucune chaîne rentable » — sans le moindre message, et seul un rechargement
 //     complet réparait. L'erreur remonte donc aux appelants, et l'action suivante réessaie.
-let MARKET_LOADING = null;
-function loadMarket() {
-  if (etat.MARKET) return Promise.resolve(etat.MARKET);
-  if (!MARKET_LOADING) {
-    MARKET_LOADING = fetch("data/market.json")
-      .then((r) => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); })
-      .then((m) => (etat.MARKET = m))
-      .catch((e) => { MARKET_LOADING = null; throw e; }); // rien n'est retenu -> réessai possible
-  }
-  return MARKET_LOADING;
-}
-
-// Géométrie des systèmes pour la carte du voyage (cf. ADR-001). 1,5 ko, chargé à la demande et une
-// seule fois : la carte n'existe que s'il y a un voyage, inutile de le payer sur une page nue.
-// Un échec ne bloque rien — la carte reste simplement absente, le reste du compagnon fonctionne.
-let starmapPending = false;
-function ensureStarmap(then) {
-  if (etat.STARMAP || starmapPending) return;
-  starmapPending = true;
-  fetch("data/starmap.json")
-    .then((r) => r.json())
-    .then((s) => { etat.STARMAP = s; starmapPending = false; then(); })
-    .catch(() => { starmapPending = false; }); // silencieux : un panneau décoratif n'alarme personne
-}
-
 // Prévient que le marché est indisponible plutôt que de laisser la vue vide ET muette.
 const marketUnavailable = () => showToast("⚠ Marché indisponible — vérifie ta connexion, puis réessaie");
-
-// Exécute `then` une fois le marché chargé et les datalists peuplées. Point de passage unique de
-// toutes les vues qui ont besoin du graphe : c'est lui qui garantit que `setupEnRoute()` ne tourne
-// jamais sur un marché vide (il pose `enrouteReady`, qui figerait les datalists une fois pour toutes).
-// RÈGLE : une VUE ne se repasse jamais elle-même ici, elle passe `refresh` — le fetch dure, et
-// l'utilisateur peut avoir changé de vue entre-temps. Rappeler son propre rendu repeignait alors
-// #empty et #manifest (partagés par Trajets / Boucles / En route) par-dessus la vue quittée :
-// message « choisis un terminal de départ » sous un tableau de trajets plein, ou inversement
-// « aucune route ne correspond » masqué au-dessus d'un tableau vide. `renderJourney`, lui, n'est
-// lié à AUCUNE vue (la carte Voyage est toujours à l'écran) et se repasse donc bien lui-même.
-function withMarket(then) {
-  loadMarket().then(() => { setupEnRoute(); then(); }).catch(marketUnavailable);
-}
-
-// Les vues « Trajets » et « Boucles » lisent routes.json / loops.json, qui ne portent que des NOMS
-// de terminaux : `autoload` et `maxBox` n'existent que dans market.json, que ces deux vues n'ont
-// jamais eu besoin de charger. On le charge donc en TÂCHE DE FOND et on re-rend à l'arrivée, plutôt
-// que de retarder — ou de vider — la vue par défaut de l'app derrière un fetch de 85 ko : le tableau
-// reste lisible, ses profits simplement bruts le temps du chargement.
-// En cas d'échec on NE re-rend PAS : ce re-rendu rappellerait ensureFeeMarket, qui relancerait un
-// fetch (loadMarket ne mémorise jamais l'échec), en boucle. La prochaine action de l'utilisateur
-// réessaiera, ce qui est exactement la règle de loadMarket.
-let feeMarketPending = false;
-function ensureFeeMarket(f, then) {
-  if (!f.autoload || etat.MARKET || feeMarketPending) return;
-  feeMarketPending = true;
-  loadMarket()
-    .then(() => { feeMarketPending = false; setupEnRoute(); then(); })
-    .catch(() => { feeMarketPending = false; marketUnavailable(); });
-}
 
 // Peuple la liste des terminaux de départ (ceux où l'on peut acheter). Idempotent.
 function setupEnRoute() {
@@ -2700,6 +2646,10 @@ function syncToggles() {
 }
 
 async function init() {
+  // Les deux crochets du chargement : `donnees.ts` sait charger, il ne sait rien des `<datalist>`
+  // ni des messages. `setupEnRoute` DOIT tourner avant chaque rappel de `withMarket` — le déclarer
+  // ici une fois vaut mieux que de le répéter à seize appels.
+  brancher({ apresMarche: setupEnRoute, signalerIndisponible: marketUnavailable });
   setupSort();
   setupLoopSort();
   applySortIndicators(); // aria-sort/classes du tri par défaut, sans dépendre des attributs du HTML

--- a/donnees.ts
+++ b/donnees.ts
@@ -1,0 +1,80 @@
+// Le chargement des données à la demande (ADR-011).
+//
+// `routes.json` est chargé à l'amorçage ; les deux autres non, et c'est délibéré :
+//   — `market.json` (85 ko) n'est lu que par les vues qui ont besoin du graphe d'échange ;
+//   — `starmap.json` (1,5 ko) n'est lu que s'il y a un voyage à dessiner.
+// La vue par défaut ne paie donc ni l'un ni l'autre.
+//
+// ── DEUX CROCHETS, ET POURQUOI ILS SONT EXPLICITES ────────────────────────────────────────────
+// Ce module sait charger ; il ne sait rien des `<datalist>` ni des messages. Or `withMarket` porte
+// un CONTRAT que ni l'un ni l'autre ne peut deviner : `setupEnRoute()` doit tourner AVANT le
+// rappel, à chaque passage, sans quoi les listes déroulantes se figeraient sur un marché vide.
+// Le laisser à chaque appelant, c'est seize occasions de l'oublier. On le déclare donc une fois,
+// à l'amorçage, par `brancher()`.
+
+import type { Filtres, Marche, Starmap } from "./types.ts";
+import { etat } from "./etat.ts";
+
+let apresMarche: () => void = () => {};
+let signalerIndisponible: () => void = () => {};
+
+/** Pose les deux crochets. Appelé une fois, à l'amorçage. */
+export function brancher(crochets: { apresMarche: () => void; signalerIndisponible: () => void }): void {
+  apresMarche = crochets.apresMarche;
+  signalerIndisponible = crochets.signalerIndisponible;
+}
+
+// La PROMESSE est mémorisée, jamais l'échec : un `catch` la remet à `null`, donc l'action suivante
+// réessaie. Retenir un rejet condamnerait la session entière à une coupure réseau d'une seconde.
+let marcheEnCours: Promise<Marche> | null = null;
+
+export function loadMarket(): Promise<Marche> {
+  if (etat.MARKET) return Promise.resolve(etat.MARKET);
+  if (!marcheEnCours) {
+    marcheEnCours = fetch("data/market.json")
+      .then((r) => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); })
+      .then((m: Marche) => (etat.MARKET = m))
+      .catch((e) => { marcheEnCours = null; throw e; });
+  }
+  return marcheEnCours;
+}
+
+/**
+ * Exécute `then` une fois le marché chargé ET les listes peuplées. Point de passage UNIQUE de
+ * toutes les vues qui ont besoin du graphe — c'est lui qui garantit que la préparation ne tourne
+ * jamais sur un marché vide.
+ */
+export function withMarket(then: () => void): void {
+  loadMarket().then(() => { apresMarche(); then(); }).catch(signalerIndisponible);
+}
+
+// Un échec ne bloque rien : la carte reste simplement absente, le reste du compagnon fonctionne.
+// Silencieux à dessein — un panneau décoratif n'alarme personne.
+let starmapEnCours = false;
+
+export function ensureStarmap(then: () => void): void {
+  if (etat.STARMAP || starmapEnCours) return;
+  starmapEnCours = true;
+  fetch("data/starmap.json")
+    .then((r) => r.json())
+    .then((s: Starmap) => { etat.STARMAP = s; starmapEnCours = false; then(); })
+    .catch(() => { starmapEnCours = false; });
+}
+
+// « Trajets » et « Boucles » lisent `routes.json` / `loops.json`, qui ne portent que des NOMS de
+// terminaux : `autoload` et `maxBox` n'existent que dans `market.json`. On le charge en TÂCHE DE
+// FOND et on re-rend à l'arrivée, plutôt que de retarder — ou de vider — la vue par défaut derrière
+// un fetch de 85 ko : le tableau reste lisible, ses profits simplement bruts le temps du chargement.
+//
+// En cas d'échec on NE re-rend PAS : ce re-rendu rappellerait cette fonction, qui relancerait un
+// fetch (`loadMarket` ne mémorise jamais l'échec) — en boucle. La prochaine action de l'utilisateur
+// réessaiera, ce qui est exactement la règle de `loadMarket`.
+let fraisEnCours = false;
+
+export function ensureFeeMarket(f: Filtres, then: () => void): void {
+  if (!f.autoload || etat.MARKET || fraisEnCours) return;
+  fraisEnCours = true;
+  loadMarket()
+    .then(() => { fraisEnCours = false; apresMarche(); then(); })
+    .catch(() => { fraisEnCours = false; signalerIndisponible(); });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,5 +36,5 @@
     "verbatimModuleSyntax": true,
     "jsx": "react-jsx"
   },
-  "include": ["logic.ts", "types.ts", "etat.ts", "format.ts", "filtres.ts", "corrections.ts", "marche.ts", "frais.ts", "persistance.ts", "vues/**/*.tsx"]
+  "include": ["logic.ts", "types.ts", "etat.ts", "format.ts", "filtres.ts", "corrections.ts", "marche.ts", "frais.ts", "persistance.ts", "donnees.ts", "vues/**/*.tsx"]
 }


### PR DESCRIPTION
## Ce que ça change

Rien à l'écran. `donnees.ts` porte `loadMarket`, `withMarket`, `ensureStarmap` et
`ensureFeeMarket`, avec leurs trois verrous de concurrence.

**`app.js` : 3 121 → 3 071 lignes**, **17 lignes de globales** — trois de moins, et ce sont les
dernières de l'infrastructure de chargement.

## Deux crochets explicites, et c'est le cœur de cette PR

Le module sait **charger** ; il ne sait rien des `<datalist>` ni des messages.

Or `withMarket` porte un **contrat** que ni l'un ni l'autre ne peut deviner : `setupEnRoute()` doit
tourner **avant** le rappel, à chaque passage, sans quoi les listes déroulantes se figeraient sur un
marché vide. Le laisser à chaque appelant, ce serait **seize occasions de l'oublier**.

Il est donc déclaré **une fois**, à l'amorçage :

```js
brancher({ apresMarche: setupEnRoute, signalerIndisponible: marketUnavailable });
```

`marketUnavailable` **reste** dans `app.js` : il appelle `showToast`. C'est le même partage que pour
les corrections (#137) et la persistance (#140) — la donnée au module, le message à la coquille.

## Trois règles reconduites telles quelles

Elles sont chèrement acquises, et leur commentaire part avec elles :

- **la promesse est mémorisée, jamais l'échec** — retenir un rejet condamnerait la session entière à
  une coupure réseau d'une seconde ;
- **`ensureStarmap` échoue en silence** — un panneau décoratif n'alarme personne ;
- **`ensureFeeMarket` ne re-rend pas en cas d'échec** — ce re-rendu la rappellerait, qui
  relancerait un fetch, en boucle.

## Ce que ça débloque

Avec cette PR, ce qui reste dans `app.js` est le **rendu des vues**, le **câblage** et
l'**amorçage**. La couche d'aides qui bloquait la racine unique est sortie : un composant peut
désormais faire ce que fait `renderTour()` sans rien demander à `app.js`.

## Vérification

**`node --test` → 484 tests, 484 pass, 0 fail.**
**`npx playwright test` → 224 passed, 2 skipped, 0 failed** (1,4 min).
**`npx tsc --noEmit` → silencieux.**
**`npm run build:site` → OK**, précache à 20 entrées.

Contrôle des identifiants après extraction (réflexe depuis #139) : `withMarket` 16, `ensureStarmap`
1, `ensureFeeMarket` 2 — tous importés. `loadMarket` n'est plus appelé directement et sort de
l'import.

## Un incident de manipulation, sans conséquence

J'ai committé ce travail sur `v2/main` local au lieu d'une branche — la branche précédente venait
d'être supprimée par sa fusion et j'étais revenu sur l'intégration. **Rien n'est parti sur le
distant** : `origin/v2/main` n'avait pas bougé. Le commit a été déplacé sur `v2/donnees-ts` et le
`v2/main` local remis sur son origine. Je le signale parce que c'est le genre de chose qui, non
dite, se découvre plus tard dans un historique qu'on ne comprend plus.

## Ce qui n'est pas couvert

- **Les deux crochets sont un état de module**, posés une fois à l'amorçage. Si `brancher()` n'était
  pas appelé, `withMarket` chargerait puis n'appellerait rien — un mode de panne silencieux. Il n'a
  qu'un appelant et il est en tête d'`init()`, mais rien ne l'impose.
- `ensureFeeMarket` prend `Filtres` entier alors qu'elle ne lit que `f.autoload`. C'est le type que
  lui passent ses appelants ; le resserrer serait une décision, pas un déménagement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
