### PR TITLE
feat(voyage): les vues Boucles et Chaîne emménagent dans l'arbre

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -22,6 +22,7 @@ import { CorpsPlan, EnTetePlan } from "./vues/plan-vue.tsx";
 import { VueCommodites } from "./vues/commodites-vue.tsx";
 import { PanneauFrais } from "./vues/frais-station.tsx";
 import { VueCorrections } from "./vues/corrections-vue.tsx";
+import { VueBouclesArbitrage } from "./vues/boucles-vue.tsx";
 import { indexStationExacte } from "./marche.ts";
 
 /**
@@ -74,6 +75,10 @@ export function App() {
           Le panneau de frais, lui, est indépendant — il ne lit ni les corrections ni la purge. */}
       <VueCorrections />
       <Portail id="correctionsFees" si="corrections"><PanneauFraisStation /></Portail>
+      {/* Boucles ne rend qu'un `<tbody>`, mais elle écrit AUSSI `#empty`, un `<p>` partagé avec
+          Trajets et « En route » qui vivent encore dans app.js. Elle porte donc sa propre garde et
+          son propre portail — voir `vues/message-vide.ts` pour pourquoi ce n'en est pas un second. */}
+      <VueBouclesArbitrage />
     </>
   );
 }

--- a/App.tsx
+++ b/App.tsx
@@ -23,6 +23,7 @@ import { VueCommodites } from "./vues/commodites-vue.tsx";
 import { PanneauFrais } from "./vues/frais-station.tsx";
 import { VueCorrections } from "./vues/corrections-vue.tsx";
 import { VueBouclesArbitrage } from "./vues/boucles-vue.tsx";
+import { VueChaineArbitrage } from "./vues/chaine-vue.tsx";
 import { indexStationExacte } from "./marche.ts";
 
 /**
@@ -79,6 +80,7 @@ export function App() {
           Trajets et « En route » qui vivent encore dans app.js. Elle porte donc sa propre garde et
           son propre portail — voir `vues/message-vide.ts` pour pourquoi ce n'en est pas un second. */}
       <VueBouclesArbitrage />
+      <VueChaineArbitrage />
     </>
   );
 }

