### PR TITLE
refactor(uex): les vues qui AGISSENT peuvent enfin emménager dans l'arbre

### DIFF
--- a/app.js
+++ b/app.js
@@ -35,6 +35,7 @@ import { construireIndex, findCommodity, indexDepartChaine, indexOrigine, libell
 import { alKey, feeCargoText, feeCell, feeCtx, feeEndText, feeLoadText, feeResolver, globalK, kFmt, kFor, lineProfitText, loadAutoloadK, saveAutoloadK } from "./frais.ts";
 import { applyState, loadState, saveState, shareURL } from "./persistance.ts";
 import { brancher, ensureFeeMarket, ensureStarmap, withMarket } from "./donnees.ts";
+import { brancherRendu } from "./rendu.ts";
 import { monterRacine } from "./main.tsx";
 import { planData, planHypotheses } from "./vues/plan-vue.tsx";
 import { jambeChargee, legEffectiveLines, legFeeCtx, legIntent, legKey, legManifest, legTerminals, loadJourneyEdits, loadJourneyPins, saveJourneyEdits, saveJourneyPins } from "./voyage-donnees.ts";
@@ -2449,6 +2450,10 @@ async function init() {
   // ni des messages. `setupEnRoute` DOIT tourner avant chaque rappel de `withMarket` — le déclarer
   // ici une fois vaut mieux que de le répéter à seize appels.
   brancher({ apresMarche: setupEnRoute, signalerIndisponible: marketUnavailable });
+  // Le crochet de rendu : c'est ce qui rend `refresh()` joignable depuis un module, et donc depuis
+  // une vue de l'arbre qui porte une ACTION. `notifier()` seule ne suffirait pas — elle ne rejoue
+  // ni la carte du voyage, ni la soute, ni `saveState()`. Voir l'en-tête de `rendu.ts`.
+  brancherRendu({ rafraichir: refresh });
   // La racine unique. Elle s'abonne à `etat` : à partir d'ici, une vue qui y vit se re-rend
   // toute seule à chaque `notifier()`, sans que `refresh()` ait à la nommer.
   monterRacine();

--- a/app.js
+++ b/app.js
@@ -33,7 +33,7 @@ import { readFilters } from "./filtres.ts";
 import { effVals, isOv, loadOverrides, ovCount, resetOverrides, saveOverrides, setOverride } from "./corrections.ts";
 import { corriger, notifySuperseded, updateOvBadge } from "./corrections-actions.ts";
 import { showToast } from "./messages.ts";
-import { construireIndex, findCommodity, indexDepartChaine, indexOrigine, libellesOrigines, libellesStations, resolveStationLabel, stationCourante, stationMap, termByName } from "./marche.ts";
+import { construireIndex, findCommodity, indexDepartChaine, indexOrigine, indexStationExacte, libellesOrigines, libellesStations, resolveStationLabel, stationCourante, stationMap, termByName } from "./marche.ts";
 import { alKey, feeCargoText, feeCell, feeCtx, feeEndText, feeLoadText, feeResolver, globalK, kFmt, kFor, lineProfitText, loadAutoloadK, saveAutoloadK } from "./frais.ts";
 import { applyState, loadState, saveState, shareURL } from "./persistance.ts";
 import { brancher, ensureFeeMarket, ensureStarmap, withMarket } from "./donnees.ts";
@@ -371,7 +371,16 @@ let enrouteReady = false;     // datalist/destSystem peuplés une seule fois
 // Nom de terminal -> terminal de market.json. Pont indispensable aux frais d'autoload : routes.json
 // et loops.json ne portent QUE des noms, et les noms sont déjà la clé métier du dépôt (corrections
 // locales, jambes de voyage). Peuplée en même temps que stationMap.
-let stationSel = null;        // index de la station sélectionnée (vue Corrections)
+// La dernière station RENDUE. Elle ne sert QU'au garde du champ #station — ne pas re-rendre si la
+// station résolue n'a pas changé, sans quoi le rendu différé du debounce détache l'éditeur d'un
+// chiffre ouvert entre les deux (même famille que #24). Ce n'est donc PAS la station affichée :
+// celle-là se dérive à chaque lecture par `indexStationExacte()`.
+//
+// `undefined` et non `null` : `null` est une valeur mesurée (« le champ ne désigne rien »), et les
+// confondre rendrait la première transition « restaurée par permalien → champ rendu illisible »
+// invisible au garde — le panneau resterait sur l'ancienne station à côté d'un champ vide.
+let derniereStation;
+const memoriserStation = () => { derniereStation = indexStationExacte(); };
 // Signature du panneau de frais déjà peint : tant qu'elle ne bouge pas, on ne le réécrit pas, et
 // une saisie en cours y survit (#24).
 let feesRendus = null;
@@ -441,9 +450,9 @@ function monteStationPicker() {
       });
       return html;
     },
-    // Écrit le LIBELLÉ CANONIQUE, jamais le nom seul : resolveStation résout par correspondance
-    // exacte via stationMap, et c'est cette même chaîne que le permalien transporte.
-    choisir: (s) => { input.value = s.label; resolveStation(); refresh(); saveState(); },
+    // Écrit le LIBELLÉ CANONIQUE, jamais le nom seul : `indexStationExacte` résout par
+    // correspondance exacte via stationMap, et c'est cette même chaîne que le permalien transporte.
+    choisir: (s) => { input.value = s.label; memoriserStation(); refresh(); saveState(); },
   });
 }
 
