### PR TITLE
feat(corrections): la vue Corrections emménage dans l'arbre

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -21,6 +21,7 @@ import { VueTourneeEcoulement } from "./vues/tournee-vue.tsx";
 import { CorpsPlan, EnTetePlan } from "./vues/plan-vue.tsx";
 import { VueCommodites } from "./vues/commodites-vue.tsx";
 import { PanneauFrais } from "./vues/frais-station.tsx";
+import { VueCorrections } from "./vues/corrections-vue.tsx";
 import { indexStationExacte } from "./marche.ts";
 
 /**
@@ -67,10 +68,11 @@ export function App() {
           vue est faite en tête de `VueCommodites`, AU-DESSUS du calcul. La répéter sur trois
           portails frères ferait recalculer tout le marché trois fois (ADR-012 §3). */}
       <VueCommodites />
-      {/* Le panneau de frais passe en JSX AVANT le reste de la vue Corrections, et dans son propre
-          commit : `corrections.tsx` avertit que changer son garde de re-rendu ET migrer la vue dans
-          la même PR rendrait un échec inexploitable. Conteneur distinct, aucun conflit de racines
-          avec les `peindre()` qu'app.js applique encore aux deux autres. */}
+      {/* La vue Corrections occupe TROIS conteneurs. Les deux premiers vivent dans un seul
+          composant, parce que l'ordre dans lequel ils sont calculés est un contrat : les tuiles
+          purgent les corrections périmées en chemin, la bande doit compter APRÈS (ADR-012 §4).
+          Le panneau de frais, lui, est indépendant — il ne lit ni les corrections ni la purge. */}
+      <VueCorrections />
       <Portail id="correctionsFees" si="corrections"><PanneauFraisStation /></Portail>
     </>
   );

--- a/App.tsx
+++ b/App.tsx
@@ -20,6 +20,8 @@ import { etat, getSnapshot, subscribe } from "./etat.ts";
 import { VueTourneeEcoulement } from "./vues/tournee-vue.tsx";
 import { CorpsPlan, EnTetePlan } from "./vues/plan-vue.tsx";
 import { VueCommodites } from "./vues/commodites-vue.tsx";
+import { PanneauFrais } from "./vues/frais-station.tsx";
+import { indexStationExacte } from "./marche.ts";
 
 /**
  * Rend `children` dans le conteneur `id`, et SEULEMENT si la vue `si` est celle qu'on regarde.
@@ -36,6 +38,16 @@ function Portail({ id, si, children }: { id: string; si?: string; children: Reac
   if (si != null && etat.view !== si) return null;
   const cible = document.getElementById(id);
   return cible ? createPortal(children, cible) : null;
+}
+
+/**
+ * Le panneau de frais a besoin de SA station, et il est le seul de son conteneur : il la dérive
+ * lui-même, comme toute vue de l'arbre. `etat.MARKET` peut manquer — la vue Corrections est encore
+ * peinte par `app.js`, qui déclenche le chargement.
+ */
+function PanneauFraisStation() {
+  const S = etat.MARKET ? indexStationExacte() : null;
+  return <PanneauFrais terminal={S != null ? etat.MARKET!.terminals[S] : null} />;
 }
 
 export function App() {
@@ -55,6 +67,11 @@ export function App() {
           vue est faite en tête de `VueCommodites`, AU-DESSUS du calcul. La répéter sur trois
           portails frères ferait recalculer tout le marché trois fois (ADR-012 §3). */}
       <VueCommodites />
+      {/* Le panneau de frais passe en JSX AVANT le reste de la vue Corrections, et dans son propre
+          commit : `corrections.tsx` avertit que changer son garde de re-rendu ET migrer la vue dans
+          la même PR rendrait un échec inexploitable. Conteneur distinct, aucun conflit de racines
+          avec les `peindre()` qu'app.js applique encore aux deux autres. */}
+      <Portail id="correctionsFees" si="corrections"><PanneauFraisStation /></Portail>
     </>
   );
 }