--- a/app.js
+++ b/app.js
@@ -16,7 +16,7 @@ import {
   loadHold, declarerLot, holdScu, freeCargo, holdByCommodity, sellFromHold, refuseHere, refusActif, migrerRefus, sellableAt, sellAllAt,
   offloadPlan, tourneesEcoulement, storeFromHold, takeFromStore, stockApres,
   startJourney, startJourneyAt, journeyStations, journeyEnd,
-  journeyConnects, addToJourney, setJourneyPosition, currentLeg, journeyMargin,
+  journeyConnects, setJourneyPosition, journeyMargin,
   removeJourneyStop as removeStopPure,
   reindexerRangsJambe, detacherLotsDeJambe,
   soldeDuPoint, poserChargement, retirerChargement, migrerChargements,
@@ -38,6 +38,7 @@ import { alKey, feeCargoText, feeCell, feeCtx, feeEndText, feeLoadText, feeResol
 import { applyState, loadState, saveState, shareURL } from "./persistance.ts";
 import { brancher, ensureFeeMarket, ensureStarmap, withMarket } from "./donnees.ts";
 import { brancherRendu } from "./rendu.ts";
+import { pickJourney, syncViewsToJourney } from "./voyage-actions.ts";
 import { monterRacine } from "./main.tsx";
 import { planData, planHypotheses } from "./vues/plan-vue.tsx";
 import { figerJambe, jambeChargee, journeyCarriedCommodities, legEffectiveLines, legFeeCtx, legIntent, legKey, legManifest, legTerminals, loadJourneyEdits, loadJourneyPins, pinLegsForVolume, saveJourneyEdits, saveJourneyPins } from "./voyage-donnees.ts";
@@ -1247,18 +1248,9 @@ function renderJourneyMap() {
 }
 
 // ---------- Compagnon de voyage : résumé du parcours (près du vaisseau) ----------
-// Sélectionne un trajet/une boucle/une chaîne -> met à jour le parcours (étend si ça s'enchaîne).
-// `apresAjout` (optionnel) tourne une fois le parcours à jour mais AVANT le rendu : c'est là que le
-// manifeste d'« En route » dépose son chargement ajusté, pour que la jambe s'affiche du premier
-// coup avec les bons SCU et son badge ✎.
-function pickJourney(legs, apresAjout) {
-  if (!legs || !legs.length) return;
-  etat.JOURNEY = addToJourney(etat.JOURNEY, legs);
-  if (apresAjout) apresAjout();
-  syncViewsToJourney();
-  renderJourney();
-  refresh(); // reflète la nouvelle destination/origine dans la vue courante
-}
+// `pickJourney` et `syncViewsToJourney` sont passées dans `voyage-actions.ts` : les QUATRE vues qui
+// restent ici les appellent, et aucune ne peut emménager tant qu'elles vivent dans un fichier qui
+// n'exporte rien (ADR-012).
 
 // « Je suis ici » : pose la position courante et recale les vues. Deux chemins y mènent — le fil
 // d'étapes textuel (⦿) et les escales de la carte — et c'est délibéré : la carte n'introduit pas
@@ -1276,21 +1268,7 @@ function setJourneyStop(i) {
 
 // Pré-remplit les contrôles des vues d'après la POSITION COURANTE du parcours.
 // « Pré-rempli » : on pose les défauts, l'utilisateur reste libre de les changer.
-function syncViewsToJourney() {
-  if (!etat.JOURNEY) return;
-  const here = journeyStations(etat.JOURNEY)[etat.JOURNEY.current]; // station où l'on se trouve
-  if (!here) return;
-  const originLabel = stationLabel(here.name, here.system);
-  $("origin").value = originLabel;    // En route : départ = station courante
-  $("chainOrigin").value = originLabel; // Chaîne : départ = station courante
-  const leg = currentLeg(etat.JOURNEY);
-  if (leg) {
-    $("destTerminal").value = stationLabel(leg.to, leg.toSystem); // arrivée forcée = jambe courante
-    $("destSystem").value = "";
-  } else {
-    $("destTerminal").value = ""; // au bout du parcours : on cherche le fret onward, pas d'arrivée imposée
-  }
-}
+
 function clearJourney() {
   etat.JOURNEY = null;
   // Sans cette purge, les manifestes édités survivaient à l'effacement du voyage et ressortaient

--- a/app.js
+++ b/app.js
@@ -6,12 +6,12 @@ import {
   scoreBarWidth, bySort, addableUnits, scuBoxes, cargoBoxes, bestChain,
   kFromReading, kPlausible,
   ovKey, groupOverridesByTerminal, safeKey, encodeState, decodeState,
-  routePasses, loopPasses,
-  routeMetrics, loopMetrics, enRouteDeals, bestManifest, buildChainAdjacency, suggestionsFrom, netMarginRoi,
+  routePasses,
+  routeMetrics, enRouteDeals, bestManifest, buildChainAdjacency, suggestionsFrom, netMarginRoi,
   commoditySummaries, commodityPoints, compactValue, palierMarge, valueTiers, resolveCommodity, ambiguousCodes,
   manifestTotals, freeAddUnits, manifestLine, freeManifestLine, hydrateManifestLine, stationLabel, parseStationLabel, stationTree,
   multiTrips, tripMetrics, legFromTrip,
-  legFromRoute, legsFromLoop, legsFromChain, legFromManifest, stopSuggestions, bestLegBetween,
+  legFromRoute, legsFromChain, legFromManifest, stopSuggestions, bestLegBetween,
   manifestJourneyState, manifestIntent, sameIntent, manifestIntentSurvives, journeyMap,
   loadHold, declarerLot, holdScu, freeCargo, holdByCommodity, sellFromHold, refuseHere, refusActif, migrerRefus, sellableAt, sellAllAt,
   offloadPlan, tourneesEcoulement, storeFromHold, takeFromStore, stockApres,
@@ -44,7 +44,6 @@ import { planData, planHypotheses } from "./vues/plan-vue.tsx";
 import { figerJambe, jambeChargee, journeyCarriedCommodities, legEffectiveLines, legFeeCtx, legIntent, legKey, legManifest, legTerminals, loadJourneyEdits, loadJourneyPins, pinLegsForVolume, saveJourneyEdits, saveJourneyPins } from "./voyage-donnees.ts";
 // (`vues/tournee.tsx` et `vues/plan.tsx` ne sont plus importés ici : leurs vues vivent dans l'arbre
 // depuis #143 et #145, et seuls leurs composants de DÉCISION les consomment désormais.)
-import { vueBoucles } from "./vues/boucles.tsx";
 import { vueChaine, indiceDepart, indiceSoute, indiceAucune } from "./vues/chaine.tsx";
 // La vue Commodités n'expose plus sa présentation à app.js — seulement ses trois ACTIONS, comme
 // `plan-vue.tsx` expose `planData`. Les écouteurs de `#commSortModes` / `#commBoardModes` restent
@@ -313,54 +312,11 @@ function renderMulti(f) {
 
 // Ligne de tableau pour une route évaluée (partagée par « Trajets simples » et « En route »).
 // `routeRowHTML` a été remplacé par vues/trajets.tsx, pour `#rows` ET `#enrouteRows`.
-function effLeg(leg, buyT, sellT) {
-  const b = effVals(leg.commodity, buyT, "buy", leg.buyPrice, leg.stock, leg.updated);
-  const s = effVals(leg.commodity, sellT, "sell", leg.sellPrice, leg.demand, leg.updated);
-  return { ...leg, buyPrice: b.price, stock: b.vol, sellPrice: s.price, demand: s.vol, demandKnown: s.ovol, margin: s.price - b.price };
-}
 
-function evaluateLoop(l, f) {
-  const out = effLeg(l.out, l.a.terminal, l.b.terminal);
-  const back = effLeg(l.back, l.b.terminal, l.a.terminal);
-  const cross = l.a.system !== l.b.system;
-  // Une boucle n'a pas un terminal d'achat et un de vente : elle a deux EXTRÉMITÉS qui sont tour à
-  // tour l'un et l'autre, d'où { a, b } et quatre opérations facturées (cf. loopMetrics).
-  const feeInfo = feeCtx(f, l.a.terminal, l.b.terminal);
-  const metrics = loopMetrics(out, back, l.distance, cross, f, feeInfo && { a: feeInfo.a.point, b: feeInfo.b.point });
-  return { ...l, out, back, cross, feeInfo, ...metrics };
-}
 
-function renderLoops() {
-  const f = readFilters();
-  $("empty").textContent = EMPTY_DEFAULT;
-  ensureFeeMarket(f, refresh); // idem render() : la vue peut avoir changé pendant le fetch
 
-  let rows = etat.LOOPS.filter((l) => loopPasses(l, f)).map((l) => evaluateLoop(l, f));
 
-  rows.sort(bySort(etat.loopSortKey, etat.loopSortDir));
-  // Compagnon : remonte en tête (sans filtrer) les boucles qui partent de la FIN du parcours —
-  // c'est le point d'extension (une boucle depuis là s'enchaîne au parcours). Cohérent avec addToJourney.
-  const hereArrival = etat.JOURNEY ? journeyEnd(etat.JOURNEY)?.name : null;
-  if (hereArrival) {
-    rows.forEach((l) => { l._fromHere = l.a.terminal === hereArrival || l.b.terminal === hereArrival; });
-    rows.sort((a, b) => (b._fromHere ? 1 : 0) - (a._fromHere ? 1 : 0)); // tri stable : pertinentes d'abord
-  }
-  // Le <tbody> passe à React ; le <thead> et ses `th[data-sort-loop]` restent dans index.html,
-  // câblés par setupLoopSort. React ne possède que le corps du tableau.
-  peindre($("loopRows"), vueBoucles({
-    lignes: rows,
-    celluleFrais: (l) => feeCell(l.feeInfo, l.fees, () => `${fmt(l.unitsOut)} + ${fmt(l.unitsBack)} SCU, 4 opérations (charge et décharge à chaque bout)`, l.units > 0),
-    avecTexteFrais: (base, cell) => (cell.text ? `${base} · ${cell.text}` : base),
-    // On entre dans le cycle par la FIN du parcours : la boucle l'étend au lieu de le remplacer.
-    // `journeyEnd(JOURNEY)` est relu DANS le corps de la flèche, donc au clic — et surtout PAS
-    // remplacé par `hereArrival` (calculé plus haut, au rendu) : le parcours a pu bouger entre les
-    // deux, et c'est la seule régression que ce lot pourrait introduire.
-    choisirBoucle: (l) => pickJourney(legsFromLoop(l, etat.JOURNEY ? journeyEnd(etat.JOURNEY)?.name : null)),
-  }));
 
-  $("empty").hidden = rows.length > 0;
-  notifySuperseded();
-}
 
 // ---------- Mode « En route » (trajet dirigé) + manifeste multi-commodité ----------
 let enrouteReady = false;     // datalist/destSystem peuplés une seule fois
@@ -1671,8 +1627,7 @@ const debounce = (fn, ms = 150) => {
 };
 
 function refresh() {
-  if (etat.view === "loops") renderLoops();
-  else if (etat.view === "enroute") renderEnRoute();
+  if (etat.view === "enroute") renderEnRoute();
   else if (etat.view === "chain") renderChain();
   // La vue Trajets est NOMMÉE, elle n'est plus le repli. Les deux vues qui vivent dans l'arbre
   // (Tournée, Plan de vol) tombaient ici : `render()` recalculait tout le tableau des trajets pour
@@ -1775,9 +1730,8 @@ function setupLoopSort() {
       if (etat.loopSortKey === key) etat.loopSortDir *= -1;
       else { etat.loopSortKey = key; etat.loopSortDir = -1; }
       applySortIndicators();
-      renderLoops();
       saveState();
-      notifier(); // idem : hors `refresh()`
+      notifier(); // la vue Boucles vit dans l'arbre : la propagation suffit, hors `refresh()`
     });
   });
 }

--- a/app.js
+++ b/app.js
@@ -3,15 +3,15 @@
 // Fonctions de calcul pures (testées par logic.test.mjs).
 import {
   tripMinutes, ageDays, pairAge,
-  scoreBarWidth, bySort, addableUnits, scuBoxes, cargoBoxes, bestChain,
+  scoreBarWidth, bySort, addableUnits, scuBoxes, cargoBoxes,
   kFromReading, kPlausible,
   ovKey, groupOverridesByTerminal, safeKey, encodeState, decodeState,
   routePasses,
-  routeMetrics, enRouteDeals, bestManifest, buildChainAdjacency, suggestionsFrom, netMarginRoi,
+  routeMetrics, enRouteDeals, bestManifest, suggestionsFrom, netMarginRoi,
   commoditySummaries, commodityPoints, compactValue, palierMarge, valueTiers, resolveCommodity, ambiguousCodes,
   manifestTotals, freeAddUnits, manifestLine, freeManifestLine, hydrateManifestLine, stationLabel, parseStationLabel, stationTree,
   multiTrips, tripMetrics, legFromTrip,
-  legFromRoute, legsFromChain, legFromManifest, stopSuggestions, bestLegBetween,
+  legFromRoute, legFromManifest, stopSuggestions, bestLegBetween,
   manifestJourneyState, manifestIntent, sameIntent, manifestIntentSurvives, journeyMap,
   loadHold, declarerLot, holdScu, freeCargo, holdByCommodity, sellFromHold, refuseHere, refusActif, migrerRefus, sellableAt, sellAllAt,
   offloadPlan, tourneesEcoulement, storeFromHold, takeFromStore, stockApres,
@@ -33,7 +33,7 @@ import { readFilters } from "./filtres.ts";
 import { effVals, isOv, loadOverrides, ovCount, resetOverrides, saveOverrides, setOverride } from "./corrections.ts";
 import { corriger, notifySuperseded, updateOvBadge } from "./corrections-actions.ts";
 import { showToast } from "./messages.ts";
-import { construireIndex, findCommodity, indexDepartChaine, indexOrigine, indexStationExacte, libellesOrigines, libellesStations, resolveStationLabel, stationCourante, stationMap, termByName } from "./marche.ts";
+import { construireIndex, findCommodity, indexOrigine, indexStationExacte, libellesOrigines, libellesStations, resolveStationLabel, stationCourante, stationMap, termByName } from "./marche.ts";
 import { alKey, feeCargoText, feeCell, feeCtx, feeEndText, feeLoadText, feeResolver, globalK, kFmt, lineProfitText, loadAutoloadK, saveAutoloadK } from "./frais.ts";
 import { applyState, loadState, saveState, shareURL } from "./persistance.ts";
 import { brancher, ensureFeeMarket, ensureStarmap, withMarket } from "./donnees.ts";
@@ -44,7 +44,6 @@ import { planData, planHypotheses } from "./vues/plan-vue.tsx";
 import { figerJambe, jambeChargee, journeyCarriedCommodities, legEffectiveLines, legFeeCtx, legIntent, legKey, legManifest, legTerminals, loadJourneyEdits, loadJourneyPins, pinLegsForVolume, saveJourneyEdits, saveJourneyPins } from "./voyage-donnees.ts";
 // (`vues/tournee.tsx` et `vues/plan.tsx` ne sont plus importés ici : leurs vues vivent dans l'arbre
 // depuis #143 et #145, et seuls leurs composants de DÉCISION les consomment désormais.)
-import { vueChaine, indiceDepart, indiceSoute, indiceAucune } from "./vues/chaine.tsx";
 // La vue Commodités n'expose plus sa présentation à app.js — seulement ses trois ACTIONS, comme
 // `plan-vue.tsx` expose `planData`. Les écouteurs de `#commSortModes` / `#commBoardModes` restent
 // ici : leurs conteneurs sont du markup d'index.html (ADR-012 §2).
@@ -782,39 +781,11 @@ function renderEnRoute() {
 }
 
 // ---------- Vue « Chaîne » (multi-sauts A -> B -> C ...) ----------
-let shownChain = null;  // chaîne actuellement affichée (pour l'ajout au voyage)
 
 // buildChainAdjacency vit dans logic.mjs (fonction pure) ; appelée avec MARKET + effVals.
 
 // `chainCardHTML` a été remplacé par vues/chaine.tsx.
-function renderChain() {
-  if (!etat.MARKET) { withMarket(refresh); return; }
-  if (!enrouteReady) setupEnRoute();
-  const box = $("chainOut");
-  const f = readFilters();
-  shownChain = null;
-  const hint = (noeud) => { peindre(box, noeud); notifySuperseded(); };
-  if (indexDepartChaine() == null) return hint(indiceDepart());
-  if (!f.useCargo || !(f.cargo > 0)) return hint(indiceSoute());
-  const hops = Number($("hops").value) || 3;
-  // Les frais sont estampillés sur chaque leg par buildChainAdjacency — seul endroit de la chaîne
-  // où les deux terminaux d'un saut coexistent — puis consommés par bestChain, dont l'élagage et la
-  // sélection portent alors sur le profit NET.
-  const chain = bestChain(buildChainAdjacency(etat.MARKET, f, effVals, feeResolver(f)), indexDepartChaine(), hops, { cargo: f.cargo });
-  if (!chain || !chain.legs.length) return hint(indiceAucune());
-  shownChain = chain;
-  // Le calcul de présentation vit dans l'îlot (il n'appelle que logic.ts) ; app.js ne lui passe que
-  // ce qui dépend de l'ÉTAT : le résolveur de terminaux, et les deux fonctions de frais.
-  peindre(box, vueChaine({
-    chaine: chain,
-    cargo: f.cargo,
-    terminal: (idx) => etat.MARKET.terminals[idx],
-    celluleFrais: (lignes, fee, a, b, scu, fees) =>
-      feeCell(feeCtx(f, a.name, b.name, a, b), fees, () => feeCargoText(lignes, a.maxBox), scu > 0),
-    texteProfitLigne: lineProfitText,
-  }));
-  notifySuperseded();
-}
+
 
 // ---------- La soute : ce qui est à bord, et ce qu'on l'a payé (ADR-002) ----------
 // Un lot par chargement — la même commodité peut y figurer deux fois à des prix différents.
@@ -1628,7 +1599,6 @@ const debounce = (fn, ms = 150) => {
 
 function refresh() {
   if (etat.view === "enroute") renderEnRoute();
-  else if (etat.view === "chain") renderChain();
   // La vue Trajets est NOMMÉE, elle n'est plus le repli. Les deux vues qui vivent dans l'arbre
   // (Tournée, Plan de vol) tombaient ici : `render()` recalculait tout le tableau des trajets pour
   // le repeindre dans un `<tbody>` masqué — et reposait `#empty`, qui est un frère de `#routes` et
@@ -2302,7 +2272,6 @@ async function init() {
   // `shownRoutes`, et la garde `isMultiRoutes()` qui rattrapait le mode déjà changé au moment du
   // clic (#25) — un rappel fermé sur SON trajet ne peut pas se tromper de tableau.
   document.addEventListener("click", (e) => {
-    if (e.target.closest("#chainToJourney") && shownChain) { pickJourney(legsFromChain(shownChain, etat.MARKET.terminals)); return; }
     if (e.target.closest("#journeyClear")) { clearJourney(); return; }
     // Démarrer un voyage « de zéro » : bouton « Commencer » depuis l'invite.
     if (e.target.closest("#journeyStartBtn")) { beginJourney($("journeyStart").value); return; }

--- a/e2e/arbre.pw.mjs
+++ b/e2e/arbre.pw.mjs
@@ -83,3 +83,16 @@ test("Arbre : taper depuis les Trajets ne repeint pas la vue Corrections", async
 
   expect(await lots(), "la vue Corrections a été repeinte depuis les Trajets").toBe(0);
 });
+
+test("Arbre : taper depuis les Trajets ne repeint pas le tableau des Boucles", async ({ page }) => {
+  await page.click("#viewLoops");
+  await expect(page.locator("#loopRows tr").first()).toBeVisible({ timeout: 20000 });
+  await page.click("#viewRoutes");
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+
+  const lots = await compterLots(page, "loopRows");
+  await page.locator("#search").pressSequentially("Laranite", { delay: 30 });
+  await expect(page).toHaveURL(/search=Laranite/, { timeout: 10000 });
+
+  expect(await lots(), "le tableau des Boucles a été repeint depuis les Trajets").toBe(0);
+});

--- a/e2e/arbre.pw.mjs
+++ b/e2e/arbre.pw.mjs
@@ -96,3 +96,23 @@ test("Arbre : taper depuis les Trajets ne repeint pas le tableau des Boucles", a
 
   expect(await lots(), "le tableau des Boucles a été repeint depuis les Trajets").toBe(0);
 });
+
+test("Arbre : taper depuis les Trajets ne recalcule pas la Chaîne", async ({ page }) => {
+  // La plus chère des cinq : `buildChainAdjacency` construit un graphe sur tout le marché, puis
+  // `bestChain` en fait une recherche par faisceau. La rejouer depuis une autre vue serait le
+  // gaspillage le plus cher du dépôt.
+  await page.fill("#cargo", "96");
+  await page.check("#useCargo");
+  await page.click("#viewChain");
+  await page.fill("#chainOrigin", "Megumi — Pyro");
+  await expect(page.locator("#chainOut .chain")).toBeVisible({ timeout: 20000 });
+
+  await page.click("#viewRoutes");
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+
+  const lots = await compterLots(page, "chainOut");
+  await page.locator("#search").pressSequentially("Laranite", { delay: 30 });
+  await expect(page).toHaveURL(/search=Laranite/, { timeout: 10000 });
+
+  expect(await lots(), "la Chaîne a été recalculée depuis les Trajets").toBe(0);
+});

--- a/filtres.ts
+++ b/filtres.ts
@@ -10,7 +10,7 @@
 // lues de l'application. Ils entreront dans l'état avec leur composant, pas avant — c'est la
 // décision prise avec le déménagement des globales (#135).
 
-import type { Filtres } from "./types.ts";
+import type { Filtres, FiltresVolume } from "./types.ts";
 
 const $ = (id: string) => document.getElementById(id) as HTMLInputElement | HTMLSelectElement | null;
 
@@ -20,8 +20,16 @@ const val = (id: string): string => $(id)?.value ?? "";
 /** L'état d'une case. */
 const coche = (id: string): boolean => !!($(id) as HTMLInputElement | null)?.checked;
 
-/** Les quatorze contrôles de la barre, lus d'un coup. */
-export function readFilters(): Filtres {
+/**
+ * Les quatorze contrôles de la barre, lus d'un coup.
+ *
+ * Le type de retour croise `FiltresVolume`, dont les cinq champs sont OPTIONNELS dans `Filtres` —
+ * parce que d'autres appelants en construisent des morceaux — mais que cette fonction-ci écrit
+ * TOUJOURS, toutes les cinq, sans branche. Le dire permet de passer le résultat directement à
+ * `routeMetrics`/`loopMetrics`/`computeUnits`, qui les exigent : sans ça, chaque vue migrée devrait
+ * poser un cast, c'est-à-dire affirmer sans preuve ce qui se lit ici en quatre lignes.
+ */
+export function readFilters(): Filtres & FiltresVolume {
   return {
     cargo: Math.max(0, Number(val("cargo")) || 0),
     budget: Math.max(0, Number(val("budget")) || 0),

--- a/frais.ts
+++ b/frais.ts
@@ -123,7 +123,15 @@ export function feeCargoText(lines: LigneManifeste[], maxBox?: number): string {
 // resté brut au milieu d'une colonne nette, sans un mot, se lit comme un bug. Le marqueur ne va que
 // sur la colonne « profit » : le répéter sur « profit/heure » doublerait le bruit sans rien ajouter.
 const CELLULE_SANS_FRAIS: CelluleFrais = { mark: "", text: "" };
-export function feeCell(ctx: ReturnType<typeof feeCtx>, fees: number, what: () => string, bounded: boolean): CelluleFrais {
+/**
+ * Ce que `feeCtx` rend : les deux extrémités facturantes, ou `null` quand l'interrupteur est éteint
+ * ou le marché pas encore là. Nommé pour que les vues puissent le TRANSPORTER — elles le reçoivent
+ * de leur calcul et le repassent à `feeCell` sans jamais le lire, et le typer `unknown` les
+ * obligeait à un cast pour rendre une cellule.
+ */
+export type ContexteFrais = ReturnType<typeof feeCtx>;
+
+export function feeCell(ctx: ContexteFrais, fees: number, what: () => string, bounded: boolean): CelluleFrais {
   if (!ctx || !bounded) return CELLULE_SANS_FRAIS;
   const text = fees > 0
     ? `Frais d'autoload ≈ ${fmt(fees)} aUEC déduits — ${what()} · ${feeEndText(ctx.a)} · ${feeEndText(ctx.b)} · estimation ±3 %`

--- a/voyage-actions.ts
+++ b/voyage-actions.ts
@@ -1,0 +1,64 @@
+// Engager un trajet dans le parcours : l'ACTION (ADR-012).
+//
+// `voyage-donnees.ts` porte la DONNÉE du parcours — manifestes de jambe, intentions persistées,
+// gel. Ce module-ci porte le geste qui l'ÉTEND, et il est à part pour une raison de dépendance :
+// il appelle `rafraichir()`, donc il touche au cycle de rendu, ce que `voyage-donnees.ts`
+// s'interdit.
+//
+// ── POURQUOI C'EST UN PRÉALABLE ───────────────────────────────────────────────────────────────
+// `pickJourney` est le point d'entrée du compagnon de voyage, et les QUATRE vues qui restent dans
+// `app.js` l'appellent — Trajets (deux fois, mode simple et mode multi), Boucles, Chaîne — plus le
+// manifeste d'« En route » et le déplacement d'arrêt. Aucune d'elles ne peut emménager dans l'arbre
+// tant qu'il vit dans un fichier qui n'exporte rien.
+
+import { addToJourney, currentLeg, journeyStations, stationLabel } from "./logic.ts";
+import type { Jambe } from "./types.ts";
+import { etat } from "./etat.ts";
+import { rafraichir } from "./rendu.ts";
+
+const champ = (id: string): HTMLInputElement | null =>
+  document.getElementById(id) as HTMLInputElement | null;
+
+/**
+ * Aligne les champs de départ et d'arrivée des vues de recherche sur le parcours.
+ *
+ * Ce sont des champs d'`index.html` qu'aucun portail ne possède : l'écriture reste impérative, et
+ * c'est la frontière et non une dette (ADR-012 §2). Elle est SILENCIEUSE — poser `.value` n'émet
+ * aucun événement `input`, donc aucun rendu ne part d'ici ; c'est l'appelant qui rafraîchit.
+ */
+export function syncViewsToJourney(): void {
+  if (!etat.JOURNEY) return;
+  const here = journeyStations(etat.JOURNEY)[etat.JOURNEY.current]; // station où l'on se trouve
+  if (!here) return;
+  const originLabel = stationLabel(here.name, here.system);
+  const poser = (id: string, v: string) => { const c = champ(id); if (c) c.value = v; };
+  poser("origin", originLabel);        // En route : départ = station courante
+  poser("chainOrigin", originLabel);   // Chaîne : départ = station courante
+  const leg = currentLeg(etat.JOURNEY);
+  if (leg) {
+    poser("destTerminal", stationLabel(leg.to, leg.toSystem)); // arrivée forcée = jambe courante
+    poser("destSystem", "");
+  } else {
+    poser("destTerminal", ""); // au bout du parcours : on cherche le fret onward, pas d'arrivée imposée
+  }
+}
+
+/**
+ * Ajoute une ou plusieurs jambes au parcours, puis réaligne les vues et rafraîchit.
+ *
+ * `apresAjout` s'exécute ENTRE l'ajout et la synchronisation : le manifeste s'en sert pour figer
+ * l'intention de la jambe qu'il vient de créer, et il a besoin de son index — donc du parcours déjà
+ * étendu, mais d'un écran pas encore repeint.
+ *
+ * `rafraichir()` remplace le couple `renderJourney(); refresh();` de la version d'`app.js` :
+ * `refresh()` rejoue déjà la carte du voyage dès que `etat.JOURNEY` existe, et il existe forcément
+ * ici — `addToJourney` vient de le poser. Le premier appel ne faisait que peindre la carte un tour
+ * plus tôt, dans la même tâche : rien ne pouvait l'observer entre les deux.
+ */
+export function pickJourney(legs: Jambe[] | null | undefined, apresAjout?: () => void): void {
+  if (!legs || !legs.length) return;
+  etat.JOURNEY = addToJourney(etat.JOURNEY, legs);
+  if (apresAjout) apresAjout();
+  syncViewsToJourney();
+  rafraichir();
+}

--- a/vues/boucles-vue.tsx
+++ b/vues/boucles-vue.tsx
@@ -1,0 +1,99 @@
+// La VUE Boucles : le composant qui décide quoi afficher (ADR-011 étape 3, ADR-012).
+//
+// `boucles.tsx` garde la PRÉSENTATION — la ligne, ses deux extrémités, le ▶. Ce fichier-ci porte la
+// DÉCISION : quelles boucles passent les filtres, comment on les évalue, dans quel ordre, et
+// laquelle remonte en tête parce qu'elle part de là où l'on est.
+//
+// ── LE `<thead>` RESTE VANILLA, ET C'EST LE POINT ─────────────────────────────────────────────
+// Le portail vise `#loopRows`, le `<tbody>`. Le `<thead>` et ses `th[data-sort-loop]` restent du
+// markup d'`index.html`, câblés par `setupLoopSort` (app.js) qui pose `aria-sort` et les classes de
+// tri. React ne possède que le corps du tableau — exactement comme quand `peindre()` s'en chargeait.
+import { useLayoutEffect } from "react";
+import { createPortal } from "react-dom";
+
+import { bySort, journeyEnd, legsFromLoop, loopMetrics, loopPasses } from "../logic.ts";
+import type { Boucle, Filtres, FiltresVolume, SegmentBoucle } from "../types.ts";
+import type { BoucleEvaluee } from "./boucles.tsx";
+import { etat, notifier } from "../etat.ts";
+import { readFilters } from "../filtres.ts";
+import { effVals } from "../corrections.ts";
+import { notifySuperseded } from "../corrections-actions.ts";
+import { ensureFeeMarket } from "../donnees.ts";
+import { feeCell, feeCtx } from "../frais.ts";
+import { fmt } from "../format.ts";
+import { pickJourney } from "../voyage-actions.ts";
+import { MESSAGE_VIDE, messageVide } from "./message-vide.ts";
+import { VueBoucles } from "./boucles.tsx";
+
+// Une jambe de boucle, corrections locales appliquées. `demandKnown` distingue « capacité inconnue
+// chez UEX » de « demande nulle » — ni zéro ni illimitée.
+function effLeg(leg: SegmentBoucle, buyT: string, sellT: string) {
+  const b = effVals(leg.commodity, buyT, "buy", leg.buyPrice, leg.stock, leg.updated);
+  const s = effVals(leg.commodity, sellT, "sell", leg.sellPrice, leg.demand, leg.updated);
+  return { ...leg, buyPrice: b.price, stock: b.vol, sellPrice: s.price, demand: s.vol, demandKnown: s.ovol, margin: s.price - b.price };
+}
+
+function evaluateLoop(l: Boucle, f: Filtres & FiltresVolume): BoucleEvaluee {
+  const out = effLeg(l.out, l.a.terminal, l.b.terminal);
+  const back = effLeg(l.back, l.b.terminal, l.a.terminal);
+  const cross = l.a.system !== l.b.system;
+  // Une boucle n'a pas un terminal d'achat et un de vente : elle a deux EXTRÉMITÉS qui sont tour à
+  // tour l'un et l'autre, d'où { a, b } et quatre opérations facturées (cf. loopMetrics).
+  const feeInfo = feeCtx(f, l.a.terminal, l.b.terminal);
+  const metrics = loopMetrics(out, back, l.distance, cross, f, feeInfo && { a: feeInfo.a.point, b: feeInfo.b.point });
+  return { ...l, out, back, cross, feeInfo, ...metrics } as BoucleEvaluee;
+}
+
+export function VueBouclesArbitrage() {
+  // Le relevé des corrections périmées : un effet, donc avant tout retour anticipé.
+  useLayoutEffect(notifySuperseded);
+
+  const active = etat.view === "loops";
+  const f = readFilters();
+
+  // Le calcul n'a lieu QUE si l'on regarde la vue — la garde de l'ADR-012, en tête. Mais le hook
+  // du message vide, lui, doit être appelé à tous les rendus : on prépare donc les lignes avant de
+  // sortir, et on ne sort qu'après. `[]` quand la vue est ailleurs ne coûte rien.
+  const lignes: BoucleEvaluee[] = [];
+  if (active) {
+    // `ensureFeeMarket` re-rend la vue RÉELLEMENT active à l'arrivée du marché, pas celle d'alors.
+    ensureFeeMarket(f, notifier);
+    const rows = etat.LOOPS.filter((l) => loopPasses(l, f)).map((l) => evaluateLoop(l, f));
+    rows.sort(bySort(etat.loopSortKey, etat.loopSortDir));
+    // Compagnon : remonte en tête (sans filtrer) les boucles qui partent de la FIN du parcours —
+    // c'est le point d'extension, une boucle depuis là s'enchaîne au parcours. Cohérent avec
+    // `addToJourney`.
+    const hereArrival = etat.JOURNEY ? journeyEnd(etat.JOURNEY)?.name : null;
+    if (hereArrival) {
+      rows.forEach((l) => { l._fromHere = l.a.terminal === hereArrival || l.b.terminal === hereArrival; });
+      rows.sort((a, b) => (b._fromHere ? 1 : 0) - (a._fromHere ? 1 : 0)); // tri stable : pertinentes d'abord
+    }
+    lignes.push(...rows);
+  }
+
+  // `#empty` est PARTAGÉ avec Trajets et « En route », toutes deux encore dans `app.js` : on passe
+  // donc par l'écrivain unique plutôt que d'y rendre un portail, qui entrerait en conflit avec leurs
+  // écritures impératives. En `useLayoutEffect` et non `useEffect` : le message doit être posé avant
+  // la peinture, sinon un tableau vide s'affiche une frame sans rien dire.
+  useLayoutEffect(() => {
+    if (active) messageVide(lignes.length ? null : MESSAGE_VIDE);
+  });
+
+  if (!active) return null;
+
+  const cible = document.getElementById("loopRows");
+  if (!cible) return null;
+
+  return createPortal(
+    <VueBoucles
+      lignes={lignes}
+      celluleFrais={(l) => feeCell(l.feeInfo, l.fees, () => `${fmt(l.unitsOut)} + ${fmt(l.unitsBack)} SCU, 4 opérations (charge et décharge à chaque bout)`, l.units > 0)}
+      avecTexteFrais={(base, cell) => (cell.text ? `${base} · ${cell.text}` : base)}
+      // On entre dans le cycle par la FIN du parcours : la boucle l'étend au lieu de le remplacer.
+      // `journeyEnd(JOURNEY)` est relu DANS le corps de la flèche, donc AU CLIC — et surtout pas
+      // repris de `hereArrival`, calculé au rendu : le parcours a pu bouger entre les deux.
+      choisirBoucle={(l) => pickJourney(legsFromLoop(l, etat.JOURNEY ? journeyEnd(etat.JOURNEY)?.name : null))}
+    />,
+    cible,
+  );
+}

--- a/vues/boucles.tsx
+++ b/vues/boucles.tsx
@@ -15,6 +15,7 @@
 // le ferait disparaître des deux autres vues.
 import { fmt, fmtFee } from "../format.ts";
 import type { Boucle } from "../types.ts";
+import type { ContexteFrais } from "../frais.ts";
 import { BadgeSysteme, TagAvantPoste, TagIllegal, IconeCommodite, PastilleFraicheur, CelluleFiabilite } from "./communs.tsx";
 
 type Fmt = (n: number) => string;
@@ -32,7 +33,7 @@ export type BoucleEvaluee = Boucle & {
   fiabilite: number; age: number | null; partVolume: number;
   units: number | null; unitsOut: number; unitsBack: number;
   profit: number; profitHour: number; minutes: number; fees: number;
-  feeInfo: unknown;
+  feeInfo: ContexteFrais;
   _fromHere?: boolean;
 };
 

--- a/vues/chaine-vue.tsx
+++ b/vues/chaine-vue.tsx
@@ -1,0 +1,78 @@
+// La VUE Chaîne : le composant qui décide quoi afficher (ADR-011 étape 3, ADR-012).
+//
+// `chaine.tsx` garde la PRÉSENTATION — la chaîne, ses sauts, leurs manifestes. Ce fichier-ci porte
+// la DÉCISION : marché absent, départ non choisi, soute désactivée, aucune chaîne rentable, ou le
+// calcul.
+//
+// ── LA GLOBALE `shownChain` DISPARAÎT ─────────────────────────────────────────────────────────
+// Le ▶ « Ajouter au voyage » était pris par une délégation posée sur `document`, qui relisait
+// `shownChain` — une globale écrite au RENDU et lue au CLIC. C'est le motif que la migration
+// élimine partout ailleurs (les ▶ des trajets et des boucles l'ont perdu en #129), et il survivait
+// ici faute d'un composant à qui confier le rappel.
+//
+// Le bouton étant rendu par React, il porte désormais son `onClick`. La branche de délégation part
+// AU MÊME COMMIT : la laisser doublerait l'ajout, et deux `pickJourney` de suite posent deux fois
+// les mêmes jambes — visible, mais seulement après coup, dans le parcours.
+import { useLayoutEffect } from "react";
+import { createPortal } from "react-dom";
+
+import { bestChain, buildChainAdjacency, legsFromChain } from "../logic.ts";
+import { etat, notifier } from "../etat.ts";
+import { readFilters } from "../filtres.ts";
+import { effVals } from "../corrections.ts";
+import { notifySuperseded } from "../corrections-actions.ts";
+import { withMarket } from "../donnees.ts";
+import { feeCargoText, feeCell, feeCtx, feeResolver, lineProfitText } from "../frais.ts";
+import { indexDepartChaine } from "../marche.ts";
+import { pickJourney } from "../voyage-actions.ts";
+import { VueChaine, indiceAucune, indiceDepart, indiceSoute } from "./chaine.tsx";
+
+const champ = (id: string): string =>
+  (document.getElementById(id) as HTMLInputElement | null)?.value ?? "";
+
+export function VueChaineArbitrage() {
+  // Un effet, donc avant tout retour anticipé. Il tournait ici à CHAQUE branche de `renderChain`,
+  // y compris les trois messages d'attente : `effVals` a pu purger pendant `buildChainAdjacency`.
+  useLayoutEffect(notifySuperseded);
+
+  if (etat.view !== "chain") return null;
+
+  const cible = document.getElementById("chainOut");
+  if (!cible) return null;
+  const dans = (noeud: React.ReactNode) => createPortal(noeud, cible);
+
+  if (!etat.MARKET) {
+    withMarket(notifier);
+    return null;
+  }
+
+  const depart = indexDepartChaine();
+  if (depart == null) return dans(indiceDepart());
+
+  const f = readFilters();
+  if (!f.useCargo || !(f.cargo > 0)) return dans(indiceSoute());
+
+  const hops = Number(champ("hops")) || 3;
+  // Les frais sont estampillés sur chaque saut par `buildChainAdjacency` — seul endroit de la
+  // chaîne où les deux terminaux d'un saut coexistent — puis consommés par `bestChain`, dont
+  // l'élagage et la sélection portent alors sur le profit NET.
+  const chaine = bestChain(
+    buildChainAdjacency(etat.MARKET, f, effVals, feeResolver(f)),
+    depart, hops, { cargo: f.cargo },
+  );
+  if (!chaine || !chaine.legs.length) return dans(indiceAucune());
+
+  return dans(
+    <VueChaine
+      chaine={chaine}
+      cargo={f.cargo}
+      terminal={(idx) => etat.MARKET!.terminals[idx]}
+      celluleFrais={(lignes, fee, a, b, scu, fees) =>
+        feeCell(feeCtx(f, a.name, b.name, a, b), fees, () => feeCargoText(lignes, a.maxBox), scu > 0)}
+      texteProfitLigne={lineProfitText}
+      // La chaîne est passée au rappel, jamais relue d'une globale : c'est CETTE chaîne-là qu'on
+      // ajoute, celle qui était à l'écran au moment du clic.
+      choisirChaine={(c) => pickJourney(legsFromChain(c, etat.MARKET!.terminals))}
+    />,
+  );
+}

--- a/vues/chaine.tsx
+++ b/vues/chaine.tsx
@@ -27,6 +27,8 @@ export type ProprietesChaine = {
   // calcule et l'îlot n'en reçoit que le résultat.
   celluleFrais: (lignes: LigneManifeste[], fee: PaireFrais | null, a: Terminal, b: Terminal, scu: number, fees: number) => CelluleFrais;
   texteProfitLigne: (units: number, l: LigneManifeste, pair: PaireFrais | null) => string;
+  /** ▶ : ajouter CETTE chaîne au voyage. Reçoit la chaîne, jamais une globale relue au clic. */
+  choisirChaine: (c: Chaine) => void;
 };
 
 const classeProfit = (n: number) => (n < 0 ? "perte" : "profit");
@@ -52,7 +54,7 @@ function LigneDeSaut({ l, fee, texteProfitLigne }: {
   );
 }
 
-export function VueChaine({ chaine, cargo, terminal, celluleFrais, texteProfitLigne }: ProprietesChaine) {
+export function VueChaine({ chaine, cargo, terminal, celluleFrais, texteProfitLigne, choisirChaine }: ProprietesChaine) {
   const totaux = chaine.legs.map((leg) => manifestTotals(leg.lines || [], leg.fee));
   const invest = totaux[0] ? totaux[0].invest : 0;
   const totalFees = totaux.reduce((s, t) => s + t.fees, 0);
@@ -89,9 +91,12 @@ export function VueChaine({ chaine, cargo, terminal, celluleFrais, texteProfitLi
           {" · "}{chaine.legs.length} saut{chaine.legs.length > 1 ? "s" : ""}
           {" · "}{fmt(totalScu)} SCU chargés · capital de départ {fmt(invest)} · ~{Math.round(minutes)} min
         </span>
-        {/* L'id est un CONTRAT : app.js y attache l'ajout au voyage. Le renommer casserait le geste
-            sans qu'aucune erreur ne soit levée — le bouton resterait simplement inerte. */}
-        <button id="chainToJourney" className="chain-pick" title="Ajouter cette chaîne au voyage en cours">▶ Ajouter au voyage</button>
+        {/* L'id reste un CONTRAT de test (smoke.pw.mjs le clique), mais ce n'est plus lui qui porte
+            le geste : le bouton reçoit un rappel fermé sur SA chaîne. Avant, une délégation posée
+            sur `document` relisait `shownChain`, une globale écrite au RENDU et lue au CLIC — le
+            motif que la migration élimine partout. */}
+        <button id="chainToJourney" className="chain-pick" onClick={() => choisirChaine(chaine)}
+                title="Ajouter cette chaîne au voyage en cours">▶ Ajouter au voyage</button>
       </div>
       <div className="chain-legs">
         {chaine.legs.map((leg, i) => {

--- a/vues/message-vide.ts
+++ b/vues/message-vide.ts
@@ -1,0 +1,40 @@
+// Le message « rien à afficher », partagé par TROIS vues (ADR-012).
+//
+// `#empty` est un `<p>` unique d'`index.html`, frère de `#routes` dans `.table-shell`. Trois vues
+// se le disputent — Trajets, Boucles et « En route » — et chacune y écrit son propre texte : « Aucune
+// route ne correspond aux filtres. » pour les deux premières, « Choisis un terminal de départ… »
+// pour la troisième. `switchView` le masque en plus pour les cinq vues qui n'ont pas de tableau.
+//
+// ── POURQUOI UNE FONCTION ET PAS UN PORTAIL ───────────────────────────────────────────────────
+// Un portail gérerait les ENFANTS du nœud, pas ses ATTRIBUTS : `hidden` resterait à poser à la
+// main. Et pendant la migration, deux mondes écrivent tour à tour dans le même nœud — un portail
+// React face à un `textContent` impératif, c'est la seule situation où les deux modèles se
+// contredisent vraiment.
+//
+// D'où une FONCTION, appelable des deux côtés. Elle n'est pas encore le seul écrivain — `app.js`
+// garde les siens tant que Trajets et « En route » y vivent, et les convertir maintenant mêlerait
+// deux migrations dans un même lot. Ce qu'elle garantit dès aujourd'hui, c'est qu'une vue de
+// l'arbre n'a pas besoin de connaître ce nœud pour lui parler.
+//
+// Elle disparaîtra quand les trois vues vivront dans l'arbre : `#empty` deviendra alors un enfant
+// de la vue active, et n'aura plus à être partagé du tout.
+
+/** Le texte par défaut, celui des tableaux de trajets. Écrit aussi en dur dans `index.html`. */
+export const MESSAGE_VIDE = "Aucune route ne correspond aux filtres.";
+
+/**
+ * Affiche `texte` dans `#empty`, ou le masque si `texte` est `null`.
+ *
+ * Le nœud est réutilisé et non recréé : c'est ce que faisaient les trois vues, et c'est ce qui
+ * permet à `switchView` de le masquer sans savoir qui l'avait rempli.
+ */
+export function messageVide(texte: string | null): void {
+  const el = document.getElementById("empty");
+  if (!el) return;
+  if (texte == null) {
+    el.hidden = true;
+    return;
+  }
+  el.textContent = texte;
+  el.hidden = false;
+}


### PR DESCRIPTION
## Ce que ça change

Rien de visible. **Deux vues de plus** vivent dans la racine React : Boucles et Chaîne. On passe de
**quatre sur huit à six sur huit**, et une globale de rendu disparaît.

## Pourquoi

### Le préalable : `pickJourney` était captif

`pickJourney` est le point d'entrée du compagnon de voyage, et les **quatre** vues qui restaient
dans `app.js` l'appellent — Trajets en mode simple **et** en mode multi, Boucles, Chaîne — plus le
manifeste d'« En route » et le déplacement d'arrêt. Aucune ne pouvait emménager tant qu'il vivait
dans un fichier qui n'exporte rien.

Il rejoint `syncViewsToJourney` dans un `voyage-actions.ts` distinct de `voyage-donnees.ts` :
celui-ci porte la **donnée** du parcours et s'interdit de toucher au cycle de rendu, celui-là
appelle `rafraichir()`.

### `#empty` : une fonction, pas un portail

Ce `<p>` est **partagé** par Trajets, Boucles et « En route », et deux des trois vivent encore dans
`app.js`. `vues/message-vide.ts` en fait une fonction appelable des deux côtés.

Un portail gérerait les **enfants** du nœud, pas ses **attributs** — `hidden` resterait à poser à la
main. Et surtout, pendant la migration, un portail React face aux `textContent` impératifs des deux
autres vues, c'est la seule situation où les deux modèles se contredisent vraiment. La fonction
disparaîtra quand les trois vues seront dans l'arbre : `#empty` deviendra alors un enfant de la vue
active, et n'aura plus à être partagé du tout.

`useLayoutEffect` et non `useEffect` pour le poser : le message doit être écrit **avant** la
peinture, sinon un tableau vide s'affiche une frame sans rien dire.

### `shownChain` disparaît, et c'est le vrai gain de la Chaîne

Le ▶ « Ajouter au voyage » était pris par une délégation posée sur `document`, qui relisait
`shownChain` — une globale **écrite au rendu, lue au clic**. C'est le motif que la migration élimine
partout ailleurs (les ▶ des trajets et des boucles l'ont perdu en #129), et il survivait ici faute
d'un composant à qui confier le rappel.

Le bouton étant rendu par React, il porte désormais son `onClick`, fermé sur **sa** chaîne. La
branche de délégation part **au même commit** : la laisser doublerait l'ajout, et deux
`pickJourney` de suite posent deux fois les mêmes jambes — visible, mais seulement après coup, dans
le parcours. L'id `#chainToJourney` reste : c'est un contrat de test.

### Deux types resserrés, tous deux relâchés faute d'appelant typé

- `readFilters()` rend désormais `Filtres & FiltresVolume`. Les cinq champs de volume sont
  optionnels dans `Filtres` parce que d'autres appelants en construisent des morceaux, mais cette
  fonction les écrit **toujours**, sans branche. Sans ça, chaque vue migrée devrait poser un cast —
  affirmer sans preuve ce qui se lit en quatre lignes.
- `feeInfo` n'est plus `unknown` mais `ContexteFrais`, un type nommé de `frais.ts`. Les vues le
  **transportent** sans jamais le lire, et `unknown` les forçait au cast pour rendre une cellule.

Ni l'un ni l'autre n'était visible tant que le seul appelant était `app.js`, que `tsc` ne lit pas.

## Vérification

| commande | avant | après |
|---|---|---|
| `node --test` | 486 pass / 0 fail | **486 pass / 0 fail** |
| `npx playwright test` | 236 (234 passés, 2 ignorés) | **238 (236 passés, 2 ignorés, 0 échec)** |
| `npx tsc --noEmit` | silencieux | **silencieux** |
| `npm run build:site` | OK | **OK** |

`app.js` : **2 544 → 2 445 lignes** · **27 → 24 `peindre()`** · **4 → 6 vues sur 8** dans l'arbre.

**Deux tests de garde ajoutés** à `e2e/arbre.pw.mjs`, qui en compte cinq maintenant. Le plus utile
est celui de la Chaîne : `buildChainAdjacency` construit un graphe sur tout le marché, puis
`bestChain` en fait une recherche par faisceau — la rejouer depuis une autre vue serait le
gaspillage le plus cher du dépôt. Le test compte les mutations DOM de `#chainOut` pendant qu'on
tape depuis les Trajets, et exige zéro.

## Ce qui n'est pas couvert

- **Trajets et En route** restent dans `app.js` : ce sont les deux dernières vues, et les deux plus
  grosses. `#empty` reste donc partagé entre deux mondes.
- **Le bandeau** (`#shipJourneyRow`, soute, entrepôts, voyage, carte, récap) n'est pas touché : il
  vit dans six vues sur huit et n'est masqué que par le Plan de vol, donc il se montera sans garde
  `si` ou avec un garde négatif. C'est l'inverse du patron des vues d'onglet et ça mérite sa mesure.
- **Le sélecteur de station** reste : sœur de `#corrections`, pas enfant.
- `setupLoopSort` continue de câbler le `<thead>` de Boucles depuis `app.js` — le portail ne vise
  que `#loopRows`, et le `<thead>` est du markup statique d'`index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
