### PR TITLE
feat(voyage): la racine unique, et la Tournée s'y installe la première

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,0 +1,39 @@
+// LA RACINE UNIQUE (ADR-011, étape 3).
+//
+// Une seule racine React possède désormais l'arbre. Elle s'abonne à `etat.ts` par
+// `useSyncExternalStore` : quand `notifier()` est appelée — c'est-à-dire à la fin de `refresh()` et
+// aux cinq rendus ciblés — tout l'arbre se réévalue. Aucun `peindre()` n'est nécessaire pour ce qui
+// vit ici, et aucune prop n'est poussée depuis `app.js` : chaque vue lit ce dont elle a besoin.
+//
+// ── POURQUOI DES PORTAILS, ET POUR COMBIEN DE TEMPS ───────────────────────────────────────────
+// `index.html` porte encore 114 balises de structure, et chaque vue a son conteneur nommé. La
+// racine rend donc ses vues DANS ces conteneurs, par `createPortal`. Ce n'est pas la forme finale —
+// une application écrite de zéro rendrait cette structure elle-même — mais c'est ce qui permet
+// d'emménager vue par vue sans réécrire `index.html` d'un bloc. Chaque portail disparaît quand le
+// markup de son conteneur devient un composant.
+//
+// La racine elle-même se monte sur `#racine`, un nœud vide : elle n'affiche rien en propre.
+import { useSyncExternalStore } from "react";
+import { createPortal } from "react-dom";
+
+import { getSnapshot, subscribe } from "./etat.ts";
+import { VueTourneeEcoulement } from "./vues/tournee-vue.tsx";
+
+/** Rend `noeud` dans le conteneur `id` s'il existe. Un conteneur absent n'est pas une erreur. */
+function Portail({ id, children }: { id: string; children: React.ReactNode }) {
+  const cible = document.getElementById(id);
+  return cible ? createPortal(children, cible) : null;
+}
+
+export function App() {
+  // L'abonnement. `getSnapshot` rend un COMPTEUR et jamais l'objet d'état : `useSyncExternalStore`
+  // compare par `Object.is`, et un objet muté en place rendrait toujours la même référence — React
+  // ne re-rendrait jamais.
+  useSyncExternalStore(subscribe, getSnapshot);
+
+  return (
+    <Portail id="tour">
+      <VueTourneeEcoulement />
+    </Portail>
+  );
+}