--- a/README.md
+++ b/README.md
@@ -541,6 +541,11 @@ prennent un **`k` global réglable** (défaut 1,2, milieu des deux mesures). S'y
 caisses, qui dépend du plafond de conteneur du terminal (`max_container_size` d'UEX), **replié sur 32
 quand UEX renvoie 0** : ce repli sous-estime les frais plutôt que de les inventer.
 
+La vue **Corrections** affiche, pour la station cherchée, le tarif qu'elle retiendrait : « Tarif retenu :
+`k = …` », suivi de « (ton relevé) » ou « (k global) » selon d'où il vient, et du montant que ça donne
+pour 32 SCU. Ce panneau **suit le `k` global en direct** : le changer met le chiffre à jour sans quitter
+la vue.
+
 D'où le **`≈` sur tout montant** : l'app donne un ordre de grandeur fiable, pas un chiffre exact. Si tu
 relèves le tarif réel d'une station, tu peux **l'enregistrer** (montant observé pour une quantité donnée →
 `k` déduit) : c'est **local**, comme les corrections, jamais partagé ni mis dans l'URL — seuls

--- a/app.js
+++ b/app.js
@@ -41,15 +41,14 @@ import { brancherRendu } from "./rendu.ts";
 import { monterRacine } from "./main.tsx";
 import { planData, planHypotheses } from "./vues/plan-vue.tsx";
 import { figerJambe, jambeChargee, journeyCarriedCommodities, legEffectiveLines, legFeeCtx, legIntent, legKey, legManifest, legTerminals, loadJourneyEdits, loadJourneyPins, pinLegsForVolume, saveJourneyEdits, saveJourneyPins } from "./voyage-donnees.ts";
-import { vueTournee, messageSouteVide, messageChargement, messageOuEsTu } from "./vues/tournee.tsx";
+// (`vues/tournee.tsx` et `vues/plan.tsx` ne sont plus importés ici : leurs vues vivent dans l'arbre
+// depuis #143 et #145, et seuls leurs composants de DÉCISION les consomment désormais.)
 import { vueBoucles } from "./vues/boucles.tsx";
 import { vueChaine, indiceDepart, indiceSoute, indiceAucune } from "./vues/chaine.tsx";
 // La vue Commodités n'expose plus sa présentation à app.js — seulement ses trois ACTIONS, comme
 // `plan-vue.tsx` expose `planData`. Les écouteurs de `#commSortModes` / `#commBoardModes` restent
 // ici : leurs conteneurs sont du markup d'index.html (ADR-012 §2).
 import { refletBoardCommodites, setCommBoard, setCommSort } from "./vues/commodites-vue.tsx";
-import { vueStation, vueBandeCorrections, inviteStation } from "./vues/corrections.tsx";
-import { enTetePlan, corpsPlan } from "./vues/plan.tsx";
 import { vueTrajets, vueTrajetsMulti } from "./vues/trajets.tsx";
 import { carteManifeste, indiceSouteInactive, indiceSoutePleine, indiceAucunChargement } from "./vues/manifeste.tsx";
 import { carteSoute, carteEntrepots } from "./vues/soute.tsx";
@@ -1697,7 +1696,6 @@ function refresh() {
   if (etat.view === "loops") renderLoops();
   else if (etat.view === "enroute") renderEnRoute();
   else if (etat.view === "chain") renderChain();
-  else if (etat.view === "corrections") renderCorrections();
   // La vue Trajets est NOMMÉE, elle n'est plus le repli. Les deux vues qui vivent dans l'arbre
   // (Tournée, Plan de vol) tombaient ici : `render()` recalculait tout le tableau des trajets pour
   // le repeindre dans un `<tbody>` masqué — et reposait `#empty`, qui est un frère de `#routes` et
@@ -2085,84 +2083,13 @@ function copierCorrections() {
 }
 
 
-// Prépare les tuiles d'une station pour l'îlot : app.js reste le seul à lire MARKET et à appeler
-// `effVals` — dont la purge d'une correction périmée est un effet de bord assumé.
-function tuilesStation(S, q) {
-  const t = etat.MARKET.terminals[S];
-  const tuiles = [];
-  etat.MARKET.commodities.forEach((c) => {
-    if (q && !c.name.toLowerCase().includes(q)) return;
-    const b = c.buys.find((x) => x[0] === S);
-    const s = c.sells.find((x) => x[0] === S);
-    if (!b && !s) return;
-    const cote = (p, side, libelle, unite) => {
-      const e = effVals(c.name, t.name, side, p[1], p[2], p[3]);
-      return {
-        cote: side, libelle, unite,
-        prix: e.price, volume: e.vol,
-        prixCorrige: e.oprice, volumeCorrige: e.ovol,
-        prixBrut: p[1], volumeBrut: p[2],
-        releve: p[3],
-      };
-    };
-    const cotes = [];
-    if (b) cotes.push(cote(b, "buy", "achat", "stock"));
-    if (s) cotes.push(cote(s, "sell", "vente", "dem."));
-    // Une seule ligne par côté RÉEL. La classe de la tuile porte le côté : c'est elle qui donne au
-    // liseré et à l'étiquette leur couleur, nécessaire depuis que l'en-tête de section sort de
-    // l'écran au défilement.
-    tuiles.push({ nom: c.name, kind: c.kind, illegal: c.illegal, achat: !!b, cotes });
-  });
-  return tuiles;
-}
 
-// Les stations corrigées, la station affichée épinglée en tête.
-function groupesCorrections(S) {
-  const actif = S != null ? etat.MARKET.terminals[S].name : null;
-  return groupOverridesByTerminal(etat.OVERRIDES, actif).map((g) => ({
-    terminal: g.terminal,
-    corrections: g.corrections,
-    actif: g.actif,
-    // `null` quand le terminal a disparu de market.json : la vignette s'affiche quand même, sinon
-    // la correction deviendrait invisible ET ineffaçable.
-    info: termByName.get(g.terminal) || null,
-  }));
-}
 
-function renderCorrections() {
-  if (!etat.MARKET) { withMarket(refresh); return; }
-  if (!enrouteReady) setupEnRoute();
-  // UNE dérivation, en tête, et tout le rendu s'y réfère : la station ne peut pas changer entre
-  // deux lectures dans la même passe.
-  const S = indexStationExacte();
-  const q = $("search").value.trim().toLowerCase();
-  // La bande est peinte APRÈS le panneau, bien qu'elle s'affiche au-dessus : la préparation des
-  // tuiles appelle effVals, dont la purge des volumes périmés est un EFFET DE BORD. Compter d'abord
-  // afficherait une correction que le rendu suivant vient d'effacer. L'ordre est donc un contrat.
-  if (S == null) peindre($("correctionsStation"), inviteStation());
-  else {
-    const t = etat.MARKET.terminals[S];
-    // Deux `const`, dans cet ordre, et non deux propriétés d'un littéral : `tuilesStation` PURGE en
-    // chemin (via effVals), donc compter avant elle annoncerait une correction qu'elle vient
-    // d'effacer. L'ordre des propriétés d'un objet le donnerait aussi, mais par accident.
-    const tuiles = tuilesStation(S, q);
-    const nbCorrections = Object.keys(etat.OVERRIDES).filter((k) => k.split("|")[1] === t.name).length;
-    peindre($("correctionsStation"), vueStation({
-      terminal: t,
-      tuiles,
-      filtre: !!q,
-      nbCorrections,
-      // Cette vue-ci ferme sur SA station : elle passe cinq arguments, pas six. L'enveloppe remet
-      // le terminal à sa place — la substituer nue décalerait tout, en silence.
-      corriger: (commodite, cote, champ, valeur, releve) => corriger(commodite, t.name, cote, champ, valeur, releve),
-    }));
-  }
-  peindre($("correctionsIndex"), vueBandeCorrections({ groupes: groupesCorrections(S) }));
-  // Le panneau de frais est rendu par l'arbre (`vues/frais-station.tsx`, portail #correctionsFees).
-  // Son garde de signature est parti avec lui : React ne réécrit pas un champ non contrôlé qu'il
-  // réconcilie, donc la raison d'être du garde — protéger une saisie en cours (#24) — s'évapore.
-  notifySuperseded();
-}
+
+
+// `renderCorrections`, `tuilesStation` et `groupesCorrections` sont passées dans
+// `vues/corrections-vue.tsx` : la vue vit dans l'arbre (ADR-012).
+
 
 // ---------- Vue « Commodités » ----------
 // `marginTier` est passée dans `logic.ts` sous le nom `palierMarge`, avec le maximum en PARAMÈTRE
@@ -2320,17 +2247,11 @@ async function init() {
       }
       return;
     }
-    const del = e.target.closest(".corr-del");
-    if (del) {
-      // Supprimer une correction de volume rend le stock d'UEX : c'est encore un changement de
-      // volume, donc la même règle s'applique — le voyage déjà planifié ne doit pas s'y rebattre.
-      const cle = del.dataset.key;
-      if (etat.OVERRIDES[cle] && etat.OVERRIDES[cle].vol != null) {
-        const [commodity, terminal, side] = cle.split("|");
-        pinLegsForVolume(commodity, terminal, side);
-      }
-      delete etat.OVERRIDES[cle]; saveOverrides(); updateOvBadge(); refresh(); return;
-    }
+    // La branche `.corr-del` générique est partie : elle était MORTE. Les deux seuls producteurs de
+    // cette classe (`vues/frais-station.tsx`) posent aussi `.al-del`, interceptée trois lignes plus
+    // haut avec un `return`. Elle datait de la liste plate de corrections, remplacée par la bande de
+    // vignettes. La garder « par prudence » rouvrirait un chemin d'écriture d'OVERRIDES qui n'existe
+    // plus — et un test asserte au contraire qu'aucun `.corr-item:not(.autoload)` ne subsiste.
     if (e.target.closest("#alSave")) { saveStationReading(); return; }
     if (e.target.closest("#resetAllK")) { resetAllReadings(); return; }
     // Avant « Tout réinitialiser » ici aussi : rien ne doit s'effacer sans qu'on ait pu l'emporter.

--- a/app.js
+++ b/app.js
@@ -4,7 +4,7 @@
 import {
   tripMinutes, ageDays, pairAge,
   scoreBarWidth, bySort, addableUnits, scuBoxes, cargoBoxes, bestChain,
-  autoloadFee, kFromReading, kPlausible,
+  kFromReading, kPlausible,
   ovKey, groupOverridesByTerminal, safeKey, encodeState, decodeState,
   routePasses, loopPasses,
   routeMetrics, loopMetrics, enRouteDeals, bestManifest, buildChainAdjacency, suggestionsFrom, netMarginRoi,
@@ -34,7 +34,7 @@ import { effVals, isOv, loadOverrides, ovCount, resetOverrides, saveOverrides, s
 import { corriger, notifySuperseded, updateOvBadge } from "./corrections-actions.ts";
 import { showToast } from "./messages.ts";
 import { construireIndex, findCommodity, indexDepartChaine, indexOrigine, indexStationExacte, libellesOrigines, libellesStations, resolveStationLabel, stationCourante, stationMap, termByName } from "./marche.ts";
-import { alKey, feeCargoText, feeCell, feeCtx, feeEndText, feeLoadText, feeResolver, globalK, kFmt, kFor, lineProfitText, loadAutoloadK, saveAutoloadK } from "./frais.ts";
+import { alKey, feeCargoText, feeCell, feeCtx, feeEndText, feeLoadText, feeResolver, globalK, kFmt, lineProfitText, loadAutoloadK, saveAutoloadK } from "./frais.ts";
 import { applyState, loadState, saveState, shareURL } from "./persistance.ts";
 import { brancher, ensureFeeMarket, ensureStarmap, withMarket } from "./donnees.ts";
 import { brancherRendu } from "./rendu.ts";
@@ -377,9 +377,6 @@ let enrouteReady = false;     // datalist/destSystem peuplés une seule fois
 // invisible au garde — le panneau resterait sur l'ancienne station à côté d'un champ vide.
 let derniereStation;
 const memoriserStation = () => { derniereStation = indexStationExacte(); };
-// Signature du panneau de frais déjà peint : tant qu'elle ne bouge pas, on ne le réécrit pas, et
-// une saisie en cours y survit (#24).
-let feesRendus = null;
 
 // Charge le graphe de marché à la demande. Deux règles, apprises à la dure :
 //   - on mémorise la PROMESSE en vol, pas seulement son résultat : sinon chaque frappe pendant le
@@ -2059,34 +2056,11 @@ function resetAllReadings() {
 // (marche.ts) : la station se dérive du champ à chaque lecture, au lieu d'être mise en cache par
 // une fonction de rendu. Voir marche.ts pour pourquoi ce n'est pas `resolveStationLabel`.
 
-// Relevé du tarif d'autoload d'une station. L'utilisateur ne saisit PAS `k` : personne ne lit un
-// coefficient en jeu, on lit une facture. Il donne un montant observé pour une quantité, et `k` s'en
-// déduit. Les champs ne portent PAS la classe `.editv` : le handler global de l'édition inline
-// l'attrape partout dans le document et écrirait dans les corrections de prix.
-function stationFeeHTML(S) {
-  const t = etat.MARKET.terminals[S];
-  const head = `<div class="fee-head">◈ Frais d'autoload — ${esc(t.name)}</div>`;
-  const wrap = (body) => `<div class="fee-panel">${head}${body}</div>`;
-  // Deux non-dits distincts, et aucun ne doit se lire « 0 aUEC » : le champ absent (instantané de
-  // market.json antérieur au build qui l'ajoute) et le service réellement indisponible.
-  if (t.autoload == null) return wrap('<p class="fee-off">Donnée d\'autoload absente de cet export UEX : aucun frais n\'est facturé à cette station tant qu\'elle manque.</p>');
-  if (t.autoload !== true) return wrap('<p class="fee-off">Cette station ne propose pas l\'autoload : aucun frais n\'y est facturé, quel que soit ton réglage.</p>');
-  const rec = etat.AUTOLOAD_K[alKey(t.name)];
-  const k = kFor(t.name);
-  const scu = rec ? rec.scu : 32;
-  const note = `<div class="fee-note">Tarif retenu : <b>k = ${kFmt(k)}</b> ${rec ? "(ton relevé)" : "(k global)"} — soit ≈ <b>${fmt(autoloadFee(scu, t.maxBox, k))}</b> aUEC pour ${fmt(scu)} SCU${t.maxBox ? `, caisses de ${fmt(t.maxBox)} SCU max` : ""}.</div>`;
-  return wrap(
-    `<div class="fee-row">
-       <span>Montant observé</span>
-       <input id="alAmount" type="number" min="0" step="1" value="${rec ? rec.amount : ""}" placeholder="ex : 1159" aria-label="Montant payé en aUEC" />
-       <span>aUEC pour</span>
-       <input id="alScu" type="number" min="1" step="1" value="${scu}" aria-label="Quantité en SCU" />
-       <span>SCU</span>
-       <button id="alSave" type="button" class="copy-btn">Enregistrer</button>
-       ${rec ? `<button type="button" class="corr-del al-del" data-key="${esc(alKey(t.name))}" title="Oublier ce relevé" aria-label="Oublier ce relevé">✕</button>` : ""}
-     </div>${note}`
-  );
-}
+// `stationFeeHTML` et `autoloadListHTML` sont passées dans `vues/frais-station.tsx` : c'étaient
+// les DEUX DERNIÈRES fonctions de vue rendant des chaînes HTML. Leur garde de signature part avec
+// elles — React ne réécrit pas un champ non contrôlé qu'il réconcilie (ADR-012).
+
+
 
 // Tableau éditable des commodités d'une station (prix/stock à l'achat, prix/demande à la vente).
 // `stationTableHTML` a été remplacé par vues/corrections.tsx.
@@ -2110,19 +2084,6 @@ function copierCorrections() {
   copierTexte(JSON.stringify(exporterCorrections(etat.OVERRIDES, nowSec()), null, 2), $("exportCorrections"), "⧉ Exporter");
 }
 
-// Liste des relevés d'autoload, à côté des corrections locales et sur le même modèle : ils sont de
-// la même nature (mesures faites en jeu, purement locales), mais ils ne comptent PAS dans le badge
-// « Corrections (n) » du rail et « Tout réinitialiser » ne les touche pas — ils ont leur propre store.
-function autoloadListHTML() {
-  const keys = Object.keys(etat.AUTOLOAD_K);
-  if (!keys.length) return "";
-  const items = keys.sort().map((key) => {
-    const o = etat.AUTOLOAD_K[key];
-    const terminal = key.slice(key.indexOf("|") + 1);
-    return `<div class="corr-item autoload"><div><b>${esc(terminal)}</b> <span class="corr-side">autoload</span><div class="loc-sub">k = <b>${kFmt(o.k)}</b> · ${fmt(o.amount)} aUEC observés pour ${fmt(o.scu)} SCU</div></div><button class="corr-del al-del" data-key="${esc(key)}" title="Oublier ce relevé">✕</button></div>`;
-  }).join("");
-  return `<div class="corr-list-head"><span>${keys.length} relevé${keys.length > 1 ? "s" : ""} d'autoload</span><button id="resetAllK" class="reset-ov">Tout oublier</button></div>${items}`;
-}
 
 // Prépare les tuiles d'une station pour l'îlot : app.js reste le seul à lire MARKET et à appeler
 // `effVals` — dont la purge d'une correction périmée est un effet de bord assumé.
@@ -2197,16 +2158,9 @@ function renderCorrections() {
     }));
   }
   peindre($("correctionsIndex"), vueBandeCorrections({ groupes: groupesCorrections(S) }));
-  // Le panneau de frais n'est réécrit QUE si son contenu a changé (#24). Le sortir de
-  // #correctionsStation ne suffisait pas : renderCorrections réécrivait son nouveau conteneur tout
-  // aussi inconditionnellement, et un montant en cours de frappe repartait à vide au moindre
-  // re-rendu — un filtre tapé, une correction ailleurs. Le panneau ne dépend que de la station
-  // affichée et du store des relevés : cette signature suffit à décider.
-  const signature = `${S}|${JSON.stringify(etat.AUTOLOAD_K)}`;
-  if (signature !== feesRendus) {
-    feesRendus = signature;
-    $("correctionsFees").innerHTML = (S != null ? stationFeeHTML(S) : "") + autoloadListHTML();
-  }
+  // Le panneau de frais est rendu par l'arbre (`vues/frais-station.tsx`, portail #correctionsFees).
+  // Son garde de signature est parti avec lui : React ne réécrit pas un champ non contrôlé qu'il
+  // réconcilie, donc la raison d'être du garde — protéger une saisie en cours (#24) — s'évapore.
   notifySuperseded();
 }
 

