### PR TITLE
perf(voyage): l'arbre n'évalue que la vue regardée

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -16,12 +16,23 @@
 import { useSyncExternalStore } from "react";
 import { createPortal } from "react-dom";
 
-import { getSnapshot, subscribe } from "./etat.ts";
+import { etat, getSnapshot, subscribe } from "./etat.ts";
 import { VueTourneeEcoulement } from "./vues/tournee-vue.tsx";
 import { CorpsPlan, EnTetePlan } from "./vues/plan-vue.tsx";
 
-/** Rend `noeud` dans le conteneur `id` s'il existe. Un conteneur absent n'est pas une erreur. */
-function Portail({ id, children }: { id: string; children: React.ReactNode }) {
+/**
+ * Rend `children` dans le conteneur `id`, et SEULEMENT si la vue `si` est celle qu'on regarde.
+ *
+ * Le garde n'est pas une optimisation prématurée, il est MESURÉ : sans lui, chaque `notifier()`
+ * réévalue TOUTES les vues montées, y compris celles que l'utilisateur ne regarde pas. Relevé avec
+ * deux vues dans l'arbre — une frappe dans `#search`, depuis la vue Trajets, évaluait la Tournée
+ * ET le Plan. À treize vues, une frappe recalculerait `commoditySummaries` sur tout le marché pour
+ * un écran que personne ne voit.
+ *
+ * Un conteneur absent n'est pas une erreur : `index.html` peut changer sans casser l'arbre.
+ */
+function Portail({ id, si, children }: { id: string; si?: string; children: React.ReactNode }) {
+  if (si != null && etat.view !== si) return null;
   const cible = document.getElementById(id);
   return cible ? createPortal(children, cible) : null;
 }
@@ -34,11 +45,11 @@ export function App() {
 
   return (
     <>
-      <Portail id="tour"><VueTourneeEcoulement /></Portail>
+      <Portail id="tour" si="tour"><VueTourneeEcoulement /></Portail>
       {/* Le Plan de vol occupe DEUX conteneurs, séparés dans `index.html` par la carte du parcours —
           un élément à écouteurs directs se déménage en frère, jamais en enfant (leçon de #24). */}
-      <Portail id="planHead"><EnTetePlan /></Portail>
-      <Portail id="planBody"><CorpsPlan /></Portail>
+      <Portail id="planHead" si="plan"><EnTetePlan /></Portail>
+      <Portail id="planBody" si="plan"><CorpsPlan /></Portail>
     </>
   );
 }


### PR DESCRIPTION
## Ce que ça change

Rien à l'écran. `<Portail>` prend un `si` : une vue n'est rendue que si `etat.view` correspond.

## Mesuré avant de corriger

Un compteur par vue, trois gestes, depuis la vue **Trajets** — donc avec ni la Tournée ni le Plan à
l'écran :

| geste | avant | après |
|---|---|---|
| 8 frappes dans `#search` | `{tournee: 1, plan: 1}` | `{}` |
| trier une colonne | `{tournee: 1, plan: 1}` | `{}` |
| changer de vue | `{tournee: 1, plan: 1}` | `{}` |

**Chaque `notifier()` réévaluait toutes les vues montées, y compris invisibles.**

Ce n'est rien à deux vues. À treize, une seule frappe recalculerait `commoditySummaries` sur tout le
marché, les manifestes de chaque jambe et la tournée d'écoulement — **pour un écran que personne ne
regarde**. C'est le mur qu'on aurait pris en montant les vues suivantes, et il valait mieux le voir
avec deux vues qu'avec dix.

## Le contrôle qui compte

Une garde qui n'évalue plus rien du tout serait un bug, pas une optimisation. Depuis la Tournée, la
même frappe donne bien **`{tournee: 1}`**.

Et surtout : **les 29 tests des deux vues passent**, sans avoir été touchés. C'est eux qui prouvent
que la garde ne masque rien — une vue qui ne se rendrait plus ferait tomber `plan.pw.mjs` en bloc.

## Vérification

**`node --test` → 484 tests, 484 pass, 0 fail.**
**`npx playwright test` → 224 passed, 2 skipped, 0 failed** (1,4 min).
**`npx tsc --noEmit` → silencieux.**
**`npm run build:site` → OK**.

## Ce qui n'est pas couvert

- **Le garde suppose qu'une vue = un `etat.view`.** C'est vrai des deux vues montées, et de la
  plupart de celles qui suivront ; ça ne le sera **pas** du bandeau (soute, compagnon, déclaration),
  visible dans toutes les vues. Ceux-là se monteront sans `si`, et devront alors être regardés de
  près : ils seront réévalués à chaque geste, partout.
- **Aucun test ne garde cette propriété.** La sonde était un outil de PR ; si quelqu'un retire un
  `si`, rien ne le dira. Un test qui compterait les évaluations serait possible — il faudrait
  instrumenter les composants, ce qui laisse une trace en production.
- Le gain n'est pas mesuré en **temps** : je compte des évaluations, pas des millisecondes. Ce qui
  est établi, c'est que le travail inutile existait et qu'il n'existe plus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
