### PR TITLE
feat(voyage): la vue Trajets emménage dans l'arbre, et #128 disparaît avec sa clé

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -24,6 +24,7 @@ import { PanneauFrais } from "./vues/frais-station.tsx";
 import { VueCorrections } from "./vues/corrections-vue.tsx";
 import { VueBouclesArbitrage } from "./vues/boucles-vue.tsx";
 import { VueChaineArbitrage } from "./vues/chaine-vue.tsx";
+import { VueTrajetsArbitrage } from "./vues/trajets-vue.tsx";
 import { indexStationExacte } from "./marche.ts";
 
 /**
@@ -81,6 +82,7 @@ export function App() {
           son propre portail — voir `vues/message-vide.ts` pour pourquoi ce n'en est pas un second. */}
       <VueBouclesArbitrage />
       <VueChaineArbitrage />
+      <VueTrajetsArbitrage />
     </>
   );
 }

--- a/app.js
+++ b/app.js
@@ -50,7 +50,7 @@ import { figerJambe, jambeChargee, journeyCarriedCommodities, legEffectiveLines,
 // `plan-vue.tsx` expose `planData`. Les écouteurs de `#commSortModes` / `#commBoardModes` restent
 // ici : leurs conteneurs sont du markup d'index.html (ADR-012 §2).
 import { refletBoardCommodites, setCommBoard, setCommSort } from "./vues/commodites-vue.tsx";
-import { vueTrajets, vueTrajetsMulti } from "./vues/trajets.tsx";
+import { vueTrajets } from "./vues/trajets.tsx";
 import { carteManifeste, indiceSouteInactive, indiceSoutePleine, indiceAucunChargement } from "./vues/manifeste.tsx";
 import { carteSoute, carteEntrepots } from "./vues/soute.tsx";
 import { carteVoyage, recapVoyage, inviteVoyage } from "./vues/voyage.tsx";
@@ -161,7 +161,6 @@ function fiabiliteCell(f, age, part) {
 // Message de #empty tel qu'il est écrit dans index.html. Le <p> est PARTAGÉ par les vues Trajets /
 // Boucles / En route, et « En route » comme le mode multi-commodité réécrivent son texte : sans
 // remise à zéro en tête de rendu, un état vide légitime affichait le message d'une AUTRE vue.
-const EMPTY_DEFAULT = "Aucune route ne correspond aux filtres.";
 
 // Ce que les deux modes de Trajets partagent. app.js garde l'ÉTAT — les frais dépendent de
 // l'interrupteur d'autoload et des relevés par station, l'écriture d'une correction doit figer les
@@ -621,7 +620,7 @@ function renderManifest(origin, destSystem, f, destTerminal) {
 function renderEnRoute() {
   // #empty est PARTAGÉ avec Trajets / Boucles, et cette vue n'a encore rien de VRAI à y écrire :
   // ce n'est pas un filtre qui vide le tableau, c'est le marché qui manque. Symétrie du
-  // EMPTY_DEFAULT posé en tête de render() / renderLoops() (#55), qui manquait ici parce que le
+  // Le message par défaut posé en tête des vues à tableau (#55) manquait ici parce que le
   // retour anticipé précède toute écriture — et withMarket ne re-rend PAS en cas d'échec, donc le
   // message de la vue quittée y serait resté pour de bon, sous le toast « Marché indisponible ».
   if (!etat.MARKET) { $("empty").hidden = true; withMarket(refresh); return; }

--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@
 
 // Fonctions de calcul pures (testées par logic.test.mjs).
 import {
-  tripMinutes, ageDays, pairAge,
+  tripMinutes, ageDays, lineFreshUpdated, pairAge,
   scoreBarWidth, bySort, addableUnits, scuBoxes, cargoBoxes,
   kFromReading, kPlausible,
   ovKey, groupOverridesByTerminal, safeKey, encodeState, decodeState,
@@ -28,7 +28,7 @@ import {
 // l'unique notification. Voir pont.js pour pourquoi il n'y a ni magasin ni abonnement.
 import { peindre } from "./pont.js";
 import { etat, notifier } from "./etat.ts";
-import { fmt, fmtVol, fmtFee, signe, TEXTE_CAPACITE_INCONNUE } from "./format.ts";
+import { fmt, fmtVol, fmtFee, scuBoxesLabel, signe, TEXTE_CAPACITE_INCONNUE } from "./format.ts";
 import { readFilters } from "./filtres.ts";
 import { effVals, isOv, loadOverrides, ovCount, resetOverrides, saveOverrides, setOverride } from "./corrections.ts";
 import { corriger, notifySuperseded, updateOvBadge } from "./corrections-actions.ts";
@@ -38,6 +38,8 @@ import { alKey, feeCargoText, feeCell, feeCtx, feeEndText, feeLoadText, feeResol
 import { applyState, loadState, saveState, shareURL } from "./persistance.ts";
 import { brancher, ensureFeeMarket, ensureStarmap, withMarket } from "./donnees.ts";
 import { brancherRendu } from "./rendu.ts";
+import { propsLignesSimples, propsTrajetsCommunes } from "./vues/trajets-props.tsx";
+import { evaluate } from "./vues/trajets-vue.tsx";
 import { pickJourney, syncViewsToJourney } from "./voyage-actions.ts";
 import { monterRacine } from "./main.tsx";
 import { planData, planHypotheses } from "./vues/plan-vue.tsx";
@@ -62,13 +64,9 @@ import { BUY_STATUS, KIND_ICON, SELL_STATUS } from "./vues/communs.tsx";
 // terminal d'achat est disponible, parce que c'est exactement la décomposition que la facture
 // d'autoload utilise — un « 📦 1×32 » à côté d'un montant calculé sur deux caisses de 16 serait
 // une incohérence directement visible.
-const boxesLabel = (boxes) => (boxes.length ? boxes.map((b) => `${b.count}×${b.size}`).join(" · ") : "");
-function scuBoxesLabel(n, maxBox) {
-  return boxesLabel(scuBoxes(n, maxBox));
-}
+
 // Même libellé pour un chargement à plusieurs commodités : une caisse ne contient qu'une commodité,
 // la décomposition se fait donc ligne par ligne (cargoBoxes) et jamais sur le total des SCU.
-const cargoBoxesLabel = (lines, maxBox) => boxesLabel(cargoBoxes(lines, maxBox));
 
 // État global
 // Tri par défaut : le PROFIT NET par voyage (ADR-005). Le score composite classait mal — la route
@@ -107,10 +105,7 @@ function sysBadge(system) {
 // ---------- Fiabilité : fraîcheur, statut de stock, aberrations ----------
 // (ageDays/pairAge et les calculs de temps/score viennent de logic.mjs)
 // Fraîcheur d'une ligne de manifeste = le plus ancien des relevés achat/vente (ou l'un des deux).
-function lineFreshUpdated(l) {
-  const b = l.buyUpdated || 0, s = l.sellUpdated || 0;
-  return b && s ? Math.min(b, s) : b || s || 0;
-}
+
 
 // `BUY_STATUS` et `SELL_STATUS` sont passées dans `vues/communs.tsx`, à côté de la pastille qui les
 // lit : app.js ne faisait que les repasser en props à deux vues.
@@ -132,34 +127,11 @@ const nowSec = () => Math.floor(Date.now() / 1000);
 // toutes deux doivent être appelables depuis une vue de l'arbre (ADR-012).
 
 // Applique les corrections à une paire buy/sell et renvoie des copies patchées + marge/roi.
-function applyOverrides(commodity, buy, sell) {
-  const b = effVals(commodity, buy.terminal, "buy", buy.price, buy.stock, buy.updated);
-  const s = effVals(commodity, sell.terminal, "sell", sell.price, sell.demand, sell.updated);
-  const nb = { ...buy, price: b.price, stock: b.vol, ovPrice: b.oprice, ovVol: b.ovol };
-  const ns = { ...sell, price: s.price, demand: s.vol, ovPrice: s.oprice, ovVol: s.ovol };
-  const margin = ns.price - nb.price;
-  const roi = nb.price > 0 ? Math.round((margin / nb.price) * 1000) / 10 : 0;
-  return { buy: nb, sell: ns, margin, roi };
-}
+
 
 // Calcule les champs dérivés d'une route selon les entrées utilisateur : applique les corrections
 // locales (impur, globales OVERRIDES) puis délègue le calcul pur à routeMetrics (logic.mjs).
-function evaluate(r, f) {
-  const { buy, sell, margin } = applyOverrides(r.commodity, r.buy, r.sell);
-  // routes.json et enRouteDeals ne donnent que des NOMS de terminaux : c'est ici, du côté impur,
-  // qu'ils deviennent des tarifs. routeMetrics, lui, reçoit un contexte déjà résolu.
-  const feeInfo = feeCtx(f, buy.terminal, sell.terminal);
-  const metrics = routeMetrics({
-    buyPrice: buy.price, buyStock: buy.stock, sellDemand: sell.demand, margin,
-    distance: r.distance, sameSystem: r.same_system,
-    buyUpdated: buy.updated, sellUpdated: sell.updated,
-    demandKnown: sell.ovVol, // ovVol = demande corrigée par l'utilisateur = fiable
-  }, f, feeInfo && feeInfo.pair);
-  // Marge et ROI nets des frais, comme en mode multi : la même colonne garde la même définition
-  // d'un mode à l'autre. Sans frais, netMarginRoi rend exactement la marge de marché et l'ancien ROI.
-  const net = netMarginRoi(margin, buy.price, metrics.units, metrics.fees);
-  return { ...r, buy, sell, buyPrice: buy.price, sellPrice: sell.price, feeInfo, ...metrics, ...net };
-}
+
 
 // Cellule de FIABILITÉ : mini-barre + valeur, de 10 à 100 (ADR-005). Ce n'est plus un classement
 // mais ce qu'on sait de la donnée — fraîcheur du relevé × part de volume publiée. Elle ne trie plus
@@ -194,116 +166,20 @@ const EMPTY_DEFAULT = "Aucune route ne correspond aux filtres.";
 // Ce que les deux modes de Trajets partagent. app.js garde l'ÉTAT — les frais dépendent de
 // l'interrupteur d'autoload et des relevés par station, l'écriture d'une correction doit figer les
 // jambes déjà planifiées, et `#empty` reste écrit ici (il est partagé par trois vues).
-function propsTrajetsCommunes() {
-  return {
-    avecTexteFrais: (base, cell) => (cell.text ? `${base} · ${cell.text}` : base),
-    legendeAchat: BUY_STATUS,
-    legendeVente: SELL_STATUS,
-    // Le contrat de cette vue est celui du module : six arguments, dans le même ordre. On le passe
-    // donc NU — c'est le seul des quatre sites, avec le manifeste, à pouvoir le faire.
-    corriger,
-  };
-}
+
 
 // Ce qui se calcule LIGNE PAR LIGNE, et qui vaut pour les deux tables à lignes simples : « Trajets »
 // (`#rows`) et « En route » (`#enrouteRows`). Elles ont toujours partagé leur rendu — c'était la
 // fonction `routeRowHTML`, appelée des deux endroits. L'îlot React la remplace, donc il doit servir
 // les deux appelants : ne peindre que `#rows` laisserait « En route » sans lignes.
-function propsLignesSimples() {
-  return {
-    celluleFrais: (r) => feeCell(r.feeInfo, r.fees, () => feeLoadText(r.units, (termByName.get(r.buy.terminal) || {}).maxBox), r.units > 0),
-    suspect: (r) => {
-      const d = pairAge(r.buy.updated, r.sell.updated);
-      if (d != null && d > 10) return "relevé de plus de 10 jours";
-      if (r.refSell > 0 && r.refBuy > 0 && (r.sell.price > r.refSell * 1.5 || r.buy.price < r.refBuy * 0.67))
-        return "prix très éloigné de la moyenne UEX";
-      return null;
-    },
-    // Le plafond de caisse vient du MARCHÉ, pas du contexte de frais : c'est une propriété physique
-    // de la station. Le prendre dans `feeInfo` le faisait disparaître dès l'interrupteur relâché, et
-    // la ligne annonçait « 3×32 » à côté d'un manifeste qui affichait « 6×16 » pour la même cargaison.
-    libelleCaisses: (r) => (r.units ? scuBoxesLabel(r.units, (termByName.get(r.buy.terminal) || {}).maxBox) : null),
-    // ▶ : le rappel est ÉTALÉ avec le reste, donc il sert les DEUX tables à lignes simples d'un
-    // coup. Le poser au seul site d'appel de `#rows` ferait taire le ▶ d'« En route » — la
-    // sur-suppression de #116 en négatif. C'est désormais gardé (e2e/choix-trajet.pw.mjs).
-    choisirTrajet: (r) => pickJourney([legFromRoute(r)]),
-  };
-}
 
-function render() {
-  const f = readFilters();
-  $("empty").textContent = EMPTY_DEFAULT;
-  if (f.multi) return renderMulti(f);
-  ensureFeeMarket(f, refresh); // re-rend la vue RÉELLEMENT active à l'arrivée du marché, pas celle d'alors
 
-  let rows = etat.ROUTES.filter((r) => routePasses(r, f)).map((r) => evaluate(r, f));
 
-  rows.sort(bySort(etat.sortKey, etat.sortDir));
-
-  peindre($("rows"), vueTrajets({
-    ...propsTrajetsCommunes(),
-    ...propsLignesSimples(),
-    lignes: rows,
-  }));
-  $("empty").hidden = rows.length > 0;
-  notifySuperseded();
-}
 
 // ---------- Vue « Trajets » en mode MULTI-COMMODITÉ ----------
 // Même tableau, mais chaque ligne est un chargement A->B composé de PLUSIEURS commodités
 // (remplissage par marge décroissante, plafonné par stock/demande et budget).
-function renderMulti(f) {
-  const empty = $("empty");
-  // Sans soute bornée, « remplir la soute » n'a pas de sens (cf. manifeste d'« En route »).
-  if (!f.useCargo || !(f.cargo > 0)) {
-    peindre($("rows"), null);
-    empty.hidden = false;
-    empty.textContent = "Active la soute (SCU) pour calculer des trajets multi-commodité.";
-    return;
-  }
-  // Graphe requis. On vide comme le fait la branche « soute inactive » juste au-dessus : laisser
-  // les trajets à UNE commodité sous un mode qui promet des chargements combinés, c'est afficher
-  // autre chose que ce qu'on annonce. (Historiquement le motif était plus dur : le tableau ne
-  // correspondait plus à `shownMulti`, et ▶ comme 📦 y lisaient un index vide — clic mort, #25.
-  // Les deux boutons portent maintenant leur ligne, mais vider reste la bonne réponse.)
-  // #empty reste masqué : le tableau n'est pas vide à cause des filtres, le marché n'est pas là.
-  if (!etat.MARKET) {
-    peindre($("rows"), null);
-    empty.hidden = true;
-    withMarket(refresh);
-    return;
-  }
-  // Le contexte de frais descend DANS multiTrips (et non après coup) : c'est lui qui trie puis
-  // TRONQUE à 300 trajets, un trajet meilleur en net serait donc coupé avant d'atteindre le tableau.
-  const trips = multiTrips(etat.MARKET, f, effVals, 300, f.multiAll ? 1 : 2, feeResolver(f))
-    .map((t) => ({ ...t, feeInfo: feeCtx(f, t.origin.name, t.dest.name, t.origin, t.dest), ...tripMetrics(t) }));
-  trips.sort(bySort(etat.sortKey, etat.sortDir));
-  peindre($("rows"), vueTrajetsMulti({
-    ...propsTrajetsCommunes(),
-    lignes: trips,
-    celluleFrais: (t) => feeCell(t.feeInfo, t.fees, () => feeCargoText(t.lines, t.origin.maxBox), t.units > 0),
-    libelleCaisses: (t) => (t.units ? cargoBoxesLabel(t.lines, t.origin.maxBox) : null),
-    // Le relevé le plus ANCIEN du chargement : un trajet ne vaut pas mieux que sa ligne la moins sûre.
-    releveLePlusAncien: (t) => t.lines.reduce((m, l) => { const u = lineFreshUpdated(l); return m && u ? Math.min(m, u) : m || u; }, 0),
-    // Les deux que le DÉPLIANT réclame. Elles restent ici : la première dépend du contexte de
-    // frais, la seconde du plafond de caisse du terminal d'achat — ni l'un ni l'autre n'est connu
-    // de l'îlot.
-    texteProfitLigne: lineProfitText,
-    libelleCaissesScu: scuBoxesLabel,
-    // EXPLICITE, et pas par `propsLignesSimples()` : cette vue-ci ne l'étale pas, et un chargement
-    // multi ne devient pas une jambe par le même chemin qu'une ligne simple.
-    choisirTrajet: (t) => pickJourney([legFromTrip(t)]),
-  }));
-  empty.hidden = trips.length > 0;
-  // Rappel : seuls les chargements COMBINÉS (≥ 2 commodités) sont listés ici — un trajet dont le
-  // remplissage optimal tient en une seule commodité est déjà dans la vue « Trajets » normale.
-  if (!trips.length) {
-    empty.textContent = f.multiAll
-      ? "Aucun chargement depuis ces terminaux avec ces filtres — élargis la soute ou le budget."
-      : "Aucun chargement combinant plusieurs commodités avec ces filtres — agrandis la soute, ou passe la liste sur « avec les simples ».";
-  }
-  notifySuperseded();
-}
+
 
 // Le chargement déplié d'un trajet multi est rendu par `ChargementDeplie` (vues/trajets.tsx), avec
 // l'état d'ouverture — `multiCargoHTML` y a disparu, et `commodityIcon`/`illegalTag` avec lui : ils
@@ -1598,14 +1474,10 @@ const debounce = (fn, ms = 150) => {
 };
 
 function refresh() {
+  // « En route » est la DERNIÈRE vue d'onglet encore peinte ici. Les sept autres vivent dans
+  // l'arbre et se réévaluent seules au `notifier()` de la fin — chacune sous sa propre garde de
+  // vue, donc sans que celle qu'on ne regarde pas ne coûte rien (ADR-012 §3).
   if (etat.view === "enroute") renderEnRoute();
-  // La vue Trajets est NOMMÉE, elle n'est plus le repli. Les deux vues qui vivent dans l'arbre
-  // (Tournée, Plan de vol) tombaient ici : `render()` recalculait tout le tableau des trajets pour
-  // le repeindre dans un `<tbody>` masqué — et reposait `#empty`, qui est un frère de `#routes` et
-  // que rien ne masque, donc « Aucune route ne correspond aux filtres. » revenait sous une vue qui
-  // n'a pas de tableau (#147). Chaque vue qui emménagera dans l'arbre passera par ce même repli :
-  // le nommer une fois vaut mieux que d'y penser à chaque migration.
-  else if (etat.view === "routes") render();
   // La carte Voyage est affichée À CÔTÉ des tableaux, dans toutes les vues : la laisser hors du
   // cycle de rendu la figeait sur l'état d'avant. Corriger un prix ne mettait donc pas à jour les
   // bénéfices du voyage — alors qu'une jambe non ajustée est justement, par contrat, branchée sur
@@ -1686,7 +1558,6 @@ function setupSort() {
         etat.sortDir = key === "commodity" ? 1 : -1;
       }
       applySortIndicators(); // classes ET aria-sort, pour les deux tables
-      render();
       saveState();
       notifier(); // rendu CIBLÉ : il ne passe pas par `refresh()`, il propage lui-même
     });

--- a/e2e/arbre.pw.mjs
+++ b/e2e/arbre.pw.mjs
@@ -145,3 +145,34 @@ test("Chargement : le marché arrivé, aucun rendu ne se déguise en panne rése
   // Aucun toast d'indisponibilité : il ne peut venir que du `.catch` de `withMarket`.
   await expect(page.locator("#toast.show")).toHaveCount(0);
 });
+
+// #128 : `key={i}` ancre l'état d'édition au RANG de la ligne, pas au trajet. Un re-rendu qui
+// reclasse le tableau — un filtre tapé, un tri — laisse donc l'éditeur ouvert à la même PLACE, sur
+// un autre trajet, et `clore()` lit les props COURANTES : la correction part sur la mauvaise
+// commodité.
+//
+// Le déclencheur ne doit surtout PAS déplacer le focus : l'input porte `onBlur={() => clore(true)}`,
+// donc cliquer un en-tête de tri ou le champ de recherche referme l'éditeur AVANT le reclassement —
+// et le test passerait sans rien prouver. On dispatche donc `input` en JS, sans toucher au focus.
+test("Trajets : une correction ouverte pendant un re-tri reste sur SA commodité (#128)", async ({ page }) => {
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+
+  // Une ligne qui n'est pas la première : la tête de liste bouge moins au filtrage.
+  const cellule = page.locator("#rows tr").nth(4).locator('.editv[data-s="buy"][data-f="price"]').first();
+  const commodite = await cellule.getAttribute("data-c");
+  await cellule.click();
+  await expect(page.locator("#rows .editv input")).toHaveCount(1);
+
+  // Re-tri SANS blur : la valeur est posée et l'événement dispatché en JS.
+  await page.$eval("#search", (el) => {
+    el.value = "a";
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  await expect(page).toHaveURL(/search=a/, { timeout: 10000 });
+
+  // L'éditeur, s'il est encore ouvert, doit l'être sur LA MÊME commodité.
+  const ouvert = page.locator("#rows .editv:has(input)");
+  if (await ouvert.count()) {
+    await expect(ouvert.first(), "l'éditeur a changé de commodité sous les doigts").toHaveAttribute("data-c", commodite);
+  }
+});

--- a/e2e/arbre.pw.mjs
+++ b/e2e/arbre.pw.mjs
@@ -116,3 +116,32 @@ test("Arbre : taper depuis les Trajets ne recalcule pas la Chaîne", async ({ pa
 
   expect(await lots(), "la Chaîne a été recalculée depuis les Trajets").toBe(0);
 });
+
+test("Arbre : depuis les Boucles, taper ne recalcule pas le tableau des Trajets", async ({ page }) => {
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+  await page.click("#viewLoops");
+  await expect(page.locator("#loopRows tr").first()).toBeVisible({ timeout: 20000 });
+
+  const lots = await compterLots(page, "rows");
+  await page.locator("#search").pressSequentially("Laranite", { delay: 30 });
+  await expect(page).toHaveURL(/search=Laranite/, { timeout: 10000 });
+
+  expect(await lots(), "le tableau des Trajets a été recalculé depuis les Boucles").toBe(0);
+});
+
+// La panne la plus coûteuse du lot, et elle ne fait rougir AUCUN test d'apparence : `withMarket`
+// enveloppe son rappel dans un `.then()`, donc une exception jetée par le rendu qui suit est
+// avalée par le `.catch()` et se présente comme « Marché indisponible ». Un identifiant libre dans
+// `app.js` — que `tsc` ne lit pas — se déguise ainsi en panne réseau.
+test("Chargement : le marché arrivé, aucun rendu ne se déguise en panne réseau", async ({ page }) => {
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+  // Ce clic déclenche `pickJourney`, donc `renderJourney`, donc le chargement du marché.
+  await page.locator("#rows tr").first().locator(".journey-pick").click();
+
+  // Le marché arrive VRAIMENT : les listes se peuplent.
+  await expect(page.locator("#originList option").first()).toBeAttached({ timeout: 20000 });
+  // Et la carte du voyage sort de son « calcul… » au lieu de rester dessus.
+  await expect(page.locator("#journeyCard .jcargo-item").first()).toBeVisible({ timeout: 20000 });
+  // Aucun toast d'indisponibilité : il ne peut venir que du `.catch` de `withMarket`.
+  await expect(page.locator("#toast.show")).toHaveCount(0);
+});

--- a/format.ts
+++ b/format.ts
@@ -1,3 +1,6 @@
+import { cargoBoxes, scuBoxes } from "./logic.ts";
+import type { LigneManifeste } from "./types.ts";
+
 // Les formateurs partagés (ADR-011).
 //
 // Ils étaient définis dans `app.js` et INJECTÉS en props : `fmt` traversait onze composants, `fmtVol`
@@ -31,3 +34,24 @@ export const fmtFee = (n: number, fees: number): string => (fees > 0 ? "≈ " + 
  * frais mangeaient la marge — en vert, sur le seul chiffre qui disait de ne pas charger la ligne.
  */
 export const signe = (n: number, texte: string): string => (n < 0 ? texte : "+" + texte);
+
+// ── Les libellés de CAISSES ────────────────────────────────────────────────────────────────────
+// Ex. « 8×32 · 1×16 · 1×4 · 1×2 · 1×1 ». `maxBox` est le plafond de caisse du terminal de
+// CHARGEMENT quand on le connaît : c'est une propriété physique de la station, indépendante de
+// l'interrupteur de frais. On le propage partout où le terminal d'achat est disponible, parce que
+// c'est exactement la décomposition que la facture d'autoload utilise — un « 📦 1×32 » à côté d'un
+// montant calculé sur deux caisses de 16 serait une incohérence directement visible.
+//
+// Ils vivaient dans `app.js` alors qu'ils ne lisent aucun état : trois vues les consomment, et deux
+// d'entre elles vivent maintenant dans l'arbre.
+
+const boxesLabel = (boxes: { count: number; size: number }[]): string =>
+  boxes.length ? boxes.map((b) => `${b.count}×${b.size}`).join(" · ") : "";
+
+export const scuBoxesLabel = (n: number, maxBox?: number | null): string =>
+  boxesLabel(scuBoxes(n, maxBox));
+
+// Même libellé pour un chargement à PLUSIEURS commodités : une caisse ne contient qu'une commodité,
+// la décomposition se fait donc ligne par ligne (`cargoBoxes`) et jamais sur le total des SCU.
+export const cargoBoxesLabel = (lines: LigneManifeste[], maxBox?: number | null): string =>
+  boxesLabel(cargoBoxes(lines, maxBox));

--- a/logic.ts
+++ b/logic.ts
@@ -44,6 +44,18 @@ export function pairAge(a: number | null | undefined, b: number | null | undefin
   const u = a && b ? Math.min(a, b) : a || b || 0;
   return ageDays(u, nowSec);
 }
+
+/**
+ * Le relevé d'une ligne de manifeste : le plus ANCIEN de ses deux bouts, ou celui qui existe.
+ *
+ * Même règle que `pairAge` — une ligne ne vaut pas mieux que son côté le moins sûr — mais elle rend
+ * la DATE et non l'âge, parce que ses appelants l'affichent en pastille de fraîcheur ou la
+ * réduisent sur tout un chargement.
+ */
+export function lineFreshUpdated(l: { buyUpdated?: number; sellUpdated?: number }): number {
+  const b = l.buyUpdated || 0, s = l.sellUpdated || 0;
+  return b && s ? Math.min(b, s) : b || s || 0;
+}
 // Facteur de fraîcheur : 1.0 tout frais -> 0.2 au-delà de ~11 j ; 0.5 si date inconnue.
 export function freshnessFactor(age: number | null): number {
   if (age == null) return 0.5;

--- a/vues/trajets-props.tsx
+++ b/vues/trajets-props.tsx
@@ -1,0 +1,56 @@
+// Les props des tables à lignes simples (ADR-012).
+//
+// DEUX tables partagent exactement le même rendu de ligne : `#rows` (vue Trajets) et
+// `#enrouteRows` (vue « En route »). Elles ne partagent PAS leur cycle de vie — la première vit
+// dans l'arbre, la seconde encore dans `app.js` — mais chacune construit les mêmes rappels, à
+// partir des mêmes modules.
+//
+// D'où ce fichier : un seul endroit qui les fabrique, importé des deux côtés. C'est ce qui évite la
+// duplication que la migration vue-par-vue produit sinon mécaniquement — et une duplication de
+// rappels ne fait rougir aucun test, elle se contente de diverger.
+//
+// ── LE PIÈGE QUE `choisirTrajet` A DÉJÀ PAYÉ ──────────────────────────────────────────────────
+// Le ▶ est ÉTALÉ avec le reste, donc il sert les DEUX tables d'un coup. Le poser au seul site
+// d'appel de `#rows` ferait taire celui d'« En route » — la sur-suppression de #116 en négatif.
+// C'est désormais gardé par `e2e/choix-trajet.pw.mjs`.
+import { legFromRoute, pairAge } from "../logic.ts";
+import type { LigneTrajet } from "./trajets.tsx";
+import { corriger } from "../corrections-actions.ts";
+import { scuBoxesLabel } from "../format.ts";
+import { feeCell, feeLoadText } from "../frais.ts";
+import { termByName } from "../marche.ts";
+import { pickJourney } from "../voyage-actions.ts";
+import { BUY_STATUS, SELL_STATUS } from "./communs.tsx";
+
+/** Ce que les DEUX modes de la vue Trajets partagent — lignes simples ET chargements combinés. */
+export function propsTrajetsCommunes() {
+  return {
+    avecTexteFrais: (base: string, cell: { text: string }) => (cell.text ? `${base} · ${cell.text}` : base),
+    legendeAchat: BUY_STATUS,
+    legendeVente: SELL_STATUS,
+    // Le contrat de cette vue est celui du module : six arguments, dans le même ordre. On le passe
+    // donc NU — c'est l'un des deux seuls sites, avec le manifeste, à pouvoir le faire.
+    corriger,
+  };
+}
+
+/** Ce qui se calcule LIGNE PAR LIGNE, et vaut pour les deux tables à lignes simples. */
+export function propsLignesSimples() {
+  const plafond = (r: LigneTrajet) => termByName.get(r.buy.terminal)?.maxBox;
+  return {
+    celluleFrais: (r: LigneTrajet) =>
+      feeCell(r.feeInfo, r.fees, () => feeLoadText(r.units, plafond(r)), r.units > 0),
+    suspect: (r: LigneTrajet) => {
+      const d = pairAge(r.buy.updated, r.sell.updated);
+      if (d != null && d > 10) return "relevé de plus de 10 jours";
+      if (r.refSell > 0 && r.refBuy > 0 && (r.sell.price > r.refSell * 1.5 || r.buy.price < r.refBuy * 0.67))
+        return "prix très éloigné de la moyenne UEX";
+      return null;
+    },
+    // Le plafond de caisse vient du MARCHÉ, pas du contexte de frais : c'est une propriété physique
+    // de la station. Le prendre dans `feeInfo` le faisait disparaître dès l'interrupteur relâché, et
+    // la ligne annonçait « 3×32 » à côté d'un manifeste qui affichait « 6×16 » pour la même cargaison.
+    libelleCaisses: (r: LigneTrajet) => (r.units ? scuBoxesLabel(r.units, plafond(r)) : null),
+    choisirTrajet: (r: LigneTrajet) => pickJourney([legFromRoute(r)]),
+  };
+}

--- a/vues/trajets-vue.tsx
+++ b/vues/trajets-vue.tsx
@@ -1,0 +1,135 @@
+// La VUE Trajets : le composant qui décide quoi afficher (ADR-011 étape 3, ADR-012).
+//
+// La vue par DÉFAUT, la plus testée du dépôt, et la seule à avoir DEUX modes qui partagent un
+// conteneur : les trajets à une commodité, et les chargements COMBINÉS que la case « Multi
+// commodité » substitue aux premiers.
+//
+// `trajets.tsx` garde la PRÉSENTATION des deux. Ce fichier-ci porte la DÉCISION : quel mode, quelles
+// lignes, dans quel ordre, et quel message quand il n'y en a aucune.
+//
+// ── LES DEUX MODES SONT UNE BRANCHE, PAS DEUX VUES ────────────────────────────────────────────
+// Ils écrivent le MÊME `<tbody>` et le MÊME `#empty`, et c'est délibéré : basculer la case ne change
+// pas d'écran, elle change ce que l'écran répond. Deux composants portails sur `#rows` se
+// battraient pour la même racine.
+import { useLayoutEffect } from "react";
+import { createPortal } from "react-dom";
+
+import {
+  bySort, legFromTrip, lineFreshUpdated, multiTrips, netMarginRoi, routeMetrics, routePasses, tripMetrics,
+} from "../logic.ts";
+import type { Filtres, FiltresVolume, Route } from "../types.ts";
+import type { LigneTrajet } from "./trajets.tsx";
+import { etat, notifier } from "../etat.ts";
+import { readFilters } from "../filtres.ts";
+import { effVals } from "../corrections.ts";
+import { notifySuperseded } from "../corrections-actions.ts";
+import { ensureFeeMarket, withMarket } from "../donnees.ts";
+import { cargoBoxesLabel, scuBoxesLabel } from "../format.ts";
+import { feeCargoText, feeCell, feeCtx, feeResolver, lineProfitText } from "../frais.ts";
+import { pickJourney } from "../voyage-actions.ts";
+import { MESSAGE_VIDE, messageVide } from "./message-vide.ts";
+import { propsLignesSimples, propsTrajetsCommunes } from "./trajets-props.tsx";
+import { VueTrajets, VueTrajetsMulti } from "./trajets.tsx";
+
+// Fraîcheur d'une ligne de manifeste = le plus ancien des relevés achat/vente (ou l'un des deux).
+/** Applique les corrections à une paire buy/sell et rend des copies patchées + marge/ROI. */
+function applyOverrides(commodity: string, buy: Route["buy"], sell: Route["sell"]) {
+  const b = effVals(commodity, buy.terminal, "buy", buy.price, buy.stock, buy.updated);
+  const s = effVals(commodity, sell.terminal, "sell", sell.price, sell.demand, sell.updated);
+  const nb = { ...buy, price: b.price, stock: b.vol, ovPrice: b.oprice, ovVol: b.ovol };
+  const ns = { ...sell, price: s.price, demand: s.vol, ovPrice: s.oprice, ovVol: s.ovol };
+  const margin = ns.price - nb.price;
+  const roi = nb.price > 0 ? Math.round((margin / nb.price) * 1000) / 10 : 0;
+  return { buy: nb, sell: ns, margin, roi };
+}
+
+/** Une ligne de `routes.json`, corrections et frais appliqués. */
+export function evaluate(r: Route, f: Filtres & FiltresVolume): LigneTrajet {
+  const { buy, sell, margin } = applyOverrides(r.commodity, r.buy, r.sell);
+  // `routes.json` et `enRouteDeals` ne donnent que des NOMS de terminaux : c'est ici, du côté
+  // impur, qu'ils deviennent des tarifs. `routeMetrics`, lui, reçoit un contexte déjà résolu.
+  const feeInfo = feeCtx(f, buy.terminal, sell.terminal);
+  const metrics = routeMetrics({
+    buyPrice: buy.price, buyStock: buy.stock, sellDemand: sell.demand, margin,
+    distance: r.distance, sameSystem: r.same_system,
+    buyUpdated: buy.updated, sellUpdated: sell.updated,
+    demandKnown: sell.ovVol, // demande corrigée par l'utilisateur = fiable
+  }, f, feeInfo && feeInfo.pair);
+  // Marge et ROI NETS des frais, comme en mode multi : la même colonne garde la même définition d'un
+  // mode à l'autre. Sans frais, `netMarginRoi` rend exactement la marge de marché et l'ancien ROI.
+  const net = netMarginRoi(margin, buy.price, metrics.units, metrics.fees);
+  return { ...r, buy, sell, buyPrice: buy.price, sellPrice: sell.price, feeInfo, ...metrics, ...net } as LigneTrajet;
+}
+
+export function VueTrajetsArbitrage() {
+  useLayoutEffect(notifySuperseded);
+
+  const active = etat.view === "routes";
+  const f = readFilters();
+  const multi = !!f.multi;
+
+  // Ce que le rendu produira : le contenu du `<tbody>` et le message de `#empty`. On les prépare
+  // AVANT le retour anticipé pour que le hook du message soit appelé à tous les rendus (règle des
+  // hooks), mais le calcul lui-même reste sous la garde de vue.
+  let contenu: React.ReactNode = null;
+  let message: string | null = null;
+
+  if (active && !multi) {
+    // `ensureFeeMarket` re-rend la vue RÉELLEMENT active à l'arrivée du marché, pas celle d'alors.
+    ensureFeeMarket(f, notifier);
+    const lignes = etat.ROUTES.filter((r) => routePasses(r, f)).map((r) => evaluate(r, f));
+    lignes.sort(bySort(etat.sortKey, etat.sortDir));
+    contenu = <VueTrajets {...propsTrajetsCommunes()} {...propsLignesSimples()} lignes={lignes} />;
+    message = lignes.length ? null : MESSAGE_VIDE;
+  } else if (active) {
+    // ── Mode MULTI-COMMODITÉ ──────────────────────────────────────────────────────────────────
+    // Sans soute bornée, « remplir la soute » n'a pas de sens (cf. manifeste d'« En route »).
+    if (!f.useCargo || !(f.cargo > 0)) {
+      message = "Active la soute (SCU) pour calculer des trajets multi-commodité.";
+    } else if (!etat.MARKET) {
+      // On VIDE le tableau, comme la branche ci-dessus : laisser les trajets à UNE commodité sous
+      // un mode qui promet des chargements combinés, c'est afficher autre chose que ce qu'on
+      // annonce. Et `#empty` reste masqué — le tableau n'est pas vide à cause des filtres, c'est le
+      // marché qui manque.
+      withMarket(notifier);
+      message = null;
+    } else {
+      // Le contexte de frais descend DANS `multiTrips` (et non après coup) : c'est lui qui trie
+      // puis TRONQUE à 300 trajets, un trajet meilleur en net serait donc coupé avant d'atteindre
+      // le tableau.
+      const trips = multiTrips(etat.MARKET, f, effVals, 300, f.multiAll ? 1 : 2, feeResolver(f))
+        .map((t) => ({ ...t, feeInfo: feeCtx(f, t.origin.name, t.dest.name, t.origin, t.dest), ...tripMetrics(t) }));
+      trips.sort(bySort(etat.sortKey, etat.sortDir));
+      contenu = (
+        <VueTrajetsMulti
+          {...propsTrajetsCommunes()}
+          lignes={trips}
+          celluleFrais={(t) => feeCell(t.feeInfo, t.fees, () => feeCargoText(t.lines, t.origin.maxBox), t.units > 0)}
+          libelleCaisses={(t) => (t.units ? cargoBoxesLabel(t.lines, t.origin.maxBox) : null)}
+          // Le relevé le plus ANCIEN du chargement : un trajet ne vaut pas mieux que sa ligne la
+          // moins sûre.
+          releveLePlusAncien={(t) => t.lines.reduce((m, l) => { const u = lineFreshUpdated(l); return m && u ? Math.min(m, u) : m || u; }, 0)}
+          texteProfitLigne={lineProfitText}
+          libelleCaissesScu={scuBoxesLabel}
+          // EXPLICITE, et pas par `propsLignesSimples()` : cette vue-ci ne l'étale pas, et un
+          // chargement multi ne devient pas une jambe par le même chemin qu'une ligne simple.
+          choisirTrajet={(t) => pickJourney([legFromTrip(t)])}
+        />
+      );
+      // Rappel : seuls les chargements COMBINÉS (≥ 2 commodités) sont listés — un trajet dont le
+      // remplissage optimal tient en une seule commodité est déjà dans la vue normale.
+      message = trips.length ? null : (f.multiAll
+        ? "Aucun chargement depuis ces terminaux avec ces filtres — élargis la soute ou le budget."
+        : "Aucun chargement combinant plusieurs commodités avec ces filtres — agrandis la soute, ou passe la liste sur « avec les simples ».");
+    }
+  }
+
+  // `#empty` est PARTAGÉ avec « En route », encore dans `app.js` : on passe par l'écrivain commun.
+  useLayoutEffect(() => {
+    if (active) messageVide(message);
+  });
+
+  if (!active) return null;
+  const cible = document.getElementById("rows");
+  return cible ? createPortal(contenu, cible) : null;
+}

--- a/vues/trajets-vue.tsx
+++ b/vues/trajets-vue.tsx
@@ -31,7 +31,6 @@ import { MESSAGE_VIDE, messageVide } from "./message-vide.ts";
 import { propsLignesSimples, propsTrajetsCommunes } from "./trajets-props.tsx";
 import { VueTrajets, VueTrajetsMulti } from "./trajets.tsx";
 
-// Fraîcheur d'une ligne de manifeste = le plus ancien des relevés achat/vente (ou l'un des deux).
 /** Applique les corrections à une paire buy/sell et rend des copies patchées + marge/ROI. */
 function applyOverrides(commodity: string, buy: Route["buy"], sell: Route["sell"]) {
   const b = effVals(commodity, buy.terminal, "buy", buy.price, buy.stock, buy.updated);

--- a/vues/trajets.tsx
+++ b/vues/trajets.tsx
@@ -132,11 +132,22 @@ function LigneSimple({ r, celluleFrais, suspect, libelleCaisses, choisirTrajet, 
   );
 }
 
+// La CLÉ D'UNE LIGNE SIMPLE. `key={i}` était un piège dès qu'une ligne porte un état : après un
+// re-tri, la ligne *i* est un AUTRE trajet, et React réutilise l'instance à sa place — donc son
+// éditeur ouvert. `clore()` lit alors les props COURANTES, et la correction part sur la mauvaise
+// commodité (#128). Le déclencheur doit seulement éviter de blurrer l'input, ce qu'une frappe
+// débouncée dans un autre champ fait très bien.
+//
+// Le triplet est unique par construction : `routes.json` ne porte qu'une ligne par
+// (commodité, comptoir d'achat, comptoir de vente) — 316/316 vérifiées — et `enRouteDeals` ne garde
+// qu'UNE vente par commodité depuis un départ donné.
+const cleLigne = (r: LigneTrajet) => `${r.commodity}|${r.buy.terminal}|${r.sell.terminal}`;
+
 export function VueTrajets({ lignes, celluleFrais, suspect, libelleCaisses, choisirTrajet, ...c }: ProprietesTrajets) {
   return (
     <>
-      {lignes.map((r, i) => (
-        <LigneSimple key={i} r={r} celluleFrais={celluleFrais} suspect={suspect}
+      {lignes.map((r) => (
+        <LigneSimple key={cleLigne(r)} r={r} celluleFrais={celluleFrais} suspect={suspect}
                      libelleCaisses={libelleCaisses} choisirTrajet={choisirTrajet} {...c} />
       ))}
     </>

--- a/vues/trajets.tsx
+++ b/vues/trajets.tsx
@@ -15,6 +15,7 @@
 import { TEXTE_CAPACITE_INCONNUE, fmt, fmtFee, fmtVol } from "../format.ts";
 import { useState } from "react";
 import type { LigneManifeste, PaireFrais, Route } from "../types.ts";
+import type { ContexteFrais } from "../frais.ts";
 import { BadgeSysteme, TagAvantPoste, TagIllegal, IconeCommodite, PastilleFraicheur, CelluleFiabilite, ValeurEditable, PastilleStatut } from "./communs.tsx";
 
 type Fmt = (n: number) => string;
@@ -31,7 +32,7 @@ export type ProprietesCommunes = {
 export type LigneTrajet = Route & {
   fiabilite: number; age: number | null; partVolume: number;
   units: number; investment: number; profit: number; profitHour: number; minutes: number; fees: number;
-  feeInfo: unknown;
+  feeInfo: ContexteFrais;
   buy: Route["buy"] & { ovPrice: boolean; ovVol: boolean };
   sell: Route["sell"] & { ovPrice: boolean; ovVol: boolean };
 };
@@ -159,7 +160,7 @@ export type LigneMulti = {
   fiabilite: number; age: number | null; partVolume: number;
   margin: number; roi: number; units: number; investment: number;
   profit: number; profitHour: number; minutes: number; fees: number;
-  feeInfo: unknown;
+  feeInfo: ContexteFrais;
 };
 
 export type ProprietesMulti = ProprietesCommunes & {


### PR DESCRIPTION
## Ce que ça change

La **vue Trajets** — la vue par défaut, la plus testée du dépôt — vit maintenant dans la racine
React. **Sept vues sur huit** y sont ; seule « En route » reste dans `app.js`.

Et un bug de longue date disparaît : **une correction ouverte pendant un re-tri s'écrivait sur une
autre commodité** (#128).

## Pourquoi

### La cause racine de #128 : une clé qui désigne une place, pas une chose

`key={i}` ancrait l'état d'édition au **rang** de la ligne. Un re-rendu qui reclasse le tableau — un
filtre tapé, un tri — laissait l'éditeur ouvert à la même **place**, sur un **autre trajet**. Et
`clore()` lit les props **courantes** : la correction partait sur la mauvaise commodité, sans le
moindre signe.

Reproduit : éditeur ouvert sur « Audio-Visual Equipment », une frappe plus tard il porte « Gasping
Weevil Eggs ».

**Le déclencheur du test ne doit surtout pas déplacer le focus.** L'input porte
`onBlur={() => clore(true)}` : cliquer un en-tête de tri ou le champ de recherche referme l'éditeur
**avant** le reclassement, et le test passerait sans rien prouver. On dispatche donc `input` en JS,
sans toucher au focus — c'est ce qui distingue un test qui reproduit d'un test qui se rassure.

La clé devient `commodité|comptoir d'achat|comptoir de vente`, unique par construction :
`routes.json` ne porte qu'une ligne par triplet (**316/316** vérifiées) et `enRouteDeals` ne garde
qu'**une** vente par commodité depuis un départ donné. Le mode multi avait déjà sa clé stable.

### La migration : deux modes, une branche

Les deux modes écrivent le **même** `<tbody>` et le **même** `#empty`, et c'est délibéré : basculer
« Multi commodité » ne change pas d'écran, elle change ce que l'écran répond. Deux composants
portails sur `#rows` se battraient pour la même racine.

`vues/trajets-props.tsx` sort les deux fabriques de props, parce que **deux tables** partagent
exactement le même rendu de ligne — `#rows` et `#enrouteRows` — mais plus le même cycle de vie : la
première vit dans l'arbre, la seconde encore dans `app.js`. Les dupliquer était le réflexe mécanique
de la migration vue-par-vue, et une duplication de rappels ne fait rougir aucun test : elle se
contente de diverger.

Trois extractions au passage, chacune vers sa place naturelle : `scuBoxesLabel`/`cargoBoxesLabel` →
`format.ts` ; `lineFreshUpdated` → `logic.ts`, à côté de `pairAge` dont elle est la jumelle (même
règle, mais elle rend la **date** et non l'âge) ; `evaluate`/`applyOverrides` →
`vues/trajets-vue.tsx`, d'où « En route » l'importe plutôt que d'en garder une seconde définition du
profit net que rien ne tiendrait d'accord.

### Deux régressions introduites et corrigées dans ce lot — les deux invisibles

Elles méritent d'être écrites, parce que ce sont exactement les deux formes que prend une erreur
dans un fichier que `tsc` ne lit pas :

1. **`lineFreshUpdated` supprimée d'`app.js` alors que `renderJourney` l'appelait encore.**
   L'exception était **avalée par le `.catch()` de `withMarket`** et se présentait comme
   « ⚠ Marché indisponible » : un identifiant libre se déguisait en panne réseau. Un test le garde
   désormais — le marché arrivé, la carte du voyage doit sortir de son « calcul… » et aucun toast
   d'indisponibilité ne doit apparaître.
2. **L'appel `renderEnRoute()` emporté par le commentaire qu'il précédait** dans `refresh()`.
   Aucune erreur, aucun toast — la vue restait simplement vide.

## Vérification

| commande | avant (#153) | après |
|---|---|---|
| `node --test` | 486 pass / 0 fail | **486 pass / 0 fail** |
| `npx playwright test` | 238 (236 passés, 2 ignorés) | **241 — 239 passés, 2 ignorés, 0 échec** |
| `npx tsc --noEmit` | silencieux | **silencieux** |
| `npm run build:site` | OK | **OK** |

Le test de #128 était **rouge avant**, avec son propre message :

```
Error: l'éditeur a changé de commodité sous les doigts
Expected: "Audio-Visual Equipment"
Received: "Gasping Weevil Eggs"
```

Les deux ignorés sont **conditionnels aux données** (`test.skip` sur « aucun chargement rentable
depuis ce terminal ») : ce sont les mêmes deux qu'avant, identifiés par nom.

`app.js` : **2 445 → 2 315 lignes** · **24 → 20 `peindre()`** · **6 → 7 vues sur 8** dans l'arbre.

`e2e/arbre.pw.mjs` compte maintenant **huit** tests de garde.

Closes #128

## Ce qui n'est pas couvert

- **« En route »** est la dernière vue d'onglet dans `app.js`, et la plus grosse machine à état qui
  reste : `etat.MANIFEST_EDIT` y est réécrit **pendant le rendu**, ce qui est l'un des trois chemins
  qu'`etat.ts` cite pour refuser un magasin réactif.
- **Le bandeau** n'est pas touché.
- Le `<thead>` de Trajets et ses `th[data-sort]` restent du markup d'`index.html`, câblés par
  `setupSort` : le portail ne vise que le `<tbody>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