--- a/e2e/arbre.pw.mjs
+++ b/e2e/arbre.pw.mjs
@@ -63,3 +63,23 @@ test("Arbre : le board se peint bien quand on le regarde, lui", async ({ page })
   expect(await lots(), "le board n'a pas suivi le filtre alors qu'il est à l'écran").toBeGreaterThan(0);
   expect(await page.locator("#commGrid .comm-tile").count()).toBeGreaterThan(0);
 });
+
+test("Arbre : taper depuis les Trajets ne repeint pas la vue Corrections", async ({ page }) => {
+  // Même mesure, sur la vue la plus chère des deux : `tuilesStation` parcourt tout le catalogue de
+  // commodités et appelle `effVals` — qui PURGE et PERSISTE — une à deux fois par tuile. La
+  // réévaluer depuis une autre vue ne serait pas seulement du calcul perdu : ce serait des
+  // écritures de `localStorage` déclenchées par une frappe qui ne la concerne pas.
+  await page.click("#viewCorrections");
+  await expect(page.locator("#stationList option").first()).toBeAttached({ timeout: 20000 });
+  await page.fill("#station", "Levski — Nyx");
+  await expect(page.locator("#correctionsStation .scomm").first()).toBeVisible({ timeout: 20000 });
+
+  await page.click("#viewRoutes");
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+
+  const lots = await compterLots(page, "correctionsStation");
+  await page.locator("#search").pressSequentially("Laranite", { delay: 30 });
+  await expect(page).toHaveURL(/search=Laranite/, { timeout: 10000 });
+
+  expect(await lots(), "la vue Corrections a été repeinte depuis les Trajets").toBe(0);
+});