@@ -2020,8 +2029,9 @@ function resetAllOverrides() {
 // quantité observés en plus de `k` : c'est la MESURE qui fait foi, `k` n'en est que la lecture — si
 // la grille change à un patch, un relevé conservé reste réinterprétable.
 function saveStationReading() {
-  if (stationSel == null) return;
-  const t = etat.MARKET.terminals[stationSel];
+  const S = indexStationExacte();
+  if (S == null) return;
+  const t = etat.MARKET.terminals[S];
   const amount = Number($("alAmount").value);
   const scu = Math.floor(Number($("alScu").value));
   const k = kFromReading(amount, scu, t.maxBox);
@@ -2050,10 +2060,9 @@ function resetAllReadings() {
 }
 
 // ---------- Vue « Corrections » : liste + édition par station ----------
-function resolveStation() {
-  const v = $("station").value.trim();
-  stationSel = stationMap.has(v) ? stationMap.get(v) : null;
-}
+// `resolveStation` et la globale `stationSel` sont remplacées par `indexStationExacte()`
+// (marche.ts) : la station se dérive du champ à chaque lecture, au lieu d'être mise en cache par
+// une fonction de rendu. Voir marche.ts pour pourquoi ce n'est pas `resolveStationLabel`.
 
 // Relevé du tarif d'autoload d'une station. L'utilisateur ne saisit PAS `k` : personne ne lit un
 // coefficient en jeu, on lit une facture. Il donne un montant observé pour une quantité, et `k` s'en
@@ -2152,8 +2161,8 @@ function tuilesStation(S, q) {
 }
 
 // Les stations corrigées, la station affichée épinglée en tête.
-function groupesCorrections() {
-  const actif = stationSel != null ? etat.MARKET.terminals[stationSel].name : null;
+function groupesCorrections(S) {
+  const actif = S != null ? etat.MARKET.terminals[S].name : null;
   return groupOverridesByTerminal(etat.OVERRIDES, actif).map((g) => ({
     terminal: g.terminal,
     corrections: g.corrections,
@@ -2167,34 +2176,41 @@ function groupesCorrections() {
 function renderCorrections() {
   if (!etat.MARKET) { withMarket(refresh); return; }
   if (!enrouteReady) setupEnRoute();
-  resolveStation();
+  // UNE dérivation, en tête, et tout le rendu s'y réfère : la station ne peut pas changer entre
+  // deux lectures dans la même passe.
+  const S = indexStationExacte();
   const q = $("search").value.trim().toLowerCase();
   // La bande est peinte APRÈS le panneau, bien qu'elle s'affiche au-dessus : la préparation des
   // tuiles appelle effVals, dont la purge des volumes périmés est un EFFET DE BORD. Compter d'abord
   // afficherait une correction que le rendu suivant vient d'effacer. L'ordre est donc un contrat.
-  if (stationSel == null) peindre($("correctionsStation"), inviteStation());
+  if (S == null) peindre($("correctionsStation"), inviteStation());
   else {
-    const t = etat.MARKET.terminals[stationSel];
+    const t = etat.MARKET.terminals[S];
+    // Deux `const`, dans cet ordre, et non deux propriétés d'un littéral : `tuilesStation` PURGE en
+    // chemin (via effVals), donc compter avant elle annoncerait une correction qu'elle vient
+    // d'effacer. L'ordre des propriétés d'un objet le donnerait aussi, mais par accident.
+    const tuiles = tuilesStation(S, q);
+    const nbCorrections = Object.keys(etat.OVERRIDES).filter((k) => k.split("|")[1] === t.name).length;
     peindre($("correctionsStation"), vueStation({
       terminal: t,
-      tuiles: tuilesStation(stationSel, q),
+      tuiles,
       filtre: !!q,
-      nbCorrections: Object.keys(etat.OVERRIDES).filter((k) => k.split("|")[1] === t.name).length,
+      nbCorrections,
       // Cette vue-ci ferme sur SA station : elle passe cinq arguments, pas six. L'enveloppe remet
       // le terminal à sa place — la substituer nue décalerait tout, en silence.
       corriger: (commodite, cote, champ, valeur, releve) => corriger(commodite, t.name, cote, champ, valeur, releve),
     }));
   }
-  peindre($("correctionsIndex"), vueBandeCorrections({ groupes: groupesCorrections() }));
+  peindre($("correctionsIndex"), vueBandeCorrections({ groupes: groupesCorrections(S) }));
   // Le panneau de frais n'est réécrit QUE si son contenu a changé (#24). Le sortir de
   // #correctionsStation ne suffisait pas : renderCorrections réécrivait son nouveau conteneur tout
   // aussi inconditionnellement, et un montant en cours de frappe repartait à vide au moindre
   // re-rendu — un filtre tapé, une correction ailleurs. Le panneau ne dépend que de la station
   // affichée et du store des relevés : cette signature suffit à décider.
-  const signature = `${stationSel}|${JSON.stringify(etat.AUTOLOAD_K)}`;
+  const signature = `${S}|${JSON.stringify(etat.AUTOLOAD_K)}`;
   if (signature !== feesRendus) {
     feesRendus = signature;
-    $("correctionsFees").innerHTML = (stationSel != null ? stationFeeHTML(stationSel) : "") + autoloadListHTML();
+    $("correctionsFees").innerHTML = (S != null ? stationFeeHTML(S) : "") + autoloadListHTML();
   }
   notifySuperseded();
 }
@@ -2437,9 +2453,9 @@ async function init() {
   // pour rien — en détachant au passage l'éditeur d'un chiffre ouvert entre les deux. Même famille
   // que #24 : tout re-rendu gratuit de cette vue efface une saisie en cours.
   $("station").addEventListener("input", debounce(() => {
-    const avant = stationSel;
-    resolveStation();
-    if (stationSel !== avant) refresh();
+    const avant = derniereStation;
+    memoriserStation();
+    if (derniereStation !== avant) refresh();
   }));
   $("corrections").addEventListener("click", (e) => {
     // Les relevés d'autoload se testent AVANT les corrections : leur ✕ porte aussi `.corr-del`
@@ -2447,11 +2463,11 @@ async function init() {
     const alDel = e.target.closest(".al-del");
     if (alDel) { forgetStationReading(alDel.dataset.key); return; }
     // Vignette de la bande : recharge sa station. Écrit le LIBELLÉ CANONIQUE, comme le sélecteur —
-    // resolveStation résout par correspondance exacte, et c'est lui que le permalien transporte.
+    // la résolution est exacte, et c'est ce libellé-là que le permalien transporte.
     const tuile = e.target.closest(".stn-tile");
     if (tuile && !tuile.disabled) {
       const t = termByName.get(tuile.dataset.terminal);
-      if (t) { $("station").value = stationLabel(t.name, t.system); resolveStation(); refresh(); saveState(); }
+      if (t) { $("station").value = stationLabel(t.name, t.system); memoriserStation(); refresh(); saveState(); }
       return;
     }
     // Retour à la valeur UEX d'un chiffre corrigé.
@@ -2469,7 +2485,8 @@ async function init() {
     }
     // Efface les corrections de la SEULE station affichée (bouton du bandeau).
     if (e.target.closest("#stnClear")) {
-      const nom = stationSel != null ? etat.MARKET.terminals[stationSel].name : null;
+      const S = indexStationExacte();
+      const nom = S != null ? etat.MARKET.terminals[S].name : null;
       if (nom) {
         for (const k of Object.keys(etat.OVERRIDES)) {
           const [commodity, terminal, side] = k.split("|");

--- a/app.js
+++ b/app.js
@@ -12,7 +12,7 @@ import {
   manifestTotals, freeAddUnits, manifestLine, freeManifestLine, hydrateManifestLine, stationLabel, parseStationLabel, stationTree,
   multiTrips, tripMetrics, legFromTrip,
   legFromRoute, legsFromLoop, legsFromChain, legFromManifest, stopSuggestions, bestLegBetween,
-  manifestJourneyState, manifestIntent, sameIntent, manifestIntentSurvives, legsToPin, journeyMap,
+  manifestJourneyState, manifestIntent, sameIntent, manifestIntentSurvives, journeyMap,
   loadHold, declarerLot, holdScu, freeCargo, holdByCommodity, sellFromHold, refuseHere, refusActif, migrerRefus, sellableAt, sellAllAt,
   offloadPlan, tourneesEcoulement, storeFromHold, takeFromStore, stockApres,
   startJourney, startJourneyAt, journeyStations, journeyEnd,
@@ -38,7 +38,7 @@ import { brancher, ensureFeeMarket, ensureStarmap, withMarket } from "./donnees.
 import { brancherRendu } from "./rendu.ts";
 import { monterRacine } from "./main.tsx";
 import { planData, planHypotheses } from "./vues/plan-vue.tsx";
-import { jambeChargee, legEffectiveLines, legFeeCtx, legIntent, legKey, legManifest, legTerminals, loadJourneyEdits, loadJourneyPins, saveJourneyEdits, saveJourneyPins } from "./voyage-donnees.ts";
+import { figerJambe, jambeChargee, journeyCarriedCommodities, legEffectiveLines, legFeeCtx, legIntent, legKey, legManifest, legTerminals, loadJourneyEdits, loadJourneyPins, pinLegsForVolume, saveJourneyEdits, saveJourneyPins } from "./voyage-donnees.ts";
 import { vueTournee, messageSouteVide, messageChargement, messageOuEsTu } from "./vues/tournee.tsx";
 import { vueBoucles } from "./vues/boucles.tsx";
 import { vueChaine, indiceDepart, indiceSoute, indiceAucune } from "./vues/chaine.tsx";
@@ -1349,38 +1349,9 @@ function clearJourney() {
   // l'effacement jusqu'au geste suivant. `refresh` finit par `saveState`, inutile de le doubler.
   refresh();
 }
-// Ensemble des commodités transportées au moins une fois sur le parcours (union des manifestes).
-function journeyCarriedCommodities() {
-  const set = new Set();
-  if (!etat.JOURNEY || !etat.MARKET) return set;
-  const f = readFilters();
-  etat.JOURNEY.legs.forEach((leg, i) => legEffectiveLines(leg, i, f).forEach((l) => set.add(l.name)));
-  return set;
-}
-
-// Manifeste optimal d'une jambe (from -> to) : remplissage multi-commodité, terminal d'arrivée forcé.
-function figerJambe(i, lignes) {
-  const k = legKey(etat.JOURNEY.legs[i], i);
-  if (etat.JOURNEY_EDITS[k]) return false;
-  etat.JOURNEY_EDITS[k] = manifestIntent(lignes || []);
-  etat.JOURNEY_PINS[k] = true;
-  return true;
-}
-
-// Le gel consulte désormais l'état « chargée » de chaque jambe (#48) : une jambe qu'on n'a pas
-// payée n'est plus figée par une correction de volume, elle RECALCULE. Voir legsToPin (logic.mjs)
-// pour le pourquoi du renversement.
-function pinLegsForVolume(commodity, terminal, side) {
-  if (!etat.JOURNEY || !etat.JOURNEY.legs.length || !etat.MARKET) return;
-  const f = readFilters();
-  const lignes = etat.JOURNEY.legs.map((leg, i) => legEffectiveLines(leg, i, f));
-  const chargees = etat.JOURNEY.legs.map((leg, i) => jambeChargee(leg, i));
-  let change = false;
-  for (const i of legsToPin(etat.JOURNEY.legs, lignes, commodity, terminal, side, chargees)) {
-    if (figerJambe(i, lignes[i])) change = true;
-  }
-  if (change) { saveJourneyEdits(); saveJourneyPins(); }
-}
+// `journeyCarriedCommodities`, `figerJambe` et `pinLegsForVolume` sont passées dans
+// `voyage-donnees.ts` : elles ne rendent rien, et le gel doit être appelable depuis une vue de
+// l'arbre (ADR-012). Leurs commentaires les y attendaient déjà, orphelins.
 
 // Engage le manifeste d'« En route » comme nouvelle jambe du voyage (bouton de la carte Manifeste).
 // La garde d'état est REJOUÉE ici : le rendu peut dater d'avant un changement de parcours.

--- a/app.js
+++ b/app.js
@@ -1761,7 +1761,13 @@ function refresh() {
   else if (etat.view === "chain") renderChain();
   else if (etat.view === "corrections") renderCorrections();
   else if (etat.view === "commodities") renderCommodities();
-  else render();
+  // La vue Trajets est NOMMÉE, elle n'est plus le repli. Les deux vues qui vivent dans l'arbre
+  // (Tournée, Plan de vol) tombaient ici : `render()` recalculait tout le tableau des trajets pour
+  // le repeindre dans un `<tbody>` masqué — et reposait `#empty`, qui est un frère de `#routes` et
+  // que rien ne masque, donc « Aucune route ne correspond aux filtres. » revenait sous une vue qui
+  // n'a pas de tableau (#147). Chaque vue qui emménagera dans l'arbre passera par ce même repli :
+  // le nommer une fois vaut mieux que d'y penser à chaque migration.
+  else if (etat.view === "routes") render();
   // La carte Voyage est affichée À CÔTÉ des tableaux, dans toutes les vues : la laisser hors du
   // cycle de rendu la figeait sur l'état d'avant. Corriger un prix ne mettait donc pas à jour les
   // bénéfices du voyage — alors qu'une jambe non ajustée est justement, par contrat, branchée sur

--- a/app.js
+++ b/app.js
@@ -5,7 +5,7 @@ import {
   tripMinutes, ageDays, pairAge,
   scoreBarWidth, bySort, addableUnits, scuBoxes, cargoBoxes, bestChain,
   autoloadFee, kFromReading, kPlausible,
-  ovKey, DUREE_VOL, groupOverridesByTerminal, safeKey, encodeState, decodeState,
+  ovKey, groupOverridesByTerminal, safeKey, encodeState, decodeState,
   routePasses, loopPasses,
   routeMetrics, loopMetrics, enRouteDeals, bestManifest, buildChainAdjacency, suggestionsFrom, netMarginRoi,
   commoditySummaries, commodityPoints, compactValue, valueTiers, resolveCommodity, ambiguousCodes,
@@ -30,7 +30,9 @@ import { peindre } from "./pont.js";
 import { etat, notifier } from "./etat.ts";
 import { fmt, fmtVol, fmtFee, signe, TEXTE_CAPACITE_INCONNUE } from "./format.ts";
 import { readFilters } from "./filtres.ts";
-import { effVals, loadOverrides, ovCount, relevePerimees, resetOverrides, saveOverrides, setOverride } from "./corrections.ts";
+import { effVals, isOv, loadOverrides, ovCount, resetOverrides, saveOverrides, setOverride } from "./corrections.ts";
+import { corriger, notifySuperseded, updateOvBadge } from "./corrections-actions.ts";
+import { showToast } from "./messages.ts";
 import { construireIndex, findCommodity, indexDepartChaine, indexOrigine, libellesOrigines, libellesStations, resolveStationLabel, stationCourante, stationMap, termByName } from "./marche.ts";
 import { alKey, feeCargoText, feeCell, feeCtx, feeEndText, feeLoadText, feeResolver, globalK, kFmt, kFor, lineProfitText, loadAutoloadK, saveAutoloadK } from "./frais.ts";
 import { applyState, loadState, saveState, shareURL } from "./persistance.ts";
@@ -132,35 +134,8 @@ const nowSec = () => Math.floor(Date.now() / 1000);
 //   - nom de terminal -> terminal de market.json, parce que routes.json et loops.json (vues
 //     « Trajets » et « Boucles ») ne portent que des noms ;
 //   - terminal -> coefficient `k`, relevé par l'utilisateur ou valeur globale par défaut.
-// Flash discret quand des corrections ont été périmées par une mise à jour UEX.
-let toastTimer = null;
-function showToast(msg) {
-  let el = $("toast");
-  if (!el) { el = document.createElement("div"); el.id = "toast"; el.className = "toast"; document.body.appendChild(el); }
-  el.textContent = msg;
-  el.classList.add("show");
-  clearTimeout(toastTimer);
-  toastTimer = setTimeout(() => el.classList.remove("show"), 4500);
-}
-// DEUX causes de péremption, donc deux messages : dire « mise à jour UEX » à propos d'un volume qui a
-// simplement vieilli serait faux, et enverrait chercher un changement de données qui n'a pas eu lieu.
-// Si les deux tombent dans le même rendu, la mise à jour UEX passe en premier — c'est un fait
-// extérieur, l'autre est une simple horloge.
-function notifySuperseded() {
-  // Le RELEVÉ vide les compteurs : appeler deux fois de suite ne redit rien. La donnée vit dans
-  // `corrections.ts`, le message reste ici — c'est ce qui permet à `effVals` d'être appelée trente
-  // fois au fond du rendu sans traîner `showToast` derrière elle.
-  const { uex: nUex, age: nAge } = relevePerimees();
-  if (!nUex && !nAge) return;
-  updateOvBadge();
-  const s = (n) => (n > 1 ? "s" : "");
-  if (nUex) showToast(`✎ ${nUex} correction${s(nUex)} périmée${s(nUex)} par une mise à jour UEX`);
-  if (nAge) {
-    const h = Math.round(DUREE_VOL / 3600);
-    const msg = `✎ ${nAge} volume${s(nAge)} corrigé${s(nAge)} périmé${s(nAge)} — plus de ${h} h, le comptoir s'est rempli depuis`;
-    if (nUex) setTimeout(() => showToast(msg), 1200); else showToast(msg);
-  }
-}
+// `showToast` est passée dans `messages.ts`, `notifySuperseded` dans `corrections-actions.ts` :
+// toutes deux doivent être appelables depuis une vue de l'arbre (ADR-012).
 
 // Applique les corrections à une paire buy/sell et renvoie des copies patchées + marge/roi.
 function applyOverrides(commodity, buy, sell) {
@@ -230,12 +205,9 @@ function propsTrajetsCommunes() {
     avecTexteFrais: (base, cell) => (cell.text ? `${base} · ${cell.text}` : base),
     legendeAchat: BUY_STATUS,
     legendeVente: SELL_STATUS,
-    corriger: (commodite, terminal, cote, champ, valeur, releve) => {
-      if (champ === "vol") pinLegsForVolume(commodite, terminal, cote);
-      setOverride(commodite, terminal, cote, champ, valeur === "" ? null : valeur, Number(releve) || 0);
-      updateOvBadge();
-      refresh();
-    },
+    // Le contrat de cette vue est celui du module : six arguments, dans le même ordre. On le passe
+    // donc NU — c'est le seul des quatre sites, avec le manifeste, à pouvoir le faire.
+    corriger,
   };
 }
 
@@ -599,10 +571,7 @@ function manifesteSansOptimal(originIdx, destIdx, f) {
   };
 }
 
-const isOv = (commodity, terminal, side, field) => {
-  const o = etat.OVERRIDES[ovKey(commodity, terminal, side)];
-  return !!(o && o[field] != null);
-};
+// `isOv` est passée dans `corrections.ts`, à côté d'`effVals` : elle lit le même store.
 
 // `m` = manifeste courant (il porte `fee`, le contexte de frais qui l'a produit) ; `t` = ses totaux.
 // Les totaux du manifeste sont rendus par vues/manifeste.tsx (`<Totaux>`).
@@ -686,12 +655,7 @@ function paintManifest() {
     texteBoutFrais: feeEndText,
     minutesTrajet: tripMinutes(0, m.cross),
     estCorrige: isOv,
-    corriger: (commodite, terminal, cote, champ, valeur, releve) => {
-      if (champ === "vol") pinLegsForVolume(commodite, terminal, cote);
-      setOverride(commodite, terminal, cote, champ, valeur === "" ? null : valeur, Number(releve) || 0);
-      updateOvBadge();
-      refresh();
-    },
+    corriger, // six arguments dans le même ordre : passé nu, comme pour les Trajets
   }));
 }
 
@@ -2041,29 +2005,8 @@ async function copyShareLink() {
 // pas la vue, le ✎ reste DANS le span — sont portés par le composant, et couverts par
 // `e2e/edition.pw.mjs`.
 
-// Met à jour le libellé du bouton de vue « Corrections » (compteur).
-function updateOvBadge() {
-  const n = ovCount();
-  const bouton = $("viewCorrections");
-  const rl = bouton.querySelector(".rl");
-  // On écrit DANS le .rl, au lieu d'écraser le bouton entier en textContent : cette écriture-là
-  // détruisait le <span class="rn">, et le numéro de Corrections n'a donc jamais existé à l'écran
-  // (#45). Le rail annonce une touche par numéro — il ne peut pas en manquer un sur huit.
-  rl.textContent = "Corrections";
-  // Le compteur en plus petit, sans interlettrage : mesuré, il rend 20 px au libellé. Sans lui
-  // « Corrections (123) » repart à la ligne, et le bouton fait deux fois la hauteur des sept
-  // autres — un rail qui cède quand la place manque, c'est le symptôme de #86.
-  if (n) {
-    const compteur = document.createElement("span");
-    compteur.className = "ov-n";
-    compteur.textContent = `(${n})`;
-    rl.append(" ", compteur);
-  }
-  // Le libellé étant maintenant dans un .rl, il disparaît au rail rétracté : l'aria-label est le
-  // seul à porter le compteur à ce moment-là, et il doit donc suivre. Même geste que
-  // copyShareLink() sur #share.
-  bouton.setAttribute("aria-label", n ? `Corrections (${n})` : "Corrections");
-}
+// `updateOvBadge` est passée dans `corrections-actions.ts`. Elle y reste impérative : le nœud
+// qu'elle touche est dans le RAIL, qu'aucun portail ne possède (ADR-012).
 
 function resetAllOverrides() {
   if (!ovCount()) return;
@@ -2237,13 +2180,9 @@ function renderCorrections() {
       tuiles: tuilesStation(stationSel, q),
       filtre: !!q,
       nbCorrections: Object.keys(etat.OVERRIDES).filter((k) => k.split("|")[1] === t.name).length,
-      // L'ÉCRITURE reste à app.js : lui seul sait qu'un VOLUME fige d'abord les jambes planifiées.
-      corriger: (commodite, cote, champ, valeur, releve) => {
-        if (champ === "vol") pinLegsForVolume(commodite, t.name, cote);
-        setOverride(commodite, t.name, cote, champ, valeur === "" ? null : valeur, Number(releve) || 0);
-        updateOvBadge();
-        refresh();
-      },
+      // Cette vue-ci ferme sur SA station : elle passe cinq arguments, pas six. L'enveloppe remet
+      // le terminal à sa place — la substituer nue décalerait tout, en silence.
+      corriger: (commodite, cote, champ, valeur, releve) => corriger(commodite, t.name, cote, champ, valeur, releve),
     }));
   }
   peindre($("correctionsIndex"), vueBandeCorrections({ groupes: groupesCorrections() }));
@@ -2317,15 +2256,9 @@ function paintCommodityDetail() {
     nomCommodite: p.name,
     butin: loot,
     estCorrige: (terminal, cote, champ) => isOv(p.name, terminal, cote, champ),
-    // L'ÉCRITURE reste à app.js : lui seul sait qu'un VOLUME doit d'abord figer les jambes déjà
-    // planifiées (avant d'écrire, pour capturer les SCU encore en vigueur), qu'un PRIX ne fige
-    // rien, et que le compteur de corrections doit suivre.
-    corriger: (terminal, cote, champ, valeur, releve) => {
-      if (champ === "vol") pinLegsForVolume(p.name, terminal, cote);
-      setOverride(p.name, terminal, cote, champ, valeur === "" ? null : valeur, Number(releve) || 0);
-      updateOvBadge();
-      refresh();
-    },
+    // Le détail ferme sur SA commodité et laisse varier le terminal — l'exact inverse de la vue
+    // Corrections. Cinq arguments là aussi, et l'enveloppe les remet dans l'ordre du module.
+    corriger: (terminal, cote, champ, valeur, releve) => corriger(p.name, terminal, cote, champ, valeur, releve),
     legendeAchat: BUY_STATUS,
     legendeVente: SELL_STATUS,
   }));

--- a/corrections-actions.ts
+++ b/corrections-actions.ts
@@ -1,0 +1,101 @@
+// Corriger un chiffre : l'ACTION (ADR-012).
+//
+// `corrections.ts` porte la DONNÉE — lire le store, écrire une correction, relever ce qui a péri.
+// Son en-tête dit « `app.js` garde le MESSAGE » : ce module EST ce message, et il est ce qui reste
+// quand `app.js` s'en va.
+//
+// La séparation tient à un fait précis : `effVals` est appelée trente fois au fond du rendu. Elle
+// ne peut donc traîner derrière elle ni un toast, ni un compteur de rail, ni un cycle de rendu.
+// Ici on est de l'autre côté — un geste de l'utilisateur, une fois.
+//
+// ── CE QUE `corriger` UNIFIE ──────────────────────────────────────────────────────────────────
+// Le même corps était écrit QUATRE fois dans `app.js` : Trajets, Manifeste, Corrections et le
+// détail des Commodités. Quatre copies d'un enchaînement dont chaque maillon est un contrat :
+//   1. un VOLUME fige d'abord les jambes déjà planifiées — avant l'écriture, pour capturer les SCU
+//      encore en vigueur (#48) ; un PRIX ne fige rien ;
+//   2. `""` efface le champ, il ne vaut pas zéro ;
+//   3. `releve` est la date UEX du point : c'est contre CET export que la correction vaut ;
+//   4. le compteur du rail suit, puis le cycle de rendu complet.
+// Une copie qui rate le point 1 ne casse aucun test — elle laisse simplement un voyage se recalculer
+// sur un stock qu'on vient de contredire.
+
+import { DUREE_VOL } from "./logic.ts";
+import type { ChampCorrection, CoteMarche } from "./types.ts";
+import { ovCount, relevePerimees, setOverride } from "./corrections.ts";
+import { pinLegsForVolume } from "./voyage-donnees.ts";
+import { showToast } from "./messages.ts";
+import { rafraichir } from "./rendu.ts";
+
+/**
+ * Met à jour le libellé du bouton de vue « Corrections » (compteur).
+ *
+ * Le nœud touché est dans le RAIL — `#viewCorrections .rl` — qu'aucun portail ne possède et qui ne
+ * passera jamais par React tant que `rail.js` existe. Cette fonction restera donc impérative après
+ * la migration des vues : ce n'est pas une dette, c'est la frontière.
+ */
+export function updateOvBadge(): void {
+  const n = ovCount();
+  const bouton = document.getElementById("viewCorrections");
+  const rl = bouton?.querySelector(".rl");
+  if (!bouton || !rl) return;
+  // On écrit DANS le .rl, au lieu d'écraser le bouton entier en textContent : cette écriture-là
+  // détruisait le <span class="rn">, et le numéro de Corrections n'a donc jamais existé à l'écran
+  // (#45). Le rail annonce une touche par numéro — il ne peut pas en manquer un sur huit.
+  rl.textContent = "Corrections";
+  // Le compteur en plus petit, sans interlettrage : mesuré, il rend 20 px au libellé. Sans lui
+  // « Corrections (123) » repart à la ligne, et le bouton fait deux fois la hauteur des sept
+  // autres — un rail qui cède quand la place manque, c'est le symptôme de #86.
+  if (n) {
+    const compteur = document.createElement("span");
+    compteur.className = "ov-n";
+    compteur.textContent = `(${n})`;
+    rl.append(" ", compteur);
+  }
+  // Le libellé étant maintenant dans un .rl, il disparaît au rail rétracté : l'aria-label est le
+  // seul à porter le compteur à ce moment-là, et il doit donc suivre.
+  bouton.setAttribute("aria-label", n ? `Corrections (${n})` : "Corrections");
+}
+
+/**
+ * Dit une fois ce que le rendu qui vient de finir a périmé.
+ *
+ * DEUX causes de péremption, donc deux messages : dire « mise à jour UEX » à propos d'un volume qui
+ * a simplement vieilli serait faux, et enverrait chercher un changement de données qui n'a pas eu
+ * lieu. Si les deux tombent dans le même rendu, la mise à jour UEX passe en premier — c'est un fait
+ * extérieur, l'autre est une simple horloge.
+ */
+export function notifySuperseded(): void {
+  // Le RELEVÉ vide les compteurs : appeler deux fois de suite ne redit rien.
+  const { uex: nUex, age: nAge } = relevePerimees();
+  if (!nUex && !nAge) return;
+  updateOvBadge();
+  const s = (n: number) => (n > 1 ? "s" : "");
+  if (nUex) showToast(`✎ ${nUex} correction${s(nUex)} périmée${s(nUex)} par une mise à jour UEX`);
+  if (nAge) {
+    const h = Math.round(DUREE_VOL / 3600);
+    const msg = `✎ ${nAge} volume${s(nAge)} corrigé${s(nAge)} périmé${s(nAge)} — plus de ${h} h, le comptoir s'est rempli depuis`;
+    if (nUex) setTimeout(() => showToast(msg), 1200); else showToast(msg);
+  }
+}
+
+/**
+ * Écrit une correction, et tout ce qui doit suivre. Le point d'entrée UNIQUE des quatre vues qui
+ * laissent corriger un chiffre.
+ *
+ * L'ordre est un contrat, pas un style — voir l'en-tête. `rafraichir()` et non `notifier()` : une
+ * correction change le prix des jambes du voyage, la valeur de la soute et l'URL partagée, et rien
+ * de tout cela ne vit encore dans l'arbre.
+ */
+export function corriger(
+  commodite: string,
+  terminal: string,
+  cote: CoteMarche,
+  champ: ChampCorrection,
+  valeur: string,
+  releve: number | string,
+): void {
+  if (champ === "vol") pinLegsForVolume(commodite, terminal, cote);
+  setOverride(commodite, terminal, cote, champ, valeur === "" ? null : valeur, Number(releve) || 0);
+  updateOvBadge();
+  rafraichir();
+}

--- a/corrections.ts
+++ b/corrections.ts
@@ -89,6 +89,20 @@ export function resetOverrides(): void {
 }
 
 /**
+ * Ce champ porte-t-il une correction locale ? Lecture seule, aucun effet de bord — c'est ce qui la
+ * distingue d'`effVals`, qui purge en chemin. Elle sert à décider d'un ✎, jamais d'une valeur.
+ */
+export const isOv = (
+  commodity: string,
+  terminal: string,
+  side: CoteMarche,
+  field: ChampCorrection,
+): boolean => {
+  const o = etat.OVERRIDES[ovKey(commodity, terminal, side)];
+  return !!(o && o[field] != null);
+};
+
+/**
  * Combien de corrections ont péri pendant le rendu qui vient de finir, et pourquoi — puis remet les
  * compteurs à zéro. C'est un RELEVÉ : appeler deux fois de suite rend zéro la seconde fois, ce qui
  * est exactement ce qu'on veut d'une notification.

--- a/docs/superpowers/specs/2026-08-17-vues-qui-agissent-adr.md
+++ b/docs/superpowers/specs/2026-08-17-vues-qui-agissent-adr.md
@@ -1,0 +1,163 @@
+# ADR-012 : Faire emménager une vue qui AGIT
+
+**Statut :** Accepté
+**Date :** 2026-08-17
+**Décideur :** 0xKestrelNova (propriétaire du dépôt)
+**Issue :** #96 · **Jalon :** v2.0.0
+**Prolonge :** ADR-011 (le démontage d'`app.js`)
+
+## Contexte
+
+L'ADR-011 a décidé qu'`app.js` disparaît. La racine unique existe (#143) et deux vues y vivent :
+la **Tournée** (#143) et le **Plan de vol** (#145). Le patron a été écrit et il tient.
+
+Mais ces deux-là sont **inertes**. La Tournée n'a aucun bouton ; le Plan de vol est une conclusion
+(ADR-004 §4) où rien n'est actionnable. Les six vues restantes portent toutes des **actions** :
+corriger un prix, choisir un trajet, changer de board, sélectionner une commodité. C'est leur
+**câblage** qu'il faut savoir déplacer, et le patron de l'ADR-011 ne dit rien là-dessus.
+
+Cet ADR répond à une seule question :
+
+> **Quand une vue de l'arbre doit ÉCRIRE, à qui parle-t-elle ?**
+
+## Le problème, mesuré
+
+`app.js` n'exporte **rien** — 2 869 lignes, pas une ligne `export`. C'est un module ES qui *importe*
+onze modules TypeScript et n'en *expose* aucun symbole. La direction des dépendances est donc à sens
+unique, et le patron de l'ADR-011 (« le composant ne reçoit AUCUNE prop ») interdit de contourner le
+problème en poussant des rappels depuis `app.js`.
+
+Une vue de l'arbre qui veut écrire n'a aujourd'hui qu'un seul interlocuteur : `notifier()`
+(`etat.ts`). Or `notifier()` réveille l'arbre React **et rien d'autre**, alors que `refresh()`
+(app.js) fait trois choses de plus, dont aucune ne vit encore dans l'arbre :
+
+| ce que `refresh()` fait en plus | conséquence si on ne l'appelle pas |
+|---|---|
+| `renderJourney()` — la carte du voyage | la carte reste figée à côté d'un tableau à jour |
+| `renderSoute()` / `renderEntrepots()` | la place libre, « où écouler » et le prix de vente périment |
+| `saveState()` | le permalien et la restauration au rechargement périment |
+
+Aucun test ne verrait ces trois-là : ils regardent tous la vue, pas ce qui l'entoure.
+
+## Décision
+
+### 1. Un canal de rafraîchissement, `rendu.ts`
+
+Même patron que `brancher()` dans `donnees.ts` : le module **déclare** le besoin, l'amorçage
+**pose** l'implémentation.
+
+```ts
+brancherRendu({ rafraichir: refresh });   // app.js, dans init()
+rafraichir();                             // n'importe quel module, y compris un composant
+```
+
+C'est un crochet, pas un import, pour deux raisons. Un import est **impossible** tant que `refresh`
+vit dans `app.js` (qui n'exporte rien) ; et il resterait **en cycle** une fois `app.js` disparu —
+c'est la vue qui déclenche le rendu, pas le rendu qui connaît la vue.
+
+**Le crochet est transitoire**, comme les portails d'`App.tsx`. Il disparaît quand `renderJourney`,
+`renderSoute` et `renderEntrepots` auront à leur tour emménagé : `notifier()` redeviendra le point
+unique, et `rafraichir()` ne sera plus qu'un alias à supprimer.
+
+**Règle d'emploi.** Une action qui change l'état **partagé** (une correction, une écriture en soute,
+un arrêt de voyage) appelle `rafraichir()`. Une action qui ne touche qu'à l'affichage d'une vue déjà
+dans l'arbre n'appelle que `notifier()`.
+
+### 2. Ce qui devient un module, et ce qui reste dans `app.js`
+
+Le critère n'est pas « est-ce du rendu ». C'est : **le nœud touché appartient-il à un portail ?**
+
+| bloc | destination | pourquoi |
+|---|---|---|
+| `showToast` | `messages.ts` | aucun nœud de vue — un toast est un message global |
+| `isOv` | `corrections.ts` | trois lignes de lecture du store, à côté d'`effVals` |
+| `updateOvBadge`, `notifySuperseded`, `corriger` | `corrections-actions.ts` | l'**action**, distincte de la **donnée** que porte `corrections.ts` |
+| `figerJambe`, `pinLegsForVolume`, `journeyCarriedCommodities` | `voyage-donnees.ts` | déjà le module du parcours, et les commentaires y sont |
+| `marginTier` → `palierMarge(m, max)` | `logic.ts` | calcul pur, à côté de `valueTiers` — la globale devient un paramètre |
+| la délégation `#corrections` | **reste dans `app.js`** | elle est posée sur un parent que React ne possède **jamais** |
+
+Le dernier point est le seul contre-intuitif, et il a un précédent mesuré : `#planHead` (#145). Une
+délégation posée sur un **conteneur** que React ne rend pas continue de fonctionner sur des enfants
+rendus par React — l'événement remonte, `closest()` trouve. La déplacer vers des `onClick` n'apporte
+rien tant que le conteneur lui-même n'est pas un composant, et coûte une réécriture de test.
+
+**Corollaire pour les contrôles vanilla.** `#commSortModes` et `#commBoardModes` restent du markup
+d'`index.html` avec des écouteurs directs. Ils **importent** leur action du module de vue plutôt que
+de la dupliquer — précédent : `app.js` importe déjà `planData` de `vues/plan-vue.tsx`.
+
+### 3. Un composant par VUE, pas un par conteneur
+
+C'est la décision qui coûte le plus cher si on la rate.
+
+Une vue peut occuper **plusieurs conteneurs séparés** dans `index.html` — le Plan de vol en occupe
+deux (#145), Commodités et Corrections en occupent trois chacune. La tentation est d'écrire un
+composant sans props par conteneur, comme le patron le dit.
+
+**C'est faux dès que les conteneurs partagent un calcul.** La grille des Commodités et son détail
+consomment le même `commoditySummaries(etat.MARKET, f, effVals)` — un parcours de tout le marché.
+Deux composants sans props le feraient **deux fois par `notifier()`** : exactement le gaspillage que
+la PR #146 vient de payer pour supprimer. Pire, chacun re-dériverait la sélection courante, et deux
+dérivations qui divergent font une tuile `.selected` qui ne correspond pas au détail affiché — ce
+qu'aucun test ne compare.
+
+La forme retenue :
+
+```tsx
+export function VueCommodites() {
+  if (etat.view !== "commodities") return null;   // la garde, UNE fois, en tête
+  // … le calcul, UNE fois …
+  return <>
+    <Portail id="commGrid">…</Portail>
+    <Portail id="commDetail">…</Portail>
+    <Portail id="commHint">…</Portail>
+  </>;
+}
+```
+
+La garde de vue monte **au-dessus** des portails au lieu d'être répétée sur chacun. Effet de bord
+bienvenu : l'ordre d'évaluation redevient l'**ordre des instructions**, et non l'ordre des frères
+JSX — ce qui compte, parce que certains de ces calculs ont des effets de bord (voir §4).
+
+### 4. Les effets de bord pendant le rendu sont un CONTRAT, pas une négligence
+
+`effVals` (`corrections.ts`) **purge** les corrections périmées et persiste. `groupOverridesByTerminal`
+(`logic.ts`) mute `OVERRIDES` en place. Ces deux-là tournent pendant le rendu, et l'ordre dans lequel
+on les appelle est observable à l'écran.
+
+`renderCorrections` le documente déjà : la bande des stations est peinte **après** le panneau, bien
+qu'elle s'affiche au-dessus, parce que compter d'abord afficherait une correction que le rendu
+suivant vient d'effacer.
+
+**Ce contrat survit à la migration, et il descend d'un cran.** Il ne suffit pas d'ordonner les deux
+portails : à l'intérieur du panneau, `nbCorrections` doit être calculé **après** `tuilesStation`,
+puisque c'est `tuilesStation` qui purge. Écrit en littéral d'objet, l'ordre des propriétés est
+l'ordre d'évaluation — ça marche, mais par accident. On l'écrit donc en `const` successives, avec
+le commentaire qui dit pourquoi.
+
+C'est aussi ce qui justifie le §3 : un composant, des instructions ordonnées, un ordre lisible.
+
+### 5. Les caches de rendu deviennent des locales, quand ils n'ont qu'un lecteur
+
+Les cinq globales de la vue Commodités (`shownCommodities`, `commTiers`, `commDupCodes`,
+`commMaxMargin`, `commCarried`) n'existent que parce que `renderCommodities` calcule et que trois
+autres fonctions peignent. Un composant qui calcule et rend dans la même passe n'en a pas besoin :
+elles deviennent des `const` locales.
+
+**La vérification n'est pas optionnelle** : chaque globale supprimée doit d'abord être `grep`ée pour
+trouver ses lecteurs *hors* de la vue. `commMaxMargin` en avait un (`marginTier`), d'où le
+paramètre ajouté au §2.
+
+## Conséquences
+
+**Ce qu'on gagne.** Une vue qui agit peut emménager sans prop et sans rival de propagation. Quatre
+copies du même corps `corriger` deviennent une. `refresh()` cesse d'être un privilège d'`app.js`.
+
+**Ce qu'on paie.** Un crochet de plus (`rendu.ts`), qu'il faudra penser à supprimer. Et un canal qui
+peut être appelé depuis n'importe où : rien n'empêche un composant d'appeler `rafraichir()` là où
+`notifier()` suffirait, ce qui rendrait la mesure de la PR #146 (l'arbre n'évalue que la vue
+regardée) trompeuse. C'est la règle d'emploi du §1 qui tient ça, et rien d'autre.
+
+**Ce qu'on ne fait pas.** Le bandeau (`#shipJourneyRow`) reste hors de l'arbre. Il vit dans six vues
+sur huit et n'est masqué que par le Plan de vol : il se montera donc **sans** garde `si`, ou avec un
+garde négatif. C'est l'inverse du patron des vues d'onglet, et ça mérite sa propre mesure — pas un
+passager clandestin dans un lot qui en porte déjà deux.

--- a/e2e/autoload.pw.mjs
+++ b/e2e/autoload.pw.mjs
@@ -412,3 +412,34 @@ test("relevé de station : un zéro de trop se fait confirmer avant d'être rete
   await page.click("#alSave");
   await expect(page.locator(".corr-item.autoload")).toContainText("413,415");
 });
+
+// Le piège silencieux de la vue Corrections, et il est INVISIBLE dans le reste de la suite : les
+// huit tests qui touchent cette vue remplissent tous `#station` par `fill` juste avant d'agir, ce
+// qui rejoue l'écouteur du champ. Aucun ne restaure une station par PERMALIEN puis clique une
+// action de station — or `applyState` repose la valeur du champ sans la résoudre.
+test("relevé de station : une station restaurée par permalien reste actionnable", async ({ page }) => {
+  await enrichMarket(page, "all", 32);
+  await page.goto("/index.html");
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+  await page.click("#viewCorrections");
+  await expect(page.locator("#stationList option").first()).toBeAttached({ timeout: 15000 });
+  const label = await page.locator("#stationList option").first().getAttribute("value");
+  await page.fill("#station", label);
+  await expect(page.locator("#alAmount")).toBeVisible();
+
+  // Le lien porte la station ET la vue. On repart de lui, dans un onglet qui n'a rien tapé.
+  const lien = await page.evaluate(() => location.hash);
+  expect(lien).toContain("station=");
+  await page.goto("/index.html" + lien);
+  await expect(page.locator("#correctionsControls")).toBeVisible();
+  await expect(page.locator("#station")).toHaveValue(label);
+
+  // SANS retoucher au champ : c'est tout le test. Le panneau de frais doit être là, et
+  // « Enregistrer » doit savoir de quelle station il parle.
+  await expect(page.locator("#alAmount")).toBeVisible({ timeout: 15000 });
+  await page.fill("#alAmount", "1159");
+  await page.fill("#alScu", "32");
+  await page.click("#alSave");
+  await expect(page.locator(".corr-item.autoload")).toContainText(label.split(" — ")[0]);
+  await expect(page.locator(".corr-item.autoload")).toContainText("1,41");
+});

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -152,6 +152,53 @@ test("vue Corrections : rechercher une station affiche ses commodités éditable
   expect(await page.locator("#correctionsStation .editv").count()).toBeGreaterThan(0);
 });
 
+// Affiche une station, et n'en rend la main que quand le panneau est VRAIMENT le sien. Sans cette
+// attente, la cellule saisie est encore celle de la station précédente : le panneau se repeint
+// pendant le geste, et la correction part sur le mauvais comptoir — silencieusement.
+async function ouvrirStation(page, label) {
+  await page.fill("#station", label);
+  await expect(page.locator("#correctionsStation .stn-hero-name")).toHaveText(label.split(" — ")[0]);
+}
+
+// Corrige le PREMIER stock d'achat de la station affichée, et rend le nom de la commodité touchée.
+// La valeur est dérivée de celle qu'affiche la cellule : identique, l'édition ne s'enregistre pas
+// (c'est un comportement acquis — consulter n'écrit rien), et le test passerait sans rien poser.
+async function corrigerPremierStock(page, label) {
+  await ouvrirStation(page, label);
+  const cell = page.locator('#correctionsStation .editv[data-s="buy"][data-f="vol"]').first();
+  await expect(cell).toBeVisible({ timeout: 8000 });
+  const nom = await cell.getAttribute("data-c");
+  const avant = Number(await cell.getAttribute("data-v")) || 0;
+  await cell.click();
+  await cell.locator("input").fill(String(avant + 1234));
+  await cell.locator("input").press("Enter");
+  await expect(page.locator("#correctionsStation .editv.ov").first()).toBeVisible();
+  return nom;
+}
+
+// `#stnClear` n'avait AUCUN test, et c'est la quatrième porte vers le gel des jambes — les trois
+// autres sont couvertes. Il lit la station affichée, boucle sur le store, et fige les jambes avant
+// d'effacer. Rendu muet, il ne dit rien : pas de message, pas de log, et la suite reste verte.
+test("Corrections : « ✕ n corrections » n'efface QUE la station affichée", async ({ page }) => {
+  await page.click("#viewCorrections");
+  await expect(page.locator("#stationList option").first()).toBeAttached({ timeout: 15000 });
+
+  await corrigerPremierStock(page, "Levski — Nyx");
+  await corrigerPremierStock(page, "GrimHEX — Stanton");
+  await expect(page.locator("#viewCorrections .rl")).toHaveText("Corrections (2)");
+
+  // Retour sur Levski : c'est SA correction que le bouton annonce, et elle seule qu'il efface.
+  await ouvrirStation(page, "Levski — Nyx");
+  await expect(page.locator("#stnClear")).toHaveText(/1 correction/);
+  await page.locator("#stnClear").click();
+
+  await expect(page.locator("#correctionsStation .editv.ov")).toHaveCount(0);
+  await expect(page.locator("#stnClear")).toHaveCount(0);        // plus rien à effacer ici
+  await expect(page.locator("#viewCorrections .rl")).toHaveText("Corrections (1)"); // l'autre est intacte
+  // Et la bande garde bien la vignette de GrimHEX : ce n'est pas « tout réinitialiser ».
+  await expect(page.locator('#correctionsIndex .stn-tile[data-terminal="GrimHEX"]')).toBeVisible();
+});
+
 test("vue Corrections : les commodités d'une station tiennent sur PLUSIEURS colonnes", async ({ page }) => {
   // En une seule colonne, GrimHEX (92 commodités) faisait 4 546 px : quatre écrans et demi à
   // parcourir pour corriger un chiffre, pendant que les colonnes du tableau mesuraient 444 px

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -2111,6 +2111,41 @@ test.describe("chargement du marché", () => {
   });
 });
 
+// ---------- Le message du tableau des trajets n'appartient qu'aux Trajets (#147) ----------
+
+test("une vue sans tableau des trajets ne dit pas « Aucune route ne correspond aux filtres » (#147)", async ({ page }) => {
+  // `switchView` masque bien #empty en entrant dans la Tournée (app.js:1818) — puis appelle
+  // refresh(), qui n'a pas de branche pour `tour` et tombe donc dans `else render()`. Ce dernier
+  // repose `$("empty").hidden = rows.length > 0` : le message revient, et il parle d'un tableau que
+  // la Tournée n'affiche pas. #empty est un <p> FRÈRE de #routes (index.html:420) : masquer la
+  // table ne le masque pas.
+  //
+  // On vérifie d'abord que le message existe VRAIMENT dans les Trajets, sinon le test passerait
+  // sans rien prouver — c'est le piège de #26, laissé écrit à côté.
+  await page.fill("#search", "zzzz");
+  await expect(page.locator("#rows tr")).toHaveCount(0);
+  await expect(page.locator("#empty")).toBeVisible();
+
+  await page.click("#viewTour");
+  await expect(page.locator("#tour")).toBeVisible();
+  await expect(page.locator("#empty")).toBeHidden();
+
+  // Et il ne revient pas non plus à la frappe suivante : c'est `refresh()` qui le repose, donc
+  // n'importe quel geste depuis la Tournée le ferait réapparaître.
+  await page.fill("#search", "zzzzz");
+  await expect(page.locator("#empty")).toBeHidden();
+
+  // Le Plan de vol masque #controls, on y arrive donc avec le filtre déjà posé.
+  await page.click("#viewPlan");
+  await expect(page.locator("#plan")).toBeVisible();
+  await expect(page.locator("#empty")).toBeHidden();
+
+  // Retour aux Trajets : le message est toujours celui du tableau, il n'a pas été perdu.
+  await page.click("#viewRoutes");
+  await expect(page.locator("#empty")).toBeVisible();
+  await expect(page.locator("#empty")).toHaveText("Aucune route ne correspond aux filtres.");
+});
+
 // ---------- Service worker : le cache doit réellement se remplir (#66) ----------
 
 test("service worker : les données atterrissent vraiment dans le cache", async ({ page }) => {

--- a/marche.ts
+++ b/marche.ts
@@ -98,6 +98,23 @@ export const indexOrigine = (): number | null => indexDepart("origin");
 /** Le même, pour le départ de la vue « Chaîne » — même champ de nature, même piège évité. */
 export const indexDepartChaine = (): number | null => indexDepart("chainOrigin");
 
+/**
+ * La station affichée par la vue « Corrections », dérivée du champ `#station`. Vif, comme les deux
+ * ci-dessus, et pour la même raison : c'était une globale `stationSel` qu'une seule fonction de
+ * rendu rafraîchissait. Une valeur dérivée qu'il faut penser à recalculer est une valeur qui sera
+ * un jour lue périmée — ici, par « Enregistrer » un relevé après une restauration par permalien,
+ * qui repose le champ sans le résoudre.
+ *
+ * Correspondance EXACTE, et surtout PAS `resolveStationLabel` : sa seconde passe retombe sur le nom
+ * seul, insensible à la casse, et deux homonymes de systèmes différents — Pyro Gateway (Stanton) et
+ * Pyro Gateway (Nyx) — se résoudraient au premier trouvé. Ce champ-ci porte toujours le libellé
+ * canonique : le sélecteur l'écrit, la vignette de la bande l'écrit, le permalien le transporte.
+ */
+export const indexStationExacte = (): number | null => {
+  const v = champ("station");
+  return stationMap.has(v) ? (stationMap.get(v) as number) : null;
+};
+
 const indexDepart = (id: string): number | null => {
   const v = champ(id);
   return originMap.has(v) ? (originMap.get(v) as number) : null;

--- a/messages.ts
+++ b/messages.ts
@@ -1,0 +1,26 @@
+// Le message éphémère (ADR-012).
+//
+// Un toast n'appartient à aucune vue : il se pose sur `document.body`, il survit au changement de
+// vue, et il n'a pas de conteneur dans `index.html`. C'est ce qui le rend extractible seul, sans
+// rien décider du reste — et c'est aussi ce qui l'empêchera un jour d'être un portail : le nœud
+// qu'il touche n'est possédé par personne.
+//
+// Il sort d'`app.js` parce que `notifySuperseded()` le suit (voir `corrections-actions.ts`), et que
+// celui-là doit devenir appelable depuis une vue de l'arbre.
+
+let toastTimer: ReturnType<typeof setTimeout> | null = null;
+
+/** Flash discret. Le nœud est créé à la volée : `index.html` n'en porte aucun. */
+export function showToast(msg: string): void {
+  let el = document.getElementById("toast");
+  if (!el) {
+    el = document.createElement("div");
+    el.id = "toast";
+    el.className = "toast";
+    document.body.appendChild(el);
+  }
+  el.textContent = msg;
+  el.classList.add("show");
+  if (toastTimer != null) clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => el.classList.remove("show"), 4500);
+}

--- a/rendu.ts
+++ b/rendu.ts
@@ -1,0 +1,43 @@
+// LE CANAL DE RAFRAÎCHISSEMENT (ADR-012).
+//
+// `app.js` n'exporte RIEN — 2 869 lignes, pas une ligne `export`. Un module ne peut donc pas
+// l'appeler, et c'est exactement ce qui bloque les vues qui portent une ACTION : les deux déjà
+// installées dans l'arbre (Tournée, Plan de vol) sont inertes et n'ont jamais eu ce besoin.
+//
+// ── POURQUOI `notifier()` NE SUFFIT PAS ───────────────────────────────────────────────────────
+// `notifier()` (etat.ts) réveille l'arbre React, et rien d'autre. Or `refresh()` fait trois choses
+// de plus, dont AUCUNE ne vit encore dans l'arbre :
+//   — `renderJourney()` (app.js) : la carte du voyage, affichée à côté des tableaux dans six vues ;
+//   — `renderSoute()` / `renderEntrepots()` : la place libre, « où écouler », le prix de vente ;
+//   — `saveState()` : le permalien et la restauration au rechargement.
+// Une action migrée qui n'appellerait que `notifier()` laisserait la carte du voyage, la soute et
+// les entrepôts figés à côté d'un tableau à jour — et le lien partagé périmé. Aucun test ne le
+// verrait : ils regardent tous la vue, pas ce qui l'entoure.
+//
+// ── POURQUOI UN CROCHET, ET PAS UN IMPORT ─────────────────────────────────────────────────────
+// Même patron que `brancher()` dans `donnees.ts` : le module DÉCLARE le besoin, l'amorçage POSE
+// l'implémentation. L'inverse — un module qui importerait `refresh` — est impossible tant que
+// `refresh` vit dans `app.js`, et le resterait de toute façon en cycle une fois `app.js` disparu :
+// c'est la vue qui déclenche le rendu, pas le rendu qui connaît la vue.
+//
+// Ce crochet est TRANSITOIRE, comme les portails d'`App.tsx`. Il disparaît quand `renderJourney`,
+// `renderSoute` et `renderEntrepots` auront à leur tour emménagé dans l'arbre : `notifier()`
+// redeviendra alors le point unique, et `rafraichir()` ne sera plus qu'un alias à supprimer.
+
+let rafraichirCrochet: () => void = () => {};
+
+/** Pose le crochet. Appelé une fois, à l'amorçage, par `app.js`. */
+export function brancherRendu(crochets: { rafraichir: () => void }): void {
+  rafraichirCrochet = crochets.rafraichir;
+}
+
+/**
+ * Rejoue le cycle de rendu complet — ce que `refresh()` fait dans `app.js`, y compris `notifier()`.
+ *
+ * À appeler par toute action migrée qui change l'état PARTAGÉ (une correction, une écriture en
+ * soute, un arrêt de voyage). Une action qui ne touche qu'à l'affichage d'une vue déjà dans l'arbre
+ * n'a besoin que de `notifier()` : ce module ne la concerne pas.
+ */
+export function rafraichir(): void {
+  rafraichirCrochet();
+}

--- a/voyage-donnees.ts
+++ b/voyage-donnees.ts
@@ -20,7 +20,7 @@
 import {
   bestManifest, legsToPin, manifestIntent, manifestIntentSurvives, hydrateManifestLine,
 } from "./logic.ts";
-import type { Filtres, Jambe, LigneManifeste } from "./types.ts";
+import type { CoteMarche, Filtres, Jambe, LigneManifeste } from "./types.ts";
 import { etat } from "./etat.ts";
 import { stationLabel } from "./logic.ts";
 import { readFilters } from "./filtres.ts";
@@ -127,7 +127,7 @@ export function figerJambe(i: number, lignes: LigneManifeste[] | null): boolean 
 //
 // Le gel consulte l'état « chargée » de chaque jambe (#48) : une jambe qu'on n'a pas payée n'est
 // plus figée par une correction de volume, elle RECALCULE. Voir `legsToPin` pour le renversement.
-export function pinLegsForVolume(commodity: string, terminal: string, side: "buy" | "sell"): void {
+export function pinLegsForVolume(commodity: string, terminal: string, side: CoteMarche): void {
   if (!etat.JOURNEY || !etat.JOURNEY.legs.length || !etat.MARKET) return;
   const f = readFilters();
   const lignes = etat.JOURNEY.legs.map((leg, i) => legEffectiveLines(leg, i, f));

--- a/voyage-donnees.ts
+++ b/voyage-donnees.ts
@@ -18,11 +18,12 @@
 // eux-mêmes.
 
 import {
-  bestManifest, manifestIntent, manifestIntentSurvives, hydrateManifestLine,
+  bestManifest, legsToPin, manifestIntent, manifestIntentSurvives, hydrateManifestLine,
 } from "./logic.ts";
 import type { Filtres, Jambe, LigneManifeste } from "./types.ts";
 import { etat } from "./etat.ts";
 import { stationLabel } from "./logic.ts";
+import { readFilters } from "./filtres.ts";
 import { findCommodity, stationMap } from "./marche.ts";
 import { effVals } from "./corrections.ts";
 import { feeCtx, feeResolver } from "./frais.ts";
@@ -107,10 +108,42 @@ export function legIntent(leg: Jambe, i: number, f: Filtres) {
   return etat.JOURNEY_EDITS[k];
 }
 
-// Fige les jambes qu'une correction de volume rebattrait, AVANT qu'elle soit appliquée : on capture
-// donc les quantités telles qu'elles sont encore. La sélection est pure (legsToPin) ; ici on ne
-// fournit que ce que logic.mjs ne peut pas connaître — les chargements effectifs du moment.
 // Fige les SCU d'une jambe : son chargement devient une INTENTION persistée, et le 🔒 dit que ce
 // n'est pas la main de l'utilisateur qui l'a voulu. Rend `true` si quelque chose a bougé.
 // Une jambe déjà ajustée (✎) ou déjà figée n'est pas retouchée : ses quantités ne bougeaient plus,
 // et l'écraser effacerait un ajustement fait à la main.
+export function figerJambe(i: number, lignes: LigneManifeste[] | null): boolean {
+  if (!etat.JOURNEY) return false;
+  const k = legKey(etat.JOURNEY.legs[i], i);
+  if (etat.JOURNEY_EDITS[k]) return false;
+  etat.JOURNEY_EDITS[k] = manifestIntent(lignes || []);
+  etat.JOURNEY_PINS[k] = true;
+  return true;
+}
+
+// Fige les jambes qu'une correction de volume rebattrait, AVANT qu'elle soit appliquée : on capture
+// donc les quantités telles qu'elles sont encore. La sélection est pure (legsToPin) ; ici on ne
+// fournit que ce que logic.ts ne peut pas connaître — les chargements effectifs du moment.
+//
+// Le gel consulte l'état « chargée » de chaque jambe (#48) : une jambe qu'on n'a pas payée n'est
+// plus figée par une correction de volume, elle RECALCULE. Voir `legsToPin` pour le renversement.
+export function pinLegsForVolume(commodity: string, terminal: string, side: "buy" | "sell"): void {
+  if (!etat.JOURNEY || !etat.JOURNEY.legs.length || !etat.MARKET) return;
+  const f = readFilters();
+  const lignes = etat.JOURNEY.legs.map((leg, i) => legEffectiveLines(leg, i, f));
+  const chargees = etat.JOURNEY.legs.map((leg, i) => jambeChargee(leg, i));
+  let change = false;
+  for (const i of legsToPin(etat.JOURNEY.legs, lignes, commodity, terminal, side, chargees)) {
+    if (figerJambe(i, lignes[i])) change = true;
+  }
+  if (change) { saveJourneyEdits(); saveJourneyPins(); }
+}
+
+// Ensemble des commodités transportées au moins une fois sur le parcours (union des manifestes).
+export function journeyCarriedCommodities(): Set<string> {
+  const set = new Set<string>();
+  if (!etat.JOURNEY || !etat.MARKET) return set;
+  const f = readFilters();
+  etat.JOURNEY.legs.forEach((leg, i) => legEffectiveLines(leg, i, f).forEach((l) => set.add(l.name)));
+  return set;
+}


### PR DESCRIPTION
## Ce que ça change

Rien de visible, sauf un correctif : depuis la **Tournée** ou le **Plan de vol**, un filtre qui ne
laissait passer aucun trajet faisait apparaître « Aucune route ne correspond aux filtres. » sous une
vue qui n'affiche pas de tableau. Il ne revient plus.

Pour le reste, c'est le **socle** des deux migrations suivantes (Commodités, puis Corrections) :
cinq blocs quittent `app.js` pour devenir des modules, et une globale disparaît.

## Pourquoi

Les deux vues déjà installées dans la racine React (#143, #145) sont **inertes**. Les six restantes
portent des **actions**, et le patron de l'ADR-011 ne dit rien de leur câblage.

Le blocage est mesurable : **`app.js` n'exporte rien** — 2 869 lignes, pas une ligne `export`. Un
module ne peut donc pas l'appeler, et le patron interdit de pousser des rappels en props. Et
`notifier()` (etat.ts) ne suffit pas : elle réveille l'arbre React et **rien d'autre**, alors que
`refresh()` rejoue en plus la carte du voyage (app.js:1770), la soute et les entrepôts (:1778) et
`saveState()` (:1779) — trois choses qu'aucun test ne regarde.

**ADR-012** (`docs/superpowers/specs/2026-08-17-vues-qui-agissent-adr.md`) tranche les six décisions
du lot, dont deux contre-intuitives : *un composant par VUE, pas un par conteneur* (sinon la grille
des Commodités et son détail recalculeraient `commoditySummaries` chacun de leur côté, soit
exactement le gaspillage que #146 vient de payer), et *les effets de bord pendant le rendu sont un
contrat* — `effVals` purge, `groupOverridesByTerminal` mute, et l'ordre est observable à l'écran.

### Les causes racines, une par commit

1. **`fix(voyage)`** — `switchView` masque `#empty` pour tour/plan/chain/corrections/commodities
   (app.js:1818), puis `refresh()` n'ayant pas de branche pour `tour` ni `plan`, les deux tombaient
   dans `else render()` (app.js:1764) qui repose `$("empty").hidden = rows.length > 0`
   (app.js:281). `#empty` est un `<p>` **frère** de `#routes` (index.html:420) : masquer la table ne
   le masque pas. La vue Trajets est désormais nommée et n'est plus le repli.
2. **`refactor(voyage)`** — `rendu.ts` : un crochet `brancherRendu({ rafraichir })`, sur le patron
   exact de `brancher()` dans `donnees.ts`. Inerte dans ce commit.
3. **`refactor(voyage)`** — `figerJambe`, `pinLegsForVolume` et `journeyCarriedCommodities` →
   `voyage-donnees.ts`, où **leurs commentaires les attendaient déjà**, orphelins depuis #144.
4. **`refactor(uex)`** — `showToast` → `messages.ts` ; `isOv` → `corrections.ts` ;
   `updateOvBadge`, `notifySuperseded` et `corriger` → `corrections-actions.ts`.
5. **`refactor(uex)`** — la globale `stationSel` disparaît au profit d'`indexStationExacte()`.

### Deux pièges que le lot désamorce

- **Les quatre `corriger` n'avaient pas la même signature.** Les *corps* étaient identiques, pas les
  *contrats* : Trajets (app.js:206) et Manifeste (:659) passent six arguments, mais Corrections
  (:2190) ferme sur sa station et le détail des Commodités (:2272) sur sa commodité — cinq chacun.
  Substituer la fonction unifiée **nue** à ces deux-là décalerait tous les arguments, écrivant des
  corrections sur des clés inventées. Ni `tsc` (app.js est hors du `include` de tsconfig) ni aucun
  test ne l'aurait dit. Les deux premiers la passent nue, les deux autres l'enveloppent.
- **`stationSel` n'était rafraîchie que par le rendu.** `renderCorrections` appelait
  `resolveStation()` en tête, et trois lecteurs qui vivent HORS du rendu comptaient dessus —
  « Enregistrer » un relevé, « ✕ n corrections », et le garde du champ. La supprimer à l'étape
  suivante les aurait rendus **muets**, sans message ni log.

## Vérification

| commande | avant | après |
|---|---|---|
| `node --test` | 484 pass / 0 fail | **484 pass / 0 fail** |
| `npx playwright test` | 226 (224 passés, 2 ignorés) | **229 (227 passés, 2 ignorés, 0 échec)** |
| `npx tsc --noEmit` | silencieux | **silencieux** |

**Le test du correctif était ROUGE avant.** `npx playwright test -g "ne dit pas"` :

```
Expected: hidden
Received: visible
  14 x locator resolved to <p id="empty" class="empty">Aucune route ne correspond aux filtres.</p>
> 2131 |   await expect(page.locator("#empty")).toBeHidden();
```

puis, après le correctif d'une ligne :

```
[1/1] e2e/smoke.pw.mjs:2116:1 - une vue sans tableau des trajets ne dit pas
« Aucune route ne correspond aux filtres » (#147)
  1 passed (2.2s)
```

Les **deux autres tests neufs sont des GARDES** : verts avant comme après. C'est voulu — ils
couvrent deux gestes qui n'avaient aucune couverture (`grep stnClear e2e/` → 0) et que le commit 5
pouvait rendre muets.

`app.js` : **2 869 → 2 801 lignes**.

Closes #147

## Ce qui n'est pas couvert

- **Le panneau de frais `#correctionsFees`** reste de l'`innerHTML` sous garde de signature. Cette
  signature est d'ailleurs incomplète — elle ignore `#alk`, le coefficient global, que
  `stationFeeHTML` affiche pourtant. C'est un vrai bug, il aura son issue et son test rouge dans la
  PR qui fait passer ce panneau en JSX.
- **La délégation `#corrections`** ne bouge pas : elle est posée sur un parent que React ne possède
  jamais. L'ADR-012 dit pourquoi, avec le précédent de `#planHead` (#145).
- **Le sélecteur de station** (`monteStationPicker`) et `setupEnRoute` sont hors périmètre : ce sont
  des sœurs de la vue, pas des enfants — aucun portail ne les touchera.
- **Le bandeau `#shipJourneyRow`** vit dans six vues sur huit : il se montera sans garde `si`, ou
  avec un garde négatif. C'est l'inverse du patron des vues d'onglet, et ça mérite sa propre mesure.
- `e2e/rail.pw.mjs:100` échoue quand on le lance **isolé** (`-g`), sur cette branche **comme sur
  `v2/main`** : il mesure la largeur des boutons juste après le repli du rail. Sensible à l'ordre,
  antérieur à ce lot, vert dans la suite complète — signalé, pas traité ici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