--- a/app.js
+++ b/app.js
@@ -35,6 +35,7 @@ import { construireIndex, indexDepartChaine, indexOrigine, libellesOrigines, lib
 import { alKey, feeCargoText, feeCell, feeCtx, feeEndText, feeLoadText, feeResolver, globalK, kFmt, kFor, lineProfitText, loadAutoloadK, saveAutoloadK } from "./frais.ts";
 import { applyState, loadState, saveState, shareURL } from "./persistance.ts";
 import { brancher, ensureFeeMarket, ensureStarmap, withMarket } from "./donnees.ts";
+import { monterRacine } from "./main.tsx";
 import { vueTournee, messageSouteVide, messageChargement, messageOuEsTu } from "./vues/tournee.tsx";
 import { vueBoucles } from "./vues/boucles.tsx";
 import { vueChaine, indiceDepart, indiceSoute, indiceAucune } from "./vues/chaine.tsx";
@@ -1779,32 +1780,6 @@ function renderJourneyRecap({ n, totalProfit, totalScu, totalFees, systems }) {
 // incompatibles, et l'écran doit le dire : sans ça l'app se contredit sous les yeux de
 // l'utilisateur, qui lit deux ordres opposés du même fret.
 
-function renderTour() {
-  const box = $("tour");
-  if (!box) return;
-  if (!etat.SOUTE.length) {
-    peindre(box, messageSouteVide());
-    return;
-  }
-  // Le graphe d'échange porte les débouchés. On passe `refresh` et non `renderTour` : c'est la règle
-  // de withMarket — le fetch dure, et l'utilisateur peut avoir changé de vue entre-temps.
-  if (!etat.MARKET) { withMarket(refresh); peindre(box, messageChargement()); return; }
-  // Le champ de la vue prime sur la position du voyage : on peut vouloir simuler depuis ailleurs.
-  const saisi = $("tourFrom").value.trim();
-  const ici = saisi ? resolveStationLabel(saisi) : stationCourante();
-  if (ici == null) {
-    peindre(box, messageOuEsTu());
-    return;
-  }
-  const f = readFilters();
-  const systeme = etat.MARKET.terminals[ici].system;
-  const toutSysteme = $("tourScope").value === "all";
-  // Portée par défaut = le système où l'on se trouve (27 terminaux en Pyro, 80 en Stanton, 7 en Nyx
-  // sur 114). L'ouvrir est un geste explicite, et le saut apparaît alors comme une ligne de coût.
-  const ft = { ...f, sysFilter: toutSysteme ? f.sysFilter : systeme };
-  const { tournee, alternative } = tourneesEcoulement(etat.MARKET, etat.SOUTE, ici, ft, effVals, feeResolver(f));
-  peindre(box, vueTournee({ tournee, alternative, systeme, toutSysteme, fmt }));
-}
 
 // ---------- Plan de vol : la vue de conclusion (ADR-004) ----------
 // Une CONCLUSION, pas un tableau de bord : on y arrive une fois tout paramétré, pour REGARDER le
@@ -1945,7 +1920,6 @@ function refresh() {
   else if (etat.view === "corrections") renderCorrections();
   else if (etat.view === "commodities") renderCommodities();
   else if (etat.view === "plan") renderPlan();
-  else if (etat.view === "tour") renderTour();
   else render();
   // La carte Voyage est affichée À CÔTÉ des tableaux, dans toutes les vues : la laisser hors du
   // cycle de rendu la figeait sur l'état d'avant. Corriger un prix ne mettait donc pas à jour les
@@ -2628,6 +2602,9 @@ async function init() {
   // ni des messages. `setupEnRoute` DOIT tourner avant chaque rappel de `withMarket` — le déclarer
   // ici une fois vaut mieux que de le répéter à seize appels.
   brancher({ apresMarche: setupEnRoute, signalerIndisponible: marketUnavailable });
+  // La racine unique. Elle s'abonne à `etat` : à partir d'ici, une vue qui y vit se re-rend
+  // toute seule à chaque `notifier()`, sans que `refresh()` ait à la nommer.
+  monterRacine();
   setupSort();
   setupLoopSort();
   applySortIndicators(); // aria-sort/classes du tri par défaut, sans dépendre des attributs du HTML

--- a/index.html
+++ b/index.html
@@ -431,6 +431,11 @@
     </div>
   </div>
 
+  <!-- La racine React unique (ADR-011). Elle n'affiche rien en propre : ses vues sont rendues
+       dans les conteneurs nommés ci-dessus, par portail, le temps que ce markup devienne des
+       composants à son tour. -->
+  <div id="racine"></div>
+
   <script type="module" src="app.js"></script>
   <!-- Sorti de la page pour que `script-src 'self'` ait un sens (cf. la <meta> du <head>).
        Script CLASSIQUE et non module : il doit continuer de s'exécuter AVANT app.js (différé),

--- a/main.tsx
+++ b/main.tsx
@@ -1,0 +1,18 @@
+// Le point de montage de la racine unique (ADR-011, étape 3).
+//
+// `app.js` importe ce module ; il n'y a donc qu'un seul `createRoot` dans toute l'application, là
+// où `pont.js` en créait un par conteneur — quarante et un au total. Ceux qui restent partiront au
+// fur et à mesure que les vues emménagent dans l'arbre.
+import { createRoot } from "react-dom/client";
+import { App } from "./App.tsx";
+
+/** Monte la racine sur `#racine`. Idempotent : deux appels ne créent qu'un arbre. */
+let montee = false;
+
+export function monterRacine(): void {
+  if (montee) return;
+  const cible = document.getElementById("racine");
+  if (!cible) return;
+  createRoot(cible).render(<App />);
+  montee = true;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,5 +36,5 @@
     "verbatimModuleSyntax": true,
     "jsx": "react-jsx"
   },
-  "include": ["logic.ts", "types.ts", "etat.ts", "format.ts", "filtres.ts", "corrections.ts", "marche.ts", "frais.ts", "persistance.ts", "donnees.ts", "vues/**/*.tsx"]
+  "include": ["logic.ts", "types.ts", "etat.ts", "format.ts", "filtres.ts", "corrections.ts", "marche.ts", "frais.ts", "persistance.ts", "donnees.ts", "App.tsx", "main.tsx", "vues/**/*.tsx"]
 }

--- a/vues/tournee-vue.tsx
+++ b/vues/tournee-vue.tsx
@@ -1,0 +1,54 @@
+// La VUE Tournée : le composant qui décide quoi afficher (ADR-011, étape 3).
+//
+// C'est le premier morceau d'`app.js` à devenir un composant plutôt qu'une fonction de rendu.
+// `renderTour()` faisait exactement ceci, puis appelait `peindre()` ; ici on rend, et la racine
+// unique s'occupe du reste.
+//
+// Il ne reçoit AUCUNE prop, et c'est le point : il lit l'état (`etat.ts`), les filtres
+// (`filtres.ts`), résout une station (`marche.ts`), déclenche un chargement (`donnees.ts`) et
+// calcule (`logic.ts`). Il ne demande rien à `app.js`. C'est ce que les six PR d'extraction
+// précédentes ont rendu possible.
+//
+// `tournee.tsx` garde la PRÉSENTATION — les arrêts, le bandeau de plancher, l'alternative. Ce
+// fichier-ci porte la DÉCISION : soute vide, marché absent, position inconnue, ou le calcul.
+import { tourneesEcoulement } from "../logic.ts";
+import { etat, notifier } from "../etat.ts";
+import { readFilters } from "../filtres.ts";
+import { effVals } from "../corrections.ts";
+import { feeResolver } from "../frais.ts";
+import { resolveStationLabel, stationCourante } from "../marche.ts";
+import { withMarket } from "../donnees.ts";
+import { messageChargement, messageOuEsTu, messageSouteVide, vueTournee } from "./tournee.tsx";
+
+const champ = (id: string): string =>
+  (document.getElementById(id) as HTMLInputElement | null)?.value.trim() ?? "";
+
+export function VueTourneeEcoulement() {
+  if (!etat.SOUTE.length) return messageSouteVide();
+
+  // Le graphe d'échange porte les débouchés. `withMarket` reçoit `notifier` et non un rendu ciblé :
+  // le fetch dure, et l'utilisateur peut avoir changé de vue entre-temps — c'est la racine qui
+  // décidera alors quoi réafficher.
+  if (!etat.MARKET) {
+    // `notifier` et non un rendu ciblé : à l'arrivée du marché c'est TOUT l'arbre qui se réévalue,
+    // et chaque vue décide alors elle-même quoi afficher — y compris si l'utilisateur a changé de
+    // vue entre-temps. C'est la même règle que l'ancien `withMarket(refresh)`, sans le rendu.
+    withMarket(notifier);
+    return messageChargement();
+  }
+
+  // Le champ de la vue prime sur la position du voyage : on peut vouloir simuler depuis ailleurs.
+  const saisi = champ("tourFrom");
+  const ici = saisi ? resolveStationLabel(saisi) : stationCourante();
+  if (ici == null) return messageOuEsTu();
+
+  const f = readFilters();
+  const systeme = etat.MARKET.terminals[ici].system;
+  const toutSysteme = champ("tourScope") === "all";
+  // Portée par défaut = le système où l'on se trouve (27 terminaux en Pyro, 80 en Stanton, 7 en Nyx
+  // sur 114). L'ouvrir est un geste explicite, et le saut apparaît alors comme une ligne de coût.
+  const ft = { ...f, sysFilter: toutSysteme ? f.sysFilter : systeme };
+  const { tournee, alternative } = tourneesEcoulement(etat.MARKET, etat.SOUTE, ici, ft, effVals, feeResolver(f));
+
+  return vueTournee({ tournee, alternative, systeme, toutSysteme });
+}


### PR DESCRIPTION
## Ce que ça change

Rien à l'écran. **ADR-011, étape 3** : une seule racine React possède un arbre, abonnée à `etat.ts`
par `useSyncExternalStore`. Quand `notifier()` est appelée — fin de `refresh()` et les cinq rendus
ciblés — **tout l'arbre se réévalue**.

## La Tournée est la première vue à ne rien recevoir

`VueTourneeEcoulement` lit l'état, les filtres, résout une station, déclenche un chargement et
calcule — **sans une prop, sans un import d'`app.js`** :

```
etat.ts · filtres.ts · marche.ts · donnees.ts · corrections.ts · frais.ts · logic.ts
```

C'est exactement ce que les sept PR d'extraction précédentes ont rendu possible, et c'est aussi ce
qui **prouve** que le préalable était bien celui-là : j'avais essayé la racine d'abord, et
`renderTour` réclamait cinq aides qui ne sortaient pas de la coquille.

`renderTour()` disparaît (26 lignes) et `refresh()` ne nomme plus cette vue.

**Les 10 tests de `tournee.pw.mjs` passent sans être touchés** — c'est le contrat de sélecteurs qui
rend ça vérifiable.

## Des portails, et pourquoi

`index.html` porte encore 114 balises de structure, chaque vue ayant son conteneur nommé. La racine
rend donc **dans** ces conteneurs par `createPortal`.

**Ce n'est pas la forme finale** — une application écrite de zéro rendrait cette structure
elle-même. C'est ce qui permet d'emménager **vue par vue** au lieu de réécrire `index.html` d'un
bloc, et chaque portail disparaîtra quand le markup de son conteneur deviendra un composant. Je le
dis ici pour que personne ne prenne le portail pour une décision d'architecture.

## Vérification

**`node --test` → 484 tests, 484 pass, 0 fail.**
**`npx playwright test` → 224 passed, 2 skipped, 0 failed** (1,3 min).
**`npx tsc --noEmit` → silencieux.**
**`npm run build:site` → OK**, précache à 20 entrées.

`app.js` : 3 049 → **3 026 lignes**. Il reste **37 `peindre()`** (41 au départ) ; ils partiront un
par un, chaque vue suivant ce chemin.

Bundle : 349,17 ko (+3,8 ko) — le coût de `useSyncExternalStore` et du portail. Loin du plafond de
coquille.

## Ce qui n'est pas couvert

- **`withMarket` est appelé pendant le rendu**, comme le faisait `renderTour`. C'est un effet de
  bord dans une fonction de rendu, donc impur au sens de React : en mode strict, un double rendu
  l'appellerait deux fois. C'est inoffensif ici — `loadMarket` mémorise la promesse — mais ce n'est
  pas propre, et ça se réglera quand le chargement deviendra un effet ou une suspension. Je le
  signale plutôt que de le maquiller.
- **Le nombre de rendus n'est pas mesuré.** L'arbre se réévalue entièrement à chaque `notifier()`,
  là où `renderTour` n'était appelée que dans sa vue. Avec une seule vue montée, c'est négligeable ;
  ça méritera une mesure quand elles y seront toutes.
- `#racine` est un `<div>` vide ajouté à `index.html`. Il disparaîtra quand la racine rendra la page
  entière — c'est-à-dire à la fin de l'étape 3.
- **La branche reste verte** : l'ADR autorisait le rouge pour cette étape, il n'a pas été nécessaire
  ici. Il le deviendra peut-être quand les vues à état partagé (Trajets, Manifeste) emménageront.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