--- a/e2e/autoload.pw.mjs
+++ b/e2e/autoload.pw.mjs
@@ -443,3 +443,33 @@ test("relevé de station : une station restaurée par permalien reste actionnabl
   await expect(page.locator(".corr-item.autoload")).toContainText(label.split(" — ")[0]);
   await expect(page.locator(".corr-item.autoload")).toContainText("1,41");
 });
+
+// Le panneau de frais annonce « Tarif retenu : k = … », lu par `kFor` — qui retombe sur le
+// coefficient GLOBAL (`#alk`) tant qu'aucun relevé n'existe pour cette station. Or le garde qui
+// décide de réécrire le panneau ne regarde que la station et le store des relevés : changer `#alk`
+// en restant sur la vue Corrections laissait donc un chiffre PÉRIMÉ à l'écran, sous un intitulé qui
+// dit exactement d'où il vient. Le danger est asymétrique : le panneau n'est visible que la case
+// `#autoload` cochée, donc personne ne le voit se tromper.
+test("frais de station : « Tarif retenu » suit le coefficient global (#alk)", async ({ page }) => {
+  await enrichMarket(page, "all", 32);
+  await page.goto("/index.html");
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+  await page.check("#autoload");
+  await expect(page.locator("#alkField")).toBeVisible();
+
+  await page.click("#viewCorrections");
+  await expect(page.locator("#stationList option").first()).toBeAttached({ timeout: 15000 });
+  const label = await page.locator("#stationList option").first().getAttribute("value");
+  await page.fill("#station", label);
+  await expect(page.locator("#correctionsFees .fee-note")).toContainText("(k global)");
+
+  const avant = await page.locator("#correctionsFees .fee-note").innerText();
+  expect(avant).toContain("1,2"); // le défaut d'index.html
+
+  // On double le coefficient. Le panneau annonce toujours « k global » : il doit donc suivre.
+  await page.fill("#alk", "2.4");
+  await expect(page.locator("#correctionsFees .fee-note")).toContainText("2,4", { timeout: 10000 });
+  // Et le montant illustré suit aussi : c'est lui que l'utilisateur compare à sa facture.
+  const apres = await page.locator("#correctionsFees .fee-note").innerText();
+  expect(apres).not.toBe(avant);
+});

--- a/vues/corrections-vue.tsx
+++ b/vues/corrections-vue.tsx
@@ -1,0 +1,139 @@
+// La VUE Corrections : le composant qui décide quoi afficher (ADR-011 étape 3, ADR-012).
+//
+// `corrections.tsx` garde la PRÉSENTATION — le bandeau de station, les tuiles, la bande des
+// stations corrigées. Ce fichier-ci porte la DÉCISION : marché absent, station résolue ou non,
+// quelles cotes, combien de corrections.
+//
+// ── L'ORDRE EST UN CONTRAT, ET IL DESCEND D'UN CRAN ───────────────────────────────────────────
+// La bande des stations s'affiche AU-DESSUS du panneau (index.html), mais elle est calculée APRÈS
+// lui. Ce n'est pas une coquetterie : `tuilesStation` appelle `effVals`, qui PURGE les corrections
+// périmées et persiste (corrections.ts). Compter d'abord annoncerait sur la vignette une correction
+// que le rendu suivant vient d'effacer.
+//
+// `renderCorrections` le documentait déjà entre ses deux `peindre()`. Ici le contrat va plus loin :
+// à l'intérieur du panneau, `nbCorrections` doit lui aussi être compté APRÈS `tuilesStation`. Écrit
+// en littéral d'objet, l'ordre des propriétés le donnait — mais par accident. On l'écrit donc en
+// `const` successives, dans un SEUL composant : l'ordre d'évaluation redevient l'ordre des
+// instructions, et non l'ordre des frères JSX (ADR-012 §3 et §4).
+//
+// ── LA DÉLÉGATION NE DÉMÉNAGE PAS ─────────────────────────────────────────────────────────────
+// `#corrections` (index.html) est le PARENT des deux conteneurs de portail, donc hors de tout arbre
+// React : les événements natifs y remontent à travers le portail. C'est le précédent
+// `#planHead`/`#planCopy` (#145). Aucun `onClick` React n'est donc posé sur `.stn-tile`,
+// `.scomm-undo`, `#stnClear`, `#exportCorrections` ni `#resetAll` — le doublement serait invisible
+// (ces gestes sont idempotents à l'échelle d'un clic) SAUF pour `pinLegsForVolume`, dont un second
+// passage APRÈS l'écriture figerait les jambes sur des SCU déjà recalculés.
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+
+import { groupOverridesByTerminal } from "../logic.ts";
+import type { CoteCommodite, GroupeCorrections, TuileCommodite } from "./corrections.tsx";
+import { etat, notifier } from "../etat.ts";
+import { readFilters } from "../filtres.ts";
+import { effVals } from "../corrections.ts";
+import { corriger, notifySuperseded } from "../corrections-actions.ts";
+import { withMarket } from "../donnees.ts";
+import { indexStationExacte, termByName } from "../marche.ts";
+import { VueBandeCorrections, VueStation, inviteStation } from "./corrections.tsx";
+
+/**
+ * Les tuiles d'une station : une par commodité qu'on peut y acheter ou y vendre, filtrées par la
+ * recherche.
+ *
+ * APPELLE `effVals`, dont la purge d'une correction périmée est un EFFET DE BORD assumé — c'est
+ * pour lui que l'ordre d'évaluation de cette vue est un contrat.
+ */
+function tuilesStation(S: number, q: string): TuileCommodite[] {
+  const marche = etat.MARKET!;
+  const t = marche.terminals[S];
+  const tuiles: TuileCommodite[] = [];
+  marche.commodities.forEach((c) => {
+    if (q && !c.name.toLowerCase().includes(q)) return;
+    const b = c.buys.find((x) => x[0] === S);
+    const s = c.sells.find((x) => x[0] === S);
+    if (!b && !s) return;
+    const cote = (p: number[], side: "buy" | "sell", libelle: string, unite: string): CoteCommodite => {
+      const e = effVals(c.name, t.name, side, p[1], p[2], p[3]);
+      return {
+        cote: side, libelle, unite,
+        prix: e.price, volume: e.vol,
+        prixCorrige: e.oprice, volumeCorrige: e.ovol,
+        prixBrut: p[1], volumeBrut: p[2],
+        releve: p[3],
+      };
+    };
+    const cotes: CoteCommodite[] = [];
+    if (b) cotes.push(cote(b, "buy", "achat", "stock"));
+    if (s) cotes.push(cote(s, "sell", "vente", "dem."));
+    // Une seule ligne par côté RÉEL. La classe de la tuile porte le côté : c'est elle qui donne au
+    // liseré et à l'étiquette leur couleur, nécessaire depuis que l'en-tête de section sort de
+    // l'écran au défilement.
+    tuiles.push({ nom: c.name, kind: c.kind, illegal: c.illegal, achat: !!b, cotes });
+  });
+  return tuiles;
+}
+
+/** Les stations corrigées, la station affichée épinglée en tête. */
+function groupesCorrections(S: number | null): GroupeCorrections[] {
+  const actif = S != null ? etat.MARKET!.terminals[S].name : null;
+  return groupOverridesByTerminal(etat.OVERRIDES, actif).map((g) => ({
+    terminal: g.terminal,
+    corrections: g.corrections,
+    actif: g.actif,
+    // `null` quand le terminal a disparu de market.json : la vignette s'affiche quand même, sinon
+    // la correction deviendrait invisible ET ineffaçable.
+    info: termByName.get(g.terminal) || null,
+  }));
+}
+
+/** Rend `children` dans le conteneur `id`. La garde de vue est faite une fois, au-dessus. */
+function Portail({ id, children }: { id: string; children: React.ReactNode }) {
+  const cible = document.getElementById(id);
+  return cible ? createPortal(children, cible) : null;
+}
+
+export function VueCorrections() {
+  // Un effet, donc avant tout retour anticipé : il affiche un toast et réécrit le compteur du rail.
+  useEffect(notifySuperseded);
+
+  if (etat.view !== "corrections") return null;
+
+  if (!etat.MARKET) {
+    withMarket(notifier);
+    return null;
+  }
+
+  // UNE dérivation, en tête : la station ne peut pas changer entre deux lectures de la même passe.
+  const S = indexStationExacte();
+  // `readFilters().q` et non une lecture brute du champ : c'est exactement la même expression, et
+  // une seule source vaut mieux que deux qui doivent rester d'accord.
+  const q = readFilters().q;
+
+  // L'ORDRE : les tuiles PURGENT, on compte ensuite, et la bande se calcule en dernier.
+  const t = S != null ? etat.MARKET.terminals[S] : null;
+  const tuiles = S != null ? tuilesStation(S, q) : [];
+  const nbCorrections = t
+    ? Object.keys(etat.OVERRIDES).filter((k) => k.split("|")[1] === t.name).length
+    : 0;
+  const groupes = groupesCorrections(S);
+
+  return (
+    <>
+      <Portail id="correctionsStation">
+        {!t ? inviteStation() : (
+          <VueStation
+            terminal={t}
+            tuiles={tuiles}
+            filtre={!!q}
+            nbCorrections={nbCorrections}
+            // Cette vue ferme sur SA station : cinq arguments, pas six. L'enveloppe remet le
+            // terminal à sa place — passer `corriger` nu décalerait tout, en silence.
+            corriger={(commodite, cote, champ, valeur, releve) =>
+              corriger(commodite, t.name, cote, champ, valeur, releve)}
+          />
+        )}
+      </Portail>
+      <Portail id="correctionsIndex"><VueBandeCorrections groupes={groupes} /></Portail>
+    </>
+  );
+}

--- a/vues/frais-station.tsx
+++ b/vues/frais-station.tsx
@@ -1,0 +1,154 @@
+// Le panneau de frais d'autoload de la vue Corrections (ADR-012).
+//
+// C'étaient les DEUX DERNIÈRES fonctions de vue rendant des chaînes HTML dans `app.js` —
+// `stationFeeHTML` et `autoloadListHTML`. Elles y avaient survécu à toute la migration pour une
+// raison précise, écrite dans `corrections.tsx` : le panneau porte des champs de SAISIE LIBRE
+// (`#alAmount`, `#alScu`), et `renderCorrections` le réécrivait inconditionnellement. Un montant en
+// cours de frappe repartait à vide au moindre re-rendu — un filtre tapé, une correction ailleurs.
+// D'où un garde de signature, `feesRendus`, qui ne réécrivait que si la signature changeait.
+//
+// ── POURQUOI LE GARDE DISPARAÎT AU LIEU D'ÊTRE PORTÉ ──────────────────────────────────────────
+// React ne réécrit PAS un champ non contrôlé qu'il réconcilie : `defaultValue` pose la valeur au
+// montage et n'y retouche jamais. La raison d'être du garde s'évapore donc — et le porter dans un
+// `useRef` figerait à l'écran des chiffres FAUX, ce qui est exactement le bug que ce commit corrige.
+//
+// Ce garde était en effet INCOMPLET : sa signature valait `station | relevés`, alors que le panneau
+// affiche aussi `kFor(t.name)`, qui retombe sur le coefficient GLOBAL (`#alk`) tant qu'aucun relevé
+// n'existe. Changer `#alk` en restant sur la vue laissait donc « Tarif retenu : k = 1,2 » sous les
+// yeux d'un utilisateur qui venait d'écrire 2,4 — et personne ne le voyait, puisque le champ `#alk`
+// n'est démasqué que la case « frais d'autoload » cochée.
+//
+// ── LA CLÉ EST L'IDENTITÉ DU RELEVÉ, PAS LE NOM DE LA STATION ─────────────────────────────────
+// `defaultValue` a un revers : si React réconcilie le même composant à la même place, les deux
+// champs gardent ce qu'ils portaient. Deux conséquences si la clé ne dépend que de la station :
+// changer de station laisserait à l'écran le montant de la PRÉCÉDENTE — et `saveStationReading`,
+// qui LIT le DOM, persisterait la mesure d'une station sur une autre ; et effacer un relevé
+// laisserait ses chiffres dans les champs, prêts à être ressuscités par « Enregistrer ».
+// La clé porte donc le relevé lui-même. Le store ne change que sur un geste délibéré (Enregistrer,
+// Oublier), jamais au milieu d'une saisie : le remontage ne peut pas tomber sur une frappe.
+import { autoloadFee } from "../logic.ts";
+import type { Terminal } from "../types.ts";
+import { etat } from "../etat.ts";
+import { fmt } from "../format.ts";
+import { alKey, kFmt, kFor } from "../frais.ts";
+
+type Releve = { k: number; amount: number; scu: number };
+
+const Panneau = ({ nom, children }: { nom: string; children: React.ReactNode }) => (
+  <div className="fee-panel">
+    <div className="fee-head">◈ Frais d'autoload — {nom}</div>
+    {children}
+  </div>
+);
+
+/**
+ * Relevé du tarif d'autoload d'une station.
+ *
+ * L'utilisateur ne saisit PAS `k` : personne ne lit un coefficient en jeu, on lit une facture. Il
+ * donne un montant observé pour une quantité, et `k` s'en déduit.
+ *
+ * Les champs ne portent PAS la classe `.editv` : la délégation de l'édition sur place l'attrape
+ * partout dans le document et écrirait dans les corrections de prix.
+ */
+export function FraisStation({ terminal }: { terminal: Terminal }) {
+  // Deux non-dits distincts, et aucun ne doit se lire « 0 aUEC » : le champ absent (instantané de
+  // market.json antérieur au build qui l'ajoute) et le service réellement indisponible.
+  if (terminal.autoload == null) {
+    return (
+      <Panneau nom={terminal.name}>
+        <p className="fee-off">Donnée d'autoload absente de cet export UEX : aucun frais n'est facturé à cette station tant qu'elle manque.</p>
+      </Panneau>
+    );
+  }
+  if (terminal.autoload !== true) {
+    return (
+      <Panneau nom={terminal.name}>
+        <p className="fee-off">Cette station ne propose pas l'autoload : aucun frais n'y est facturé, quel que soit ton réglage.</p>
+      </Panneau>
+    );
+  }
+
+  const cle = alKey(terminal.name);
+  const rec = etat.AUTOLOAD_K[cle] as Releve | undefined;
+  const k = kFor(terminal.name);
+  const scu = rec ? rec.scu : 32;
+
+  return (
+    <Panneau nom={terminal.name}>
+      <div className="fee-row">
+        <span>Montant observé</span>
+        <input id="alAmount" type="number" min="0" step="1" defaultValue={rec ? String(rec.amount) : ""}
+               placeholder="ex : 1159" aria-label="Montant payé en aUEC" />
+        <span>aUEC pour</span>
+        <input id="alScu" type="number" min="1" step="1" defaultValue={String(scu)}
+               aria-label="Quantité en SCU" />
+        <span>SCU</span>
+        {/* Ces trois-là restent pris par la délégation posée sur `#corrections`, le PARENT de ce
+            portail : un événement natif y remonte à travers le portail. Leur ajouter un onClick
+            doublerait l'action. */}
+        <button id="alSave" type="button" className="copy-btn">Enregistrer</button>
+        {rec ? (
+          <button type="button" className="corr-del al-del" data-key={cle}
+                  title="Oublier ce relevé" aria-label="Oublier ce relevé">✕</button>
+        ) : null}
+      </div>
+      <div className="fee-note">
+        Tarif retenu : <b>k = {kFmt(k)}</b> {rec ? "(ton relevé)" : "(k global)"} — soit ≈{" "}
+        <b>{fmt(autoloadFee(scu, terminal.maxBox, k))}</b> aUEC pour {fmt(scu)} SCU
+        {terminal.maxBox ? `, caisses de ${fmt(terminal.maxBox)} SCU max` : ""}.
+      </div>
+    </Panneau>
+  );
+}
+
+/**
+ * La liste des relevés d'autoload, à côté des corrections locales et sur le même modèle.
+ *
+ * Ils sont de même nature — des mesures faites en jeu, purement locales — mais ils ne comptent PAS
+ * dans le badge « Corrections (n) » du rail, et « Tout réinitialiser » ne les touche pas : ils ont
+ * leur propre store.
+ */
+export function ListeAutoload() {
+  const cles = Object.keys(etat.AUTOLOAD_K).sort();
+  if (!cles.length) return null;
+  return (
+    <>
+      <div className="corr-list-head">
+        <span>{cles.length} relevé{cles.length > 1 ? "s" : ""} d'autoload</span>
+        <button id="resetAllK" className="reset-ov">Tout oublier</button>
+      </div>
+      {cles.map((cle) => {
+        const o = etat.AUTOLOAD_K[cle] as Releve;
+        const terminal = cle.slice(cle.indexOf("|") + 1);
+        return (
+          <div className="corr-item autoload" key={cle}>
+            <div>
+              <b>{terminal}</b> <span className="corr-side">autoload</span>
+              <div className="loc-sub">k = <b>{kFmt(o.k)}</b> · {fmt(o.amount)} aUEC observés pour {fmt(o.scu)} SCU</div>
+            </div>
+            <button className="corr-del al-del" data-key={cle} title="Oublier ce relevé">✕</button>
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
+/**
+ * Le conteneur `#correctionsFees` en entier : le panneau de la station affichée, puis les relevés.
+ *
+ * `key` porte l'IDENTITÉ DU RELEVÉ et pas seulement la station — voir l'en-tête. Sans elle, les
+ * deux champs non contrôlés survivraient à un changement de station comme à la suppression du
+ * relevé qu'ils affichent.
+ */
+export function PanneauFrais({ terminal }: { terminal: Terminal | null }) {
+  const rec = terminal ? (etat.AUTOLOAD_K[alKey(terminal.name)] as Releve | undefined) : undefined;
+  return (
+    <>
+      {terminal ? (
+        <FraisStation key={`${terminal.name}|${rec ? `${rec.amount}/${rec.scu}` : ""}`} terminal={terminal} />
+      ) : null}
+      <ListeAutoload />
+    </>
+  );
+}


### PR DESCRIPTION
> **Empilée sur #151**, elle-même sur #148. Base : `v2/commodites-dans-larbre`. À fusionner en dernier.

## Ce que ça change

Deux choses, et la première est un **correctif** : le panneau de frais d'autoload de la vue
Corrections annonçait « Tarif retenu : **k = 1,2** *(k global)* » et n'en bougeait plus quand on
changeait le coefficient global. Il suit désormais en direct.

La seconde est invisible : la **vue Corrections** emménage dans la racine React. C'est la dernière
marche du lot — deux vues sur huit y vivaient hier, quatre y vivent maintenant.

## Pourquoi

### Le bug (#150) : un garde qui ignorait la moitié de ce qu'il gardait

`#correctionsFees` n'était réécrit que si sa signature changeait :

```js
const signature = `${S}|${JSON.stringify(etat.AUTOLOAD_K)}`;
```

Station + relevés. Mais le panneau affiche `kFor(t.name)` (frais.ts), qui retombe sur `globalK()` —
donc sur le champ `#alk` — tant qu'aucun relevé n'existe pour cette station. Le garde ignorait la
moitié de ce que le panneau montre.

Le garde lui-même était **légitime** : il protégeait une saisie en cours (#24, #28). Mais React ne
réécrit **pas** un champ non contrôlé qu'il réconcilie — `defaultValue` pose la valeur au montage et
n'y retouche jamais. En passant le panneau en JSX, la raison d'être du garde s'évapore avec lui. Le
reproduire dans un `useRef` « par conformité » figerait un chiffre **faux** à l'écran, c'est-à-dire
ce bug exactement.

**Le revers de `defaultValue`, et pourquoi la clé porte le relevé.** À place égale dans l'arbre, les
champs gardent ce qu'ils portaient. Une clé qui ne dépendrait que de la station laisserait, en
changeant de station, le montant de la **précédente** — et `saveStationReading`, qui **lit le DOM**,
persisterait la mesure d'une station sur une autre. Effacer un relevé laisserait de même ses
chiffres prêts à être ressuscités par « Enregistrer ». La clé porte donc l'identité du relevé ; le
store ne change que sur un geste délibéré, jamais au milieu d'une frappe.

`stationFeeHTML` et `autoloadListHTML` étaient les **deux dernières** fonctions de vue rendant des
chaînes HTML dans `app.js`.

### Pourquoi le panneau passe en JSX dans un commit SÉPARÉ

`vues/corrections.tsx` l'avertissait noir sur blanc : « changer ce garde ET migrer la vue dans la
même PR rendrait un échec inexploitable ». Les deux commits sont donc distincts et mesurés
séparément, le premier tournant pendant que `renderCorrections` peint encore les deux autres
conteneurs — conteneurs différents, aucun conflit de racines.

### La migration : un composant, parce que l'ordre est un contrat

`tuilesStation` appelle `effVals`, qui **purge** les corrections périmées et **persiste**. Compter
d'abord annoncerait sur la vignette une correction que le rendu suivant vient d'effacer.
`renderCorrections` documentait déjà ce contrat entre ses deux `peindre()` ; ici il **descend d'un
cran** — `nbCorrections` doit lui aussi être compté après les tuiles. Écrit en `const` successives
dans un seul composant, l'ordre d'évaluation redevient l'ordre des instructions, et non l'ordre des
frères JSX.

**La délégation `#corrections` ne bouge pas.** Elle est posée sur le **parent** des deux conteneurs
de portail, donc hors de tout arbre React : les événements natifs y remontent à travers le portail
(précédent `#planHead`, #145). Aucun `onClick` React n'est posé sur `.stn-tile`, `.scomm-undo`,
`#stnClear`, `#exportCorrections` ni `#resetAll`. Le doublement serait invisible — ces gestes sont
idempotents à l'échelle d'un clic — **sauf** pour `pinLegsForVolume`, dont un second passage *après*
l'écriture figerait les jambes sur des SCU déjà recalculés.

Une seule branche disparaît : `.corr-del` générique, **code mort vérifié**. Ses deux seuls
producteurs posent aussi `.al-del`, interceptée trois lignes plus haut avec un `return`. Elle datait
de la liste plate remplacée par la bande de vignettes (#38).

## Vérification

| commande | avant (#151) | après |
|---|---|---|
| `node --test` | 486 pass / 0 fail | **486 pass / 0 fail** |
| `npx playwright test` | 234 (232 passés, 2 ignorés) | **236 (234 passés, 2 ignorés, 0 échec)** |
| `npx tsc --noEmit` | silencieux | **silencieux** |
| `npm run build:site` | OK | **OK** |

**Le test de #150 était ROUGE avant :**

```
Error: expect(locator).toContainText(expected) failed
Locator: locator('#correctionsFees .fee-note')
Expected substring: "2,4"
Received string:    "Tarif retenu : k = 1,2 (k global) — soit ≈ 984 aUEC pour 32 SCU, caisses de 32 SCU max."
```

Après : `2 passed (2.8s)`, et `autoload.pw.mjs` → **14/14**, dont le test de #28 nommément vérifié
(« un rendu différé n'efface pas le montant déjà saisi »).

Sous-ensemble le plus exposé — Corrections + les quatre tests de Soute qui utilisent
`#correctionsStation .editv[data-v]` comme oracle du stock effectif + le sélecteur de station :
**42/42**.

`app.js` : **2 669 → 2 544 lignes** · **30 → 27 `peindre()`**.

Closes #150

## Ce qui n'est pas couvert

- **Le sélecteur de station** (`monteStationPicker`, `#correctionsControls`) reste dans `app.js` :
  c'est une **sœur** de `#corrections`, pas une enfant — aucun portail ne la touche. Six tests e2e
  la tiennent, et elle emporte avec elle les derniers `esc()` / `vignetteStation()` / `sysBadge()`
  en chaîne HTML. Lot à part.
- `setupEnRoute` / `enrouteReady` restent : du peuplement de `<datalist>` en `innerHTML`, sans
  rapport avec React. Les deux gardes qui les appelaient dans les vues migrées ont disparu sans
  perte — `withMarket` rejoue `apresMarche` avant chaque rappel.
- **Le bandeau `#shipJourneyRow`** et les vues Boucles / En route / Chaîne / Trajets restent dans
  `app.js` : 27 `peindre()` sur les 41 du départ, et quatre vues sur huit dans l'arbre.
- **`#alk` lui-même** reste un champ d'`index.html` lu par `globalK()`. C'est cohérent avec les
  quatorze autres filtres, et hors périmètre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
