### PR TITLE
feat(manifeste): la dernière vue emménage — les huit vivent dans l'arbre

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -26,6 +26,7 @@ import { VueBouclesArbitrage } from "./vues/boucles-vue.tsx";
 import { VueChaineArbitrage } from "./vues/chaine-vue.tsx";
 import { VueTrajetsArbitrage } from "./vues/trajets-vue.tsx";
 import { CarteParcours } from "./vues/carte-vue.tsx";
+import { VueEnRoute } from "./vues/enroute-vue.tsx";
 import { indexStationExacte } from "./marche.ts";
 
 /**
@@ -87,6 +88,9 @@ export function App() {
       {/* La carte du parcours vit DANS la section du Plan de vol : garde POSITIVE, l'inverse du
           bandeau. Elle était redessinée à chaque rendu depuis les huit vues. */}
       <Portail id="journeyMap" si="plan"><CarteParcours /></Portail>
+      {/* La HUITIÈME et dernière vue d'onglet. Elle occupe deux conteneurs — la carte de chargement
+          et la table du fret rentable — qui partagent les filtres, le départ et l'arrivée forcée. */}
+      <VueEnRoute />
     </>
   );
 }

--- a/App.tsx
+++ b/App.tsx
@@ -25,6 +25,7 @@ import { VueCorrections } from "./vues/corrections-vue.tsx";
 import { VueBouclesArbitrage } from "./vues/boucles-vue.tsx";
 import { VueChaineArbitrage } from "./vues/chaine-vue.tsx";
 import { VueTrajetsArbitrage } from "./vues/trajets-vue.tsx";
+import { CarteParcours } from "./vues/carte-vue.tsx";
 import { indexStationExacte } from "./marche.ts";
 
 /**
@@ -83,6 +84,9 @@ export function App() {
       <VueBouclesArbitrage />
       <VueChaineArbitrage />
       <VueTrajetsArbitrage />
+      {/* La carte du parcours vit DANS la section du Plan de vol : garde POSITIVE, l'inverse du
+          bandeau. Elle était redessinée à chaque rendu depuis les huit vues. */}
+      <Portail id="journeyMap" si="plan"><CarteParcours /></Portail>
     </>
   );
 }

--- a/app.js
+++ b/app.js
@@ -33,13 +33,13 @@ import { readFilters } from "./filtres.ts";
 import { effVals, isOv, loadOverrides, ovCount, resetOverrides, saveOverrides, setOverride } from "./corrections.ts";
 import { corriger, notifySuperseded, updateOvBadge } from "./corrections-actions.ts";
 import { showToast } from "./messages.ts";
-import { construireIndex, findCommodity, indexOrigine, indexStationExacte, libellesOrigines, libellesStations, resolveStationLabel, stationCourante, stationMap, termByName } from "./marche.ts";
+import { construireIndex, findCommodity, indexArriveeForcee, indexOrigine, indexStationExacte, libellesOrigines, libellesStations, resolveStationLabel, stationCourante, stationMap, termByName } from "./marche.ts";
 import { alKey, feeCargoText, feeCell, feeCtx, feeEndText, feeLoadText, feeResolver, globalK, kFmt, lineProfitText, loadAutoloadK, saveAutoloadK } from "./frais.ts";
 import { applyState, loadState, saveState, shareURL } from "./persistance.ts";
 import { brancher, ensureFeeMarket, withMarket } from "./donnees.ts";
 import { brancherRendu } from "./rendu.ts";
-import { manifestRemaining, suggestionsFor } from "./manifeste-donnees.ts";
-import { compositionValide, loadManifestEdit, oublierComposition, retenirComposition } from "./manifeste-etat.ts";
+import { manifesteCourant, manifestRemaining, suggestionsFor } from "./manifeste-donnees.ts";
+import { compositionValide, loadManifestEdit, nouvelleGenerationManifeste, oublierComposition, retenirComposition } from "./manifeste-etat.ts";
 import { propsLignesSimples, propsTrajetsCommunes } from "./vues/trajets-props.tsx";
 import { evaluate } from "./vues/trajets-vue.tsx";
 import { pickJourney, syncViewsToJourney } from "./voyage-actions.ts";
@@ -299,20 +299,20 @@ function vignetteStation(s) {
 // Résout le terminal de départ depuis le texte du champ (libellé exact).
 
 // Résout le terminal d'ARRIVÉE forcé (En route) depuis le champ (libellé exact), ou null.
-let enrouteDest = null;
-function resolveDest() {
-  const v = $("destTerminal").value.trim();
-  enrouteDest = stationMap.has(v) ? stationMap.get(v) : null;
-}
+
 
 // dealFrom / enRouteDeals / bestManifest / buildChainAdjacency vivent dans logic.mjs (fonctions
 // pures) ; on leur passe MARKET et le résolveur de corrections effVals depuis les vues.
 
-let currentManifest = null; // manifeste courant, mutable (édition SCU + suggestions ajoutées)
+// Le chargement courant se DÉRIVE à la demande — plus de globale écrite au rendu et relue au clic.
+// C'est la même leçon qu'`indexOrigine` : une valeur dérivée qu'il faut penser à recalculer est une
+// valeur qui sera un jour lue périmée. Le coût est un `bestManifest` par geste — celui-là même que
+// le rendu que le geste déclenche referait de toute façon.
+const chargementCourant = () => { const r = manifesteCourant(readFilters()); return r.etat === "ok" ? r.m : null; };
 
 // ---------- Le chargement qu'on COMPOSE à la main (#19) ----------
 // Lignes ajoutées, SCU ramenés à ce qu'on veut vraiment acheter : cette intention n'existait que
-// dans `currentManifest`, que renderManifest remet à null à chaque rendu. Un prix corrigé, une
+// dans une globale que le rendu remettait à null à chaque passe. Un prix corrigé, une
 // frappe dans la recherche ou un vaisseau changé l'effaçaient sans un mot. Elle se persiste donc
 // comme le manifeste d'une jambe de voyage, et SOUS LA MÊME FORME : l'INTENTION seule —
 // [{ name, units }] — jamais un instantané de marché, dont les prix se figeraient au jour de
@@ -342,9 +342,9 @@ function oublierCompositionSiRouteChangee() {
   if (!etat.MANIFEST_EDIT || !etat.MARKET) return;
   const origin = indexOrigine();
   if (origin == null) return;
-  resolveDest();
+  const arrivee = indexArriveeForcee();
   const ot = etat.MARKET.terminals[origin];
-  const dt = enrouteDest == null ? null : etat.MARKET.terminals[enrouteDest];
+  const dt = arrivee == null ? null : etat.MARKET.terminals[arrivee];
   const valide = compositionValide(
     { name: ot.name, system: ot.system },
     dt && { name: dt.name, system: dt.system },
@@ -370,23 +370,13 @@ function oublierCompositionSiRouteChangee() {
 
 // Lignes d'une composition, RELUES au marché courant : c'est ce qui fait qu'un prix corrigé
 // s'affiche alors que les SCU, eux, ne bougent pas.
-const lignesComposees = (lignes, fromIdx, toIdx) =>
-  lignes.map((e) => hydrateManifestLine(etat.MARKET, fromIdx, toIdx, findCommodity(e.name), e.units, effVals));
 
 // Carte d'un couple de terminaux dont plus AUCUN chargement n'est rentable : bestManifest ne rend
 // alors rien, et la composition faite à la main disparaîtrait avec lui — alors que le geste qui
 // vient de tuer la rentabilité (un prix d'achat corrigé vers le haut) est justement celui qui la
 // rend précieuse. Mêmes champs que ceux que manifestsFrom estampille sur un trajet ; les lignes
 // viennent de l'appelant.
-function manifesteSansOptimal(originIdx, destIdx, f) {
-  const ot = etat.MARKET.terminals[originIdx], dt = etat.MARKET.terminals[destIdx];
-  const point = feeResolver(f);
-  return {
-    origin: ot, originIdx, dest: dt, destIdx, cross: ot.system !== dt.system,
-    lines: [], profit: 0, cargo: f.cargo,
-    fee: point ? { buy: point(ot), sell: point(dt) } : null,
-  };
-}
+
 
 // `isOv` est passée dans `corrections.ts`, à côté d'`effVals` : elle lit le même store.
 
@@ -411,14 +401,15 @@ function manifesteSansOptimal(originIdx, destIdx, f) {
 // et n'a plus lieu d'être : deux fabriques du même bloc auraient fini par diverger.
 
 function addSuggestion(name) {
-  if (!currentManifest) return;
-  const it = suggestionsFor(currentManifest).find((x) => x.name === name);
+  const m = chargementCourant();
+  if (!m) return;
+  const it = suggestionsFor(m).find((x) => x.name === name);
   if (!it) return;
-  const u = addableUnits(it, manifestRemaining(currentManifest));
+  const u = addableUnits(it, manifestRemaining(m));
   if (u <= 0) return;
-  currentManifest.lines.push({ ...it, units: u, cap: u });
-  retenirComposition(currentManifest);
-  paintManifest();
+  m.lines.push({ ...it, units: u, cap: u });
+  retenirComposition(m);
+  notifier();
 }
 
 // Trouve une commodité par nom OU code (insensible à la casse/espaces). Partagé par les ajouts
@@ -427,22 +418,22 @@ function addSuggestion(name) {
 // Ajout LIBRE : n'importe quelle commodité (par nom ou code), même si elle n'est pas vendable à
 // destination — on la charge pour l'écouler ailleurs (ligne « carry-only », marge nulle ici).
 function addManifestCommodity(name) {
-  const m = currentManifest;
+  const m = chargementCourant();
   if (!m || !etat.MARKET) return;
   const c = findCommodity(name);
   if (!c || m.lines.some((l) => l.name === c.name)) return; // inconnue ou déjà dans le manifeste
   m.lines.push(freeManifestLine(etat.MARKET, m.originIdx, m.destIdx, c, manifestRemaining(m).cargoLeft, effVals));
-  retenirComposition(currentManifest);
-  paintManifest();
+  retenirComposition(m);
+  notifier();
 }
 
 // Retire une ligne du manifeste (par nom de commodité).
 function removeManifestLine(name) {
-  const m = currentManifest;
+  const m = chargementCourant();
   if (!m) return;
   m.lines = m.lines.filter((l) => l.name !== name);
-  retenirComposition(currentManifest);
-  paintManifest();
+  retenirComposition(m);
+  notifier();
 }
 
 // Engager le chargement dans le voyage : le bouton, ou la phrase qui dit pourquoi il n'y est pas.
@@ -454,23 +445,7 @@ function removeManifestLine(name) {
 // Dessine le manifeste courant : totaux + lignes (SCU/prix/stock éditables) + suggestions.
 // Tout ce qui suit dépend de l'ÉTAT GLOBAL (le marché, les corrections, le parcours, la
 // composition à la main) ; la mise en forme, elle, vit dans l'îlot.
-function paintManifest() {
-  const m = currentManifest;
-  $("manifest").hidden = false;
-  peindre($("manifest"), carteManifeste({
-    m,
-    generation: manifestGen,
-    compose: !!etat.MANIFEST_EDIT,
-    parcours: etat.JOURNEY,
-    suggestions: suggestionsFor(m),
-    restant: manifestRemaining(m),
-    libelleCaisses: (units) => scuBoxesLabel(units, m.origin.maxBox),
-    texteBoutFrais: feeEndText,
-    minutesTrajet: tripMinutes(0, m.cross),
-    estCorrige: isOv,
-    corriger, // six arguments dans le même ordre : passé nu, comme pour les Trajets
-  }));
-}
+
 
 // Recalcule totaux + profit par ligne d'après les SCU saisis, et rafraîchit les suggestions.
 //
@@ -480,26 +455,29 @@ function paintManifest() {
 // permet de supprimer les trois écritures en place (`.mprofit`, `.mboxes`, `#manifestTot`) — un
 // nœud possédé par React et muté hors de React, c'est précisément ce que le garde de #113 interdit.
 function updateManifestTotals() {
-  if (!currentManifest) return;
+  const m = chargementCourant();
+  if (!m) return;
   document.querySelectorAll("#manifest .mqty-input").forEach((inp) => {
     const i = Number(inp.dataset.i);
     let u = Math.floor(Number(inp.value));
     if (!Number.isFinite(u) || u < 0) u = 0;
     // Le dépassement du stock UEX est autorisé (vol de fret, relevé périmé…) : on ne plafonne
     // plus à `cap`, on le signale visuellement — la classe `over-stock` est posée au rendu.
-    const l = currentManifest.lines[i];
+    const l = m.lines[i];
     if (l) l.units = u;
   });
   // À la FRAPPE, pas au blur : le champ ne porte aucun `change`, et le premier refresh venu — un
   // prix corrigé ailleurs, une recherche tapée — repeindrait la carte avant qu'on ait quitté le
   // champ. Ce que ça écrit tient en deux nombres par ligne.
-  retenirComposition(currentManifest);
-  paintManifest();
+  retenirComposition(m);
+  // `notifier()` et non `rafraichir()` : la frappe ne doit PAS bouger la génération de la carte,
+  // sans quoi les champs SCU se remonteraient sous les doigts (cf. manifeste-etat.ts).
+  notifier();
 }
 
 // Copie le plan de chargement en texte (pour un 2e écran / des notes).
 function copyManifest() {
-  const m = currentManifest;
+  const m = chargementCourant();
   if (!m) return;
   const { profit, invest, scu, fees } = manifestTotals(m.lines, m.fee);
   const rows = m.lines.map(
@@ -540,114 +518,9 @@ function copierTexte(texte, btn, libelle) {
   }).catch(() => showToast("⚠ Presse-papiers refusé — la copie n'a pas eu lieu"));
 }
 
-let manifestGen = 0; // cf. l'affectation de `currentManifest`, plus bas
-function renderManifest(origin, destSystem, f, destTerminal) {
-  const card = $("manifest");
-  currentManifest = null;
-  // Les trois messages ci-dessous passent par React, comme la carte. `#manifest` lui appartient
-  // depuis #96 : un `innerHTML` y détacherait les nœuds qu'il a créés sans qu'il le sache, et la
-  // racine mémorisée dans pont.js appliquerait ensuite ses différences hors du document — le
-  // message resterait à l'écran pour de bon, sans lever (#120).
-  if (indexOrigine() == null) { card.hidden = true; peindre(card, null); return; }
-  if (!f.useCargo || !(f.cargo > 0)) {
-    card.hidden = false;
-    peindre(card, indiceSouteInactive());
-    return;
-  }
-  // La soute n'est pas vide : on ne peut charger QUE la place qui reste. C'est la question du
-  // scénario d'ADR-002 — « j'ai 30 SCU de libre, qu'est-ce que j'y mets maintenant ? ». Les autres
-  // vues gardent la soute nominale : elles répondent à « quelle est la meilleure route », pas à
-  // « que puis-je embarquer là, tout de suite ».
-  const aBord = holdScu(etat.SOUTE);
-  const libre = freeCargo(etat.SOUTE, f.cargo);
-  if (aBord > 0 && libre <= 0) {
-    card.hidden = false;
-    peindre(card, indiceSoutePleine(fmt(aBord)));
-    return;
-  }
-  const fLibre = aBord > 0 ? { ...f, cargo: libre } : f;
-  // Une composition en cours IMPOSE sa destination : laisser la carte se re-router toute seule sous
-  // une correction de prix ferait disparaître de l'écran le chargement qu'on est en train de
-  // composer — le symptôme même qu'on corrige. Forcer l'arrivée au champ, elle, l'abandonne.
-  const ot = etat.MARKET.terminals[origin];
-  const dt = destTerminal == null ? null : etat.MARKET.terminals[destTerminal];
-  // PURE : elle ne décide plus d'abandonner, elle dit seulement si la composition vaut encore pour
-  // cette route. L'abandon est descendu dans les gestes qui CHANGENT de route — le rendu n'écrit
-  // plus rien (ADR-012 §4, et le point 3 de l'en-tête d'`etat.ts`).
-  const compo = compositionValide(
-    { name: ot.name, system: ot.system },
-    dt && { name: dt.name, system: dt.system },
-    destSystem,
-    (nom, systeme) => stationMap.get(stationLabel(nom, systeme)),
-    findCommodity,
-  );
-  const cible = compo ? compo.destIdx : destTerminal;
-  const man = bestManifest(etat.MARKET, origin, destSystem, fLibre, effVals, cible, feeResolver(f))
-    || (compo ? manifesteSansOptimal(origin, cible, fLibre) : null);
-  if (!man) {
-    card.hidden = false;
-    peindre(card, indiceAucunChargement(aBord > 0 ? fmt(libre) : null));
-    return;
-  }
-  // Les lignes EFFECTIVES : celles de l'utilisateur, moins ce qu'UEX ne publie plus. Le filtre est
-  // fait par `compositionValide`, qui ne persiste rien — le prochain geste réécrit l'objet entier.
-  if (compo) man.lines = lignesComposees(compo.lignes, origin, cible);
-  man.originIdx = origin;
-  man.f = fLibre;
-  man.aBord = aBord; // pour que la carte dise pourquoi elle ne remplit que ça
-  // `man.fee` (le contexte de frais) vient de manifestsFrom : on ne le reconstruit pas, on ne
-  // risque donc pas de le reconstruire AUTREMENT que ce qui a servi à choisir la destination.
-  man.feeInfo = feeCtx(f, man.origin.name, man.dest.name, man.origin, man.dest);
-  currentManifest = man;
-  // La GÉNÉRATION distingue les deux façons de repeindre la carte, et c'est tout ce qui reste du
-  // comportement de l'ancien `card.innerHTML` :
-  //   - ici, le manifeste vient d'être RECALCULÉ (départ changé, « ↺ optimal », correction de
-  //     prix…) : les champs SCU doivent adopter les nouvelles valeurs, donc ils se remontent ;
-  //   - depuis `updateManifestTotals`, on est EN TRAIN de taper : la génération ne bouge pas, le
-  //     champ garde son nœud, sa valeur et son curseur.
-  // Sans elle, un champ non contrôlé garderait à jamais ce que l'utilisateur y a tapé — « ↺
-  // optimal » remettait `value="96"` dans l'attribut pendant que le champ affichait encore 30.
-  manifestGen++;
-  paintManifest();
-}
 
-function renderEnRoute() {
-  // #empty est PARTAGÉ avec Trajets / Boucles, et cette vue n'a encore rien de VRAI à y écrire :
-  // ce n'est pas un filtre qui vide le tableau, c'est le marché qui manque. Symétrie du
-  // Le message par défaut posé en tête des vues à tableau (#55) manquait ici parce que le
-  // retour anticipé précède toute écriture — et withMarket ne re-rend PAS en cas d'échec, donc le
-  // message de la vue quittée y serait resté pour de bon, sous le toast « Marché indisponible ».
-  if (!etat.MARKET) { $("empty").hidden = true; withMarket(refresh); return; }
-  if (!enrouteReady) setupEnRoute();
-  resolveDest();
-  const f = readFilters();
-  const emptyMsg = $("empty");
 
-  renderManifest(indexOrigine(), $("destSystem").value, f, enrouteDest);
 
-  if (indexOrigine() == null) {
-    peindre($("enrouteRows"), null);
-    emptyMsg.hidden = false;
-    emptyMsg.textContent = "Choisis un terminal de départ pour voir le fret à emporter.";
-    return;
-  }
-
-  const destSystem = $("destSystem").value;
-  // sysFilter:"" — le système d'arrivée est filtré par destSystem (ou le terminal forcé), pas par le menu « système d'achat ».
-  const ef = { ...f, sysFilter: "" };
-  // Le contexte de frais descend DANS enRouteDeals : elle ne garde qu'UNE vente par commodité, donc
-  // une destination meilleure en net n'entrerait jamais dans la liste — et la carte Manifeste, juste
-  // au-dessus, afficherait la destination inverse (bestManifest, lui, tranche déjà sur le net).
-  let deals = enRouteDeals(etat.MARKET, indexOrigine(), destSystem, enrouteDest, f, feeResolver(f))
-    .filter((r) => routePasses(r, ef))
-    .map((r) => evaluate(r, f));
-
-  deals.sort(bySort(etat.sortKey, etat.sortDir));
-  peindre($("enrouteRows"), vueTrajets({ ...propsTrajetsCommunes(), ...propsLignesSimples(), lignes: deals }));
-  emptyMsg.hidden = deals.length > 0;
-  if (!deals.length) emptyMsg.textContent = "Aucun fret rentable depuis ce terminal avec ces filtres.";
-  notifySuperseded();
-}
 
 // ---------- Vue « Chaîne » (multi-sauts A -> B -> C ...) ----------
 
@@ -1079,7 +952,7 @@ function clearJourney() {
 // Engage le manifeste d'« En route » comme nouvelle jambe du voyage (bouton de la carte Manifeste).
 // La garde d'état est REJOUÉE ici : le rendu peut dater d'avant un changement de parcours.
 function manifestToJourney() {
-  const m = currentManifest;
+  const m = chargementCourant();
   if (!m || !m.lines.length || !etat.MARKET) return;
   if (manifestJourneyState(etat.JOURNEY, m.origin, m.dest).etat !== "ajouter") return;
   const intent = manifestIntent(m.lines);
@@ -1436,10 +1309,14 @@ const debounce = (fn, ms = 150) => {
 };
 
 function refresh() {
-  // « En route » est la DERNIÈRE vue d'onglet encore peinte ici. Les sept autres vivent dans
-  // l'arbre et se réévaluent seules au `notifier()` de la fin — chacune sous sa propre garde de
-  // vue, donc sans que celle qu'on ne regarde pas ne coûte rien (ADR-012 §3).
-  if (etat.view === "enroute") renderEnRoute();
+  // PLUS AUCUNE BRANCHE DE VUE : les huit vivent dans l'arbre et se réévaluent seules au
+  // `notifier()` de la fin, chacune sous sa propre garde. Ce qui reste ici, c'est le BANDEAU —
+  // visible dans six vues sur huit — et `saveState()`.
+  //
+  // La génération de la carte de chargement bouge ICI et nulle part ailleurs : un cycle complet est
+  // par définition un RECALCUL, donc les champs SCU doivent adopter les nouvelles valeurs. Une
+  // frappe, elle, n'appelle que `notifier()` et laisse la génération tranquille (manifeste-etat.ts).
+  nouvelleGenerationManifeste();
   // La carte Voyage est affichée À CÔTÉ des tableaux, dans toutes les vues : la laisser hors du
   // cycle de rendu la figeait sur l'état d'avant. Corriger un prix ne mettait donc pas à jour les
   // bénéfices du voyage — alors qu'une jambe non ajustée est justement, par contrat, branchée sur
@@ -1923,7 +1800,7 @@ async function init() {
   // rien n'oblige à choisir dans la liste) : même debounce que ci-dessus. Sans lui, chaque frappe
   // re-rendait la vue ET réécrivait le hash — or WebKit plafonne history.replaceState à 100 appels
   // par 10 s : taper deux noms de terminal suffisait à le franchir. Les résolveurs restent DANS le
-  // rappel, donc dans le même ordre qu'avant ; renderEnRoute / renderChain / renderCorrections les
+  // rappel, donc dans le même ordre qu'avant ; les vues de l'arbre les
   // rejouent de toute façon avant de peindre.
   // CHANGER DE ROUTE ABANDONNE LA COMPOSITION, et c'est un GESTE — plus une décision du rendu.
   // `compositionValide` se contente désormais de dire qu'elle ne vaut plus ; c'est ici qu'on

--- a/app.js
+++ b/app.js
@@ -39,6 +39,7 @@ import { applyState, loadState, saveState, shareURL } from "./persistance.ts";
 import { brancher, ensureFeeMarket, withMarket } from "./donnees.ts";
 import { brancherRendu } from "./rendu.ts";
 import { manifestRemaining, suggestionsFor } from "./manifeste-donnees.ts";
+import { compositionValide, loadManifestEdit, oublierComposition, retenirComposition } from "./manifeste-etat.ts";
 import { propsLignesSimples, propsTrajetsCommunes } from "./vues/trajets-props.tsx";
 import { evaluate } from "./vues/trajets-vue.tsx";
 import { pickJourney, syncViewsToJourney } from "./voyage-actions.ts";
@@ -321,33 +322,38 @@ let currentManifest = null; // manifeste courant, mutable (édition SCU + sugges
 // une composition rangée sous un couple qu'on ne regarde plus ressortirait des jours plus tard sans
 // qu'on l'ait demandée. Le système est stocké avec le nom — deux terminaux peuvent porter le même
 // nom dans deux systèmes, et les lignes se relisent par INDEX de terminal.
-const MANIFEST_EDIT_KEY = "best-hauling-manifest-edit";
-function loadManifestEdit() {
-  try { etat.MANIFEST_EDIT = JSON.parse(localStorage.getItem(MANIFEST_EDIT_KEY)) || null; } catch { etat.MANIFEST_EDIT = null; }
-  if (!etat.MANIFEST_EDIT || !Array.isArray(etat.MANIFEST_EDIT.lines)) etat.MANIFEST_EDIT = null;
-}
-function saveManifestEdit() {
-  try {
-    if (etat.MANIFEST_EDIT) localStorage.setItem(MANIFEST_EDIT_KEY, JSON.stringify(etat.MANIFEST_EDIT));
-    else localStorage.removeItem(MANIFEST_EDIT_KEY);
-  } catch {}
-}
+
+
 // Retient ce qui est à l'écran comme intention. Appelée par CHAQUE geste de composition — ajout
 // suggéré, ajout libre, retrait, SCU ajustés — parce que c'est le geste qui fait la composition,
 // pas son résultat : deux gestes qui se compensent laissent quand même une carte à soi.
-function retenirManifeste() {
-  const m = currentManifest;
-  if (!m) return;
-  etat.MANIFEST_EDIT = {
-    from: m.origin.name, fromSystem: m.origin.system,
-    to: m.dest.name, toSystem: m.dest.system,
-    lines: manifestIntent(m.lines),
-  };
-  saveManifestEdit();
-}
-function oublierManifeste() { etat.MANIFEST_EDIT = null; saveManifestEdit(); }
+
 // « ↺ optimal » : la carte redevient un calcul, et se remet à suivre le marché et les filtres.
-function resetManifeste() { oublierManifeste(); refresh(); }
+function resetManifeste() { oublierComposition(); refresh(); }
+
+/**
+ * Efface la composition si la route affichée n'est plus la sienne.
+ *
+ * C'est l'ancienne décision de `compositionEnCours`, sortie du rendu. On la rejoue au GESTE, avec
+ * la même règle et le même juge (`compositionValide`) : ce qui change, c'est QUI décide — un clic
+ * de l'utilisateur, et non un repaint provoqué par une correction de prix ailleurs.
+ */
+function oublierCompositionSiRouteChangee() {
+  if (!etat.MANIFEST_EDIT || !etat.MARKET) return;
+  const origin = indexOrigine();
+  if (origin == null) return;
+  resolveDest();
+  const ot = etat.MARKET.terminals[origin];
+  const dt = enrouteDest == null ? null : etat.MARKET.terminals[enrouteDest];
+  const valide = compositionValide(
+    { name: ot.name, system: ot.system },
+    dt && { name: dt.name, system: dt.system },
+    $("destSystem").value,
+    (nom, systeme) => stationMap.get(stationLabel(nom, systeme)),
+    findCommodity,
+  );
+  if (!valide) oublierComposition();
+}
 
 // La marque et le contrôle du chargement composé à la main. Les deux mêmes chaînes servent au rendu
 // de la carte ET à leur pose en direct à la première frappe dans un champ SCU : celle-là ne repeint
@@ -360,33 +366,12 @@ function resetManifeste() { oublierManifeste(); refresh(); }
 // La composition vaut-elle pour la carte demandée ? Sinon elle est abandonnée SUR PLACE : la garder
 // en réserve la ferait ressurgir au retour sur cette route, longtemps après le geste qui l'a écrite.
 // Rend { edit, destIdx } ou null ; `destIdx` est l'arrivée que la carte doit alors afficher.
-function compositionEnCours(originIdx, destTerminal, destSystem) {
-  if (!etat.MANIFEST_EDIT) return null;
-  const ot = etat.MARKET.terminals[originIdx];
-  const dt = destTerminal == null ? null : etat.MARKET.terminals[destTerminal];
-  const destIdx = stationMap.get(stationLabel(etat.MANIFEST_EDIT.to, etat.MANIFEST_EDIT.toSystem));
-  const vivante = destIdx != null && manifestIntentSurvives(etat.MANIFEST_EDIT, {
-    from: { name: ot.name, system: ot.system },
-    dest: dt && { name: dt.name, system: dt.system },
-    destSystem,
-  });
-  if (!vivante) { oublierManifeste(); return null; }
-  // Commodité disparue d'UEX : oubliée plutôt qu'affichée en fantôme, comme sur une jambe de voyage.
-  // Purge SUR PLACE — les SCU sont adressés par index de ligne (`data-i`), l'intention et l'écran ne
-  // peuvent pas diverger d'un cran.
-  const gardees = etat.MANIFEST_EDIT.lines.filter((e) => findCommodity(e.name));
-  const perdues = gardees.length !== etat.MANIFEST_EDIT.lines.length;
-  if (perdues) { etat.MANIFEST_EDIT.lines = gardees; saveManifestEdit(); }
-  // Vidée par cette purge, et non par un geste : la composition ne parlait plus que de commodités
-  // qui n'existent plus, la carte reprend son calcul. Vidée à la main, elle reste (cf. logic.mjs).
-  if (perdues && !gardees.length) { oublierManifeste(); return null; }
-  return { edit: etat.MANIFEST_EDIT, destIdx };
-}
+
 
 // Lignes d'une composition, RELUES au marché courant : c'est ce qui fait qu'un prix corrigé
 // s'affiche alors que les SCU, eux, ne bougent pas.
-const lignesComposees = (edit, fromIdx, toIdx) =>
-  edit.lines.map((e) => hydrateManifestLine(etat.MARKET, fromIdx, toIdx, findCommodity(e.name), e.units, effVals));
+const lignesComposees = (lignes, fromIdx, toIdx) =>
+  lignes.map((e) => hydrateManifestLine(etat.MARKET, fromIdx, toIdx, findCommodity(e.name), e.units, effVals));
 
 // Carte d'un couple de terminaux dont plus AUCUN chargement n'est rentable : bestManifest ne rend
 // alors rien, et la composition faite à la main disparaîtrait avec lui — alors que le geste qui
@@ -432,7 +417,7 @@ function addSuggestion(name) {
   const u = addableUnits(it, manifestRemaining(currentManifest));
   if (u <= 0) return;
   currentManifest.lines.push({ ...it, units: u, cap: u });
-  retenirManifeste();
+  retenirComposition(currentManifest);
   paintManifest();
 }
 
@@ -447,7 +432,7 @@ function addManifestCommodity(name) {
   const c = findCommodity(name);
   if (!c || m.lines.some((l) => l.name === c.name)) return; // inconnue ou déjà dans le manifeste
   m.lines.push(freeManifestLine(etat.MARKET, m.originIdx, m.destIdx, c, manifestRemaining(m).cargoLeft, effVals));
-  retenirManifeste();
+  retenirComposition(currentManifest);
   paintManifest();
 }
 
@@ -456,7 +441,7 @@ function removeManifestLine(name) {
   const m = currentManifest;
   if (!m) return;
   m.lines = m.lines.filter((l) => l.name !== name);
-  retenirManifeste();
+  retenirComposition(currentManifest);
   paintManifest();
 }
 
@@ -508,7 +493,7 @@ function updateManifestTotals() {
   // À la FRAPPE, pas au blur : le champ ne porte aucun `change`, et le premier refresh venu — un
   // prix corrigé ailleurs, une recherche tapée — repeindrait la carte avant qu'on ait quitté le
   // champ. Ce que ça écrit tient en deux nombres par ligne.
-  retenirManifeste();
+  retenirComposition(currentManifest);
   paintManifest();
 }
 
@@ -584,7 +569,18 @@ function renderManifest(origin, destSystem, f, destTerminal) {
   // Une composition en cours IMPOSE sa destination : laisser la carte se re-router toute seule sous
   // une correction de prix ferait disparaître de l'écran le chargement qu'on est en train de
   // composer — le symptôme même qu'on corrige. Forcer l'arrivée au champ, elle, l'abandonne.
-  const compo = compositionEnCours(origin, destTerminal, destSystem);
+  const ot = etat.MARKET.terminals[origin];
+  const dt = destTerminal == null ? null : etat.MARKET.terminals[destTerminal];
+  // PURE : elle ne décide plus d'abandonner, elle dit seulement si la composition vaut encore pour
+  // cette route. L'abandon est descendu dans les gestes qui CHANGENT de route — le rendu n'écrit
+  // plus rien (ADR-012 §4, et le point 3 de l'en-tête d'`etat.ts`).
+  const compo = compositionValide(
+    { name: ot.name, system: ot.system },
+    dt && { name: dt.name, system: dt.system },
+    destSystem,
+    (nom, systeme) => stationMap.get(stationLabel(nom, systeme)),
+    findCommodity,
+  );
   const cible = compo ? compo.destIdx : destTerminal;
   const man = bestManifest(etat.MARKET, origin, destSystem, fLibre, effVals, cible, feeResolver(f))
     || (compo ? manifesteSansOptimal(origin, cible, fLibre) : null);
@@ -593,7 +589,9 @@ function renderManifest(origin, destSystem, f, destTerminal) {
     peindre(card, indiceAucunChargement(aBord > 0 ? fmt(libre) : null));
     return;
   }
-  if (compo) man.lines = lignesComposees(compo.edit, origin, cible);
+  // Les lignes EFFECTIVES : celles de l'utilisateur, moins ce qu'UEX ne publie plus. Le filtre est
+  // fait par `compositionValide`, qui ne persiste rien — le prochain geste réécrit l'objet entier.
+  if (compo) man.lines = lignesComposees(compo.lignes, origin, cible);
   man.originIdx = origin;
   man.f = fLibre;
   man.aBord = aBord; // pour que la carte dise pourquoi elle ne remplit que ça
@@ -1927,9 +1925,14 @@ async function init() {
   // par 10 s : taper deux noms de terminal suffisait à le franchir. Les résolveurs restent DANS le
   // rappel, donc dans le même ordre qu'avant ; renderEnRoute / renderChain / renderCorrections les
   // rejouent de toute façon avant de peindre.
-  $("origin").addEventListener("input", debounce(refresh));
-  $("destSystem").addEventListener("input", refresh); // <select> : un seul événement, immédiat
-  $("destTerminal").addEventListener("input", refreshDebounced); // terminal d'arrivée forcé
+  // CHANGER DE ROUTE ABANDONNE LA COMPOSITION, et c'est un GESTE — plus une décision du rendu.
+  // `compositionValide` se contente désormais de dire qu'elle ne vaut plus ; c'est ici qu'on
+  // l'efface, parce que c'est ici que l'utilisateur a changé d'avis. La laisser en réserve la
+  // ferait ressurgir au retour sur cette route, longtemps après le geste qui l'avait écrite.
+  const changerDeRoute = () => { oublierCompositionSiRouteChangee(); refresh(); };
+  $("origin").addEventListener("input", debounce(changerDeRoute));
+  $("destSystem").addEventListener("input", changerDeRoute); // <select> : un seul événement, immédiat
+  $("destTerminal").addEventListener("input", debounce(changerDeRoute)); // terminal d'arrivée forcé
   // Contrôles « Chaîne ».
   $("chainOrigin").addEventListener("input", debounce(refresh));
   $("hops").addEventListener("input", refresh);

--- a/app.js
+++ b/app.js
@@ -12,7 +12,7 @@ import {
   manifestTotals, freeAddUnits, manifestLine, freeManifestLine, hydrateManifestLine, stationLabel, parseStationLabel, stationTree,
   multiTrips, tripMetrics, legFromTrip,
   legFromRoute, legFromManifest, stopSuggestions, bestLegBetween,
-  manifestJourneyState, manifestIntent, sameIntent, manifestIntentSurvives, journeyMap,
+  manifestJourneyState, manifestIntent, sameIntent, manifestIntentSurvives,
   loadHold, declarerLot, holdScu, freeCargo, holdByCommodity, sellFromHold, refuseHere, refusActif, migrerRefus, sellableAt, sellAllAt,
   offloadPlan, tourneesEcoulement, storeFromHold, takeFromStore, stockApres,
   startJourney, startJourneyAt, journeyStations, journeyEnd,
@@ -36,7 +36,7 @@ import { showToast } from "./messages.ts";
 import { construireIndex, findCommodity, indexOrigine, indexStationExacte, libellesOrigines, libellesStations, resolveStationLabel, stationCourante, stationMap, termByName } from "./marche.ts";
 import { alKey, feeCargoText, feeCell, feeCtx, feeEndText, feeLoadText, feeResolver, globalK, kFmt, lineProfitText, loadAutoloadK, saveAutoloadK } from "./frais.ts";
 import { applyState, loadState, saveState, shareURL } from "./persistance.ts";
-import { brancher, ensureFeeMarket, ensureStarmap, withMarket } from "./donnees.ts";
+import { brancher, ensureFeeMarket, withMarket } from "./donnees.ts";
 import { brancherRendu } from "./rendu.ts";
 import { propsLignesSimples, propsTrajetsCommunes } from "./vues/trajets-props.tsx";
 import { evaluate } from "./vues/trajets-vue.tsx";
@@ -54,7 +54,6 @@ import { vueTrajets } from "./vues/trajets.tsx";
 import { carteManifeste, indiceSouteInactive, indiceSoutePleine, indiceAucunChargement } from "./vues/manifeste.tsx";
 import { carteSoute, carteEntrepots } from "./vues/soute.tsx";
 import { carteVoyage, recapVoyage, inviteVoyage } from "./vues/voyage.tsx";
-import { carteParcours } from "./vues/carte.tsx";
 import { carteDeclaration } from "./vues/declaration.tsx";
 import { BUY_STATUS, KIND_ICON, SELL_STATUS } from "./vues/communs.tsx";
 
@@ -1028,26 +1027,10 @@ function renderSoute(synchrone = false) {
 // que le branchement à l'état — les globales JOURNEY / MARKET / STARMAP, qu'un îlot ne lit pas.
 
 // Dessine (ou masque) le panneau carte. Appelé par renderJourney, donc à chaque refresh.
-function renderJourneyMap() {
-  const box = $("journeyMap");
-  if (!box) return;
-  // Masquer NE SUFFIT PAS : le conteneur reste possédé par React, donc on le repeint à vide. Une
-  // branche qui se contenterait de poser `hidden` laisserait le dessin précédent en place, prêt à
-  // réapparaître tel quel — c'est la même règle que pour les messages vides des autres îlots.
-  if (!etat.JOURNEY || !etat.MARKET) { box.hidden = true; peindre(box, null); return; }
-  if (!etat.STARMAP) { ensureStarmap(renderJourneyMap); box.hidden = true; peindre(box, null); return; }
-  const info = (nom) => {
-    const i = stationMap.get(stationLabel(nom, (journeyStations(etat.JOURNEY).find((s) => s.name === nom) || {}).system || ""));
-    return i == null ? null : etat.MARKET.terminals[i];
-  };
-  // Jambe courante chargée = on a payé et on est parti : le vaisseau quitte le quai sur la carte.
-  const legCourante = etat.JOURNEY.legs[etat.JOURNEY.current];
-  const enVol = !!legCourante && jambeChargee(legCourante, etat.JOURNEY.current);
-  const c = journeyMap(journeyStations(etat.JOURNEY), etat.JOURNEY.current, etat.STARMAP, info, enVol);
-  if (!c) { box.hidden = true; peindre(box, null); return; }
-  box.hidden = false;
-  peindre(box, carteParcours(c));
-}
+// `renderJourneyMap` est passée dans `vues/carte-vue.tsx`, avec une garde `si="plan"` : elle était
+// rejouée à chaque `refresh()` depuis les huit vues, pour un <aside> que sept d'entre elles
+// n'affichent pas (ADR-012).
+
 
 // ---------- Compagnon de voyage : résumé du parcours (près du vaisseau) ----------
 // `pickJourney` et `syncViewsToJourney` sont passées dans `voyage-actions.ts` : les QUATRE vues qui
@@ -1316,7 +1299,6 @@ function renderJourney({ frappe = false } = {}) {
     card.hidden = false;
     const recap0 = $("journeyRecap"); if (recap0) { recap0.hidden = true; peindre(recap0, null); } // pas de récap sans voyage
     const row0 = $("shipJourneyRow"); if (row0) row0.classList.remove("stacked");
-    renderJourneyMap();
     renderSoute();
     renderEntrepots();
     peindre(card, inviteVoyage(), { synchrone: true });
@@ -1385,7 +1367,6 @@ function renderJourney({ frappe = false } = {}) {
   }), { synchrone: true });
 
   renderJourneyRecap({ n, totalProfit, totalScu, totalFees, systems: new Set(stations.map((s) => s.system)).size });
-  renderJourneyMap();
   // SYNCHRONES, les quatre : `ajusterRangeeVoyage` MESURE les hauteurs juste en dessous
   // (`getBoundingClientRect`) pour décider d'empiler les colonnes. Un rendu React groupé les lui
   // ferait lire AVANT peinture — la carte basculait de 1172 px à 640 px de large selon l'état,

--- a/app.js
+++ b/app.js
@@ -38,12 +38,13 @@ import { alKey, feeCargoText, feeCell, feeCtx, feeEndText, feeLoadText, feeResol
 import { applyState, loadState, saveState, shareURL } from "./persistance.ts";
 import { brancher, ensureFeeMarket, withMarket } from "./donnees.ts";
 import { brancherRendu } from "./rendu.ts";
+import { manifestRemaining, suggestionsFor } from "./manifeste-donnees.ts";
 import { propsLignesSimples, propsTrajetsCommunes } from "./vues/trajets-props.tsx";
 import { evaluate } from "./vues/trajets-vue.tsx";
 import { pickJourney, syncViewsToJourney } from "./voyage-actions.ts";
 import { monterRacine } from "./main.tsx";
 import { planData, planHypotheses } from "./vues/plan-vue.tsx";
-import { figerJambe, jambeChargee, journeyCarriedCommodities, legEffectiveLines, legFeeCtx, legIntent, legKey, legManifest, legTerminals, loadJourneyEdits, loadJourneyPins, pinLegsForVolume, saveJourneyEdits, saveJourneyPins } from "./voyage-donnees.ts";
+import { figerJambe, jambeChargee, legSuggestCtx, journeyCarriedCommodities, legEffectiveLines, legFeeCtx, legIntent, legKey, legManifest, legTerminals, loadJourneyEdits, loadJourneyPins, pinLegsForVolume, saveJourneyEdits, saveJourneyPins } from "./voyage-donnees.ts";
 // (`vues/tournee.tsx` et `vues/plan.tsx` ne sont plus importés ici : leurs vues vivent dans l'arbre
 // depuis #143 et #145, et seuls leurs composants de DÉCISION les consomment désormais.)
 // La vue Commodités n'expose plus sa présentation à app.js — seulement ses trois ACTIONS, comme
@@ -410,16 +411,11 @@ function manifesteSansOptimal(originIdx, destIdx, f) {
 // Espace/budget restants d'après les SCU actuellement affectés.
 // m = contexte de manifeste { lines, cargo, f, originIdx, destIdx, origin, dest } ; par défaut
 // celui d'« En route », mais une jambe de voyage passe le sien (cf. legSuggestCtx).
-function manifestRemaining(m = currentManifest) {
-  const { scu, invest } = manifestTotals(m.lines);
-  const budgetLeft = m.f.useBudget && m.f.budget > 0 ? m.f.budget - invest : Infinity;
-  return { scu, invest, cargoLeft: m.cargo - scu, budgetLeft };
-}
+
 
 // Commodités qui pourraient remplir l'espace libre (même origine -> même destination), non chargées.
 // Le calcul vit dans logic.mjs (partagé avec le manifeste optimal, donc éligibilité identique) ;
 // app.js ne fournit que le marché et le résolveur de corrections.
-const suggestionsFor = (m = currentManifest) => suggestionsFrom(etat.MARKET, m, effVals);
 
 // addableUnits vient de logic.mjs.
 
@@ -430,9 +426,10 @@ const suggestionsFor = (m = currentManifest) => suggestionsFrom(etat.MARKET, m, 
 // et n'a plus lieu d'être : deux fabriques du même bloc auraient fini par diverger.
 
 function addSuggestion(name) {
-  const it = suggestionsFor().find((x) => x.name === name);
+  if (!currentManifest) return;
+  const it = suggestionsFor(currentManifest).find((x) => x.name === name);
   if (!it) return;
-  const u = addableUnits(it, manifestRemaining());
+  const u = addableUnits(it, manifestRemaining(currentManifest));
   if (u <= 0) return;
   currentManifest.lines.push({ ...it, units: u, cap: u });
   retenirManifeste();
@@ -449,7 +446,7 @@ function addManifestCommodity(name) {
   if (!m || !etat.MARKET) return;
   const c = findCommodity(name);
   if (!c || m.lines.some((l) => l.name === c.name)) return; // inconnue ou déjà dans le manifeste
-  m.lines.push(freeManifestLine(etat.MARKET, m.originIdx, m.destIdx, c, manifestRemaining().cargoLeft, effVals));
+  m.lines.push(freeManifestLine(etat.MARKET, m.originIdx, m.destIdx, c, manifestRemaining(m).cargoLeft, effVals));
   retenirManifeste();
   paintManifest();
 }
@@ -1105,20 +1102,7 @@ function manifestToJourney() {
 
 // Contexte de manifeste d'une jambe, à la forme attendue par suggestionsFor/manifestRemaining
 // (mêmes suggestions de remplissage qu'« En route »). null si le terminal ou la soute manque.
-function legSuggestCtx(leg, lines, f) {
-  if (!etat.MARKET || !stationMap.size) return null;
-  if (!f.useCargo || !(f.cargo > 0)) return null; // sans soute bornée, « SCU libres » n'a pas de sens
-  const originIdx = stationMap.get(stationLabel(leg.from, leg.fromSystem));
-  const destIdx = stationMap.get(stationLabel(leg.to, leg.toSystem));
-  if (originIdx == null || destIdx == null) return null;
-  const ctx = legFeeCtx(leg, f);
-  return {
-    lines, originIdx, destIdx,
-    origin: { name: leg.from, system: leg.fromSystem },
-    dest: { name: leg.to, system: leg.toSystem },
-    cargo: f.cargo, f, fee: ctx && ctx.pair, // même filtrage des suggestions qu'« En route »
-  };
-}
+
 
 // Actions d'édition d'une jambe (i = index de jambe).
 function toggleLegEditor(i) {

--- a/e2e/arbre.pw.mjs
+++ b/e2e/arbre.pw.mjs
@@ -176,3 +176,21 @@ test("Trajets : une correction ouverte pendant un re-tri reste sur SA commodité
     await expect(ouvert.first(), "l'éditeur a changé de commodité sous les doigts").toHaveAttribute("data-c", commodite);
   }
 });
+
+test("Arbre : la carte du parcours ne se redessine pas hors du Plan de vol", async ({ page }) => {
+  // Elle vit DANS la section du Plan, donc une vue sur huit — mais elle était repeinte à chaque
+  // rendu depuis les sept autres, géométrie de tous les arrêts recalculée pour un <aside> masqué.
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+  await page.locator("#rows tr").first().locator(".journey-pick").click();
+  await page.click("#viewPlan");
+  await expect(page.locator("#journeyMap svg")).toBeVisible({ timeout: 20000 });
+
+  await page.click("#viewRoutes");
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+
+  const lots = await compterLots(page, "journeyMap");
+  await page.locator("#search").pressSequentially("Laranite", { delay: 30 });
+  await expect(page).toHaveURL(/search=Laranite/, { timeout: 10000 });
+
+  expect(await lots(), "la carte du parcours a été redessinée hors du Plan de vol").toBe(0);
+});

--- a/e2e/arbre.pw.mjs
+++ b/e2e/arbre.pw.mjs
@@ -229,3 +229,23 @@ test("Manifeste : la composition survit à un rendu, et s'abandonne au changemen
   await page.fill("#origin", autre);
   await expect.poll(compo, { timeout: 8000 }).toBeNull();
 });
+
+test("Arbre : taper depuis les Trajets ne recalcule pas la carte de chargement", async ({ page }) => {
+  // La dernière vue à emménager, et la plus chère à recalculer pour rien : `bestManifest` remplit
+  // une soute par marge décroissante sur tout le marché, puis `enRouteDeals` reprend une vente par
+  // commodité.
+  await page.click("#viewEnroute");
+  await expect(page.locator("#originList option").first()).toBeAttached({ timeout: 20000 });
+  const origine = await page.locator("#originList option").first().getAttribute("value");
+  await page.fill("#origin", origine);
+  await expect(page.locator("#manifest")).toBeVisible();
+
+  await page.click("#viewRoutes");
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+
+  const lots = await compterLots(page, "manifest");
+  await page.locator("#search").pressSequentially("Laranite", { delay: 30 });
+  await expect(page).toHaveURL(/search=Laranite/, { timeout: 10000 });
+
+  expect(await lots(), "la carte de chargement a été recalculée depuis les Trajets").toBe(0);
+});

--- a/e2e/arbre.pw.mjs
+++ b/e2e/arbre.pw.mjs
@@ -194,3 +194,38 @@ test("Arbre : la carte du parcours ne se redessine pas hors du Plan de vol", asy
 
   expect(await lots(), "la carte du parcours a été redessinée hors du Plan de vol").toBe(0);
 });
+
+// La composition manuelle d'un chargement s'écrivait — et se PERSISTAIT — en pleine phase de rendu :
+// `compositionEnCours` décidait de l'abandonner, effaçait `localStorage`, tout ça pendant qu'on
+// dessinait. C'est l'un des trois chemins qu'`etat.ts` cite pour refuser un magasin qui notifierait
+// à l'écriture, et sous React une écriture pendant le rendu qui déclenche un rendu est une boucle.
+//
+// La décision est la MÊME (`compositionValide`, restée pure), mais c'est le GESTE qui l'applique.
+// Ce test tient les deux bouts : la composition survit à un rendu qui n'a rien à voir avec elle,
+// et elle est bel et bien abandonnée quand on change de route.
+test("Manifeste : la composition survit à un rendu, et s'abandonne au changement de route", async ({ page }) => {
+  const compo = () => page.evaluate(() => localStorage.getItem("best-hauling-manifest-edit"));
+
+  await page.click("#viewEnroute");
+  await expect(page.locator("#originList option").first()).toBeAttached({ timeout: 20000 });
+  const origine = await page.locator("#originList option").first().getAttribute("value");
+  await page.fill("#origin", origine);
+  await expect(page.locator("#manifest")).toBeVisible();
+  test.skip(!(await page.locator("#manifest .mline-del").count()), "aucun chargement rentable depuis ce terminal");
+
+  // Un geste de composition : on retire une ligne. La carte devient « à soi ».
+  await page.locator("#manifest .mline-del").first().click();
+  await expect.poll(compo, { timeout: 5000 }).not.toBeNull();
+
+  // Un rendu qui n'a RIEN à voir : une frappe dans la recherche. La composition doit survivre —
+  // avant, le rendu pouvait décider de l'abandonner au passage.
+  const avant = await compo();
+  await page.fill("#search", "a");
+  await expect(page).toHaveURL(/search=a/, { timeout: 10000 });
+  await expect.poll(compo, { timeout: 5000 }).toBe(avant);
+
+  // Changer de route, en revanche, l'abandonne — et c'est bien le GESTE qui le fait.
+  const autre = await page.locator("#originList option").nth(3).getAttribute("value");
+  await page.fill("#origin", autre);
+  await expect.poll(compo, { timeout: 8000 }).toBeNull();
+});

--- a/manifeste-donnees.test.mjs
+++ b/manifeste-donnees.test.mjs
@@ -1,0 +1,58 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { manifestRemaining } from "./manifeste-donnees.ts";
+
+// Ces tests n'étaient pas ÉCRIVABLES avant le lot qui a sorti la fonction d'`app.js` : son contexte
+// retombait sur `currentManifest`, une globale de module qu'aucun test ne pouvait poser. C'est tout
+// l'intérêt du paramètre requis — la fonction sert DEUX porteurs (la carte d'« En route » et une
+// jambe du parcours), et rien ne le prouvait.
+
+const ligne = (name, units, buyPrice) => ({ name, units, buyPrice, sellPrice: buyPrice * 2, margin: buyPrice });
+
+test("manifestRemaining : ce qui reste, avec un contexte EXPLICITE", () => {
+  const m = {
+    lines: [ligne("A", 30, 100), ligne("B", 20, 50)],
+    originIdx: 0, destIdx: 1, origin: { name: "X" }, dest: { name: "Y" },
+    cargo: 96, f: { useBudget: true, budget: 10_000 },
+  };
+  const r = manifestRemaining(m);
+  assert.equal(r.scu, 50);              // 30 + 20
+  assert.equal(r.invest, 4_000);        // 30×100 + 20×50
+  assert.equal(r.cargoLeft, 46);        // 96 − 50
+  assert.equal(r.budgetLeft, 6_000);    // 10 000 − 4 000
+});
+
+test("manifestRemaining : budget éteint = AUCUNE borne, et surtout pas zéro", () => {
+  // Une contrainte désactivée ne borne rien. `budgetLeft: 0` ferait refuser tout ajout, en
+  // silence : le bouton de suggestion resterait là et ne ferait plus rien.
+  const base = { lines: [ligne("A", 10, 100)], originIdx: 0, destIdx: 1, origin: { name: "X" }, dest: { name: "Y" }, cargo: 96 };
+  assert.equal(manifestRemaining({ ...base, f: { useBudget: false, budget: 10_000 } }).budgetLeft, Infinity);
+  assert.equal(manifestRemaining({ ...base, f: { useBudget: true, budget: 0 } }).budgetLeft, Infinity);
+});
+
+test("manifestRemaining : un contexte de JAMBE se calcule exactement pareil", () => {
+  // La forme que `legSuggestCtx` (voyage-donnees.ts) fabrique : mêmes clés, plus `system` et `fee`.
+  // C'est ce test qui interdit de redescendre un jour cette fonction dans « En route ».
+  const jambe = {
+    lines: [ligne("Laranite", 64, 2_500)],
+    originIdx: 3, destIdx: 7,
+    origin: { name: "Megumi", system: "Pyro" },
+    dest: { name: "Checkmate", system: "Pyro" },
+    cargo: 96, f: { useCargo: true, cargo: 96, useBudget: false, budget: 0 },
+    fee: null,
+  };
+  const r = manifestRemaining(jambe);
+  assert.equal(r.scu, 64);
+  assert.equal(r.cargoLeft, 32);
+  assert.equal(r.budgetLeft, Infinity);
+});
+
+test("manifestRemaining : une soute déjà dépassée rend un reste NÉGATIF, jamais zéro", () => {
+  // Le manifeste est ajustable à la main et peut dépasser la soute (vol de fret, relevé périmé) :
+  // c'est ce négatif que la carte affiche en « 120/96 SCU ». Le borner à zéro effacerait le signal.
+  const m = {
+    lines: [ligne("A", 120, 10)], originIdx: 0, destIdx: 1,
+    origin: { name: "X" }, dest: { name: "Y" }, cargo: 96, f: {},
+  };
+  assert.equal(manifestRemaining(m).cargoLeft, -24);
+});

--- a/manifeste-donnees.ts
+++ b/manifeste-donnees.ts
@@ -14,7 +14,7 @@
 // interdisait.
 
 import { manifestTotals, suggestionsFrom } from "./logic.ts";
-import type { ContexteManifeste } from "./types.ts";
+
 import { etat } from "./etat.ts";
 import { effVals } from "./corrections.ts";
 
@@ -32,3 +32,109 @@ export function manifestRemaining(m: ContexteManifeste) {
 
 /** Ce qu'on pourrait ajouter pour combler la place libre, dans ce contexte-là. */
 export const suggestionsFor = (m: ContexteManifeste) => suggestionsFrom(etat.MARKET, m, effVals);
+
+// ── LE CHARGEMENT COURANT, DÉRIVÉ ET NON MIS EN CACHE ─────────────────────────────────────────
+// `currentManifest` était une globale d'`app.js` : écrite en tête du rendu de la carte, relue au
+// clic par les six gestes de composition. Le motif que la migration élimine partout — et ici il
+// coûtait plus cher qu'ailleurs, parce qu'un geste fait avant le premier rendu de la carte lisait
+// `null` sans rien dire.
+//
+// Elle devient une DÉRIVATION, sur le patron d'`indexOrigine` (marche.ts) : « une valeur dérivée
+// qu'il faut penser à recalculer est une valeur qui sera un jour lue périmée ». Le coût est un
+// `bestManifest` par geste — le même que celui du rendu que le geste déclenche de toute façon.
+
+import { bestManifest, hydrateManifestLine, stationLabel } from "./logic.ts";
+import type { ContexteManifeste, Filtres, FiltresVolume, LigneManifeste, PaireFrais, Terminal } from "./types.ts";
+import { freeCargo, holdScu } from "./logic.ts";
+import { feeCtx, feeResolver } from "./frais.ts";
+import { findCommodity, indexArriveeForcee, indexOrigine, stationMap } from "./marche.ts";
+import { compositionValide } from "./manifeste-etat.ts";
+
+const champ = (id: string): string =>
+  (document.getElementById(id) as HTMLInputElement | null)?.value ?? "";
+
+/** Les lignes d'une composition, RELUES au marché courant : un prix corrigé s'affiche, les SCU non. */
+const lignesComposees = (lignes: { name: string; units: number }[], fromIdx: number, toIdx: number) =>
+  lignes.map((e) => hydrateManifestLine(etat.MARKET!, fromIdx, toIdx, findCommodity(e.name), e.units, effVals));
+
+/**
+ * Le chargement affiché par la carte d'« En route » — ou une RAISON de ne rien afficher.
+ *
+ * Rend `{ etat: "sans-depart" | "soute-inactive" | "soute-pleine" | "aucun" }` quand il n'y a rien
+ * à charger, et `{ etat: "ok", m }` sinon. Les quatre cas étaient quatre retours anticipés de
+ * `renderManifest` : les nommer, c'est ce qui permet à la vue de choisir son message sans
+ * reproduire la décision.
+ */
+/**
+ * Le chargement ENRICHI que la carte consomme : ce que `bestManifest` rend, plus les trois choses
+ * qu' y accrochait à la main — le départ, les filtres retenus, ce qui est déjà à bord, et
+ * le contexte de frais. Les nommer, c'est ce qui a permis à `tsc` de voir la carte pour la
+ * première fois : elles étaient posées sur un objet non typé.
+ */
+export type ChargementCourant = {
+  lines: LigneManifeste[]; cargo: number; aBord: number; cross: boolean;
+  origin: Terminal; originIdx: number; dest: Terminal; destIdx: number;
+  fee: PaireFrais | null; feeInfo: ReturnType<typeof feeCtx>;
+  profit: number; f: Filtres & FiltresVolume;
+};
+
+export function manifesteCourant(f: Filtres & FiltresVolume) {
+  const origin = indexOrigine();
+  if (origin == null || !etat.MARKET) return { etat: "sans-depart" as const };
+  if (!f.useCargo || !(f.cargo > 0)) return { etat: "soute-inactive" as const };
+
+  // La soute n'est pas vide : on ne peut charger QUE la place qui reste. C'est la question de
+  // l'ADR-002 — « j'ai 30 SCU de libre, qu'est-ce que j'y mets maintenant ? ». Les autres vues
+  // gardent la soute nominale : elles répondent à « quelle est la meilleure route ».
+  const aBord = holdScu(etat.SOUTE);
+  const libre = freeCargo(etat.SOUTE, f.cargo);
+  if (aBord > 0 && libre <= 0) return { etat: "soute-pleine" as const, aBord };
+
+  const fLibre = aBord > 0 ? { ...f, cargo: libre } : f;
+  const destSystem = champ("destSystem");
+  const destTerminal = indexArriveeForcee();
+  const ot = etat.MARKET.terminals[origin];
+  const dt = destTerminal == null ? null : etat.MARKET.terminals[destTerminal];
+
+  // Une composition en cours IMPOSE sa destination : laisser la carte se re-router toute seule sous
+  // une correction de prix ferait disparaître de l'écran le chargement qu'on est en train de
+  // composer — le symptôme même qu'on corrige.
+  const compo = compositionValide(
+    { name: ot.name, system: ot.system },
+    dt && { name: dt.name, system: dt.system },
+    destSystem,
+    (nom, systeme) => stationMap.get(stationLabel(nom, systeme)),
+    findCommodity,
+  );
+  const cible = compo ? compo.destIdx : destTerminal;
+  const man = bestManifest(etat.MARKET, origin, destSystem, fLibre, effVals, cible, feeResolver(f))
+    || (compo ? manifesteSansOptimal(origin, cible!, fLibre) : null);
+  if (!man) return { etat: "aucun" as const, aBord, libre };
+
+  // Les lignes EFFECTIVES : celles de l'utilisateur, moins ce qu'UEX ne publie plus.
+  const carte = man as unknown as ChargementCourant;
+  if (compo) carte.lines = lignesComposees(compo.lignes, origin, cible!);
+  carte.originIdx = origin;
+  carte.f = fLibre;
+  carte.aBord = aBord; // pour que la carte dise pourquoi elle ne remplit que ça
+  // `man.fee` vient de `bestManifest` : on ne le reconstruit pas, donc on ne risque pas de le
+  // reconstruire AUTREMENT que ce qui a servi à choisir la destination.
+  carte.feeInfo = feeCtx(f, carte.origin.name, carte.dest.name, carte.origin, carte.dest);
+  return { etat: "ok" as const, m: carte, aBord, libre };
+}
+
+/**
+ * Une carte VIDE sur une route imposée par la composition.
+ *
+ * Existe pour le cas où `bestManifest` ne trouve rien mais qu'une composition manuelle désigne
+ * quand même cette arrivée : sans elle, la carte que l'utilisateur vient de composer disparaîtrait.
+ */
+function manifesteSansOptimal(originIdx: number, destIdx: number, f: Filtres & FiltresVolume) {
+  const ot = etat.MARKET!.terminals[originIdx], dt = etat.MARKET!.terminals[destIdx];
+  const point = feeResolver(f);
+  return {
+    origin: ot, originIdx, dest: dt, destIdx, cross: ot.system !== dt.system,
+    lines: [] as ReturnType<typeof lignesComposees>, profit: 0, cargo: f.cargo,
+    fee: point ? { buy: point(ot), sell: point(dt) } : null,
+  } as ReturnType<typeof bestManifest>;
+}

--- a/manifeste-donnees.ts
+++ b/manifeste-donnees.ts
@@ -1,0 +1,34 @@
+// Le CHARGEMENT : ce qu'il reste à remplir, et de quoi (ADR-012).
+//
+// Ces deux fonctions ont l'air d'appartenir à la vue « En route » — elles y sont nées, et leur
+// paramètre retombait sur `currentManifest`, la globale de cette vue. C'est FAUX : le compagnon de
+// voyage les appelle quatre fois avec un contexte de JAMBE, fabriqué par `legSuggestCtx`.
+//
+// Le défaut par défaut cachait cette double appartenance, et il l'aurait fait payer cher : descendre
+// ces fonctions dans le composant d'« En route » aurait cassé le compagnon, et le symptôme serait
+// arrivé tard — les suggestions ne sont calculées que pour la jambe DÉPLIÉE, donc un test qui ne
+// déplie pas ne verrait rien.
+//
+// Le contexte devient donc un paramètre REQUIS. Ce n'est pas une précaution de style : c'est ce qui
+// rend ces deux fonctions testables unitairement, ce qu'une retombée sur une globale de module
+// interdisait.
+
+import { manifestTotals, suggestionsFrom } from "./logic.ts";
+import type { ContexteManifeste } from "./types.ts";
+import { etat } from "./etat.ts";
+import { effVals } from "./corrections.ts";
+
+/**
+ * Ce qu'il reste à charger dans un contexte donné — celui d'« En route » comme celui d'une jambe.
+ *
+ * `budgetLeft` vaut `Infinity` quand l'interrupteur de budget est éteint, et non zéro : une
+ * contrainte désactivée ne borne rien.
+ */
+export function manifestRemaining(m: ContexteManifeste) {
+  const { scu, invest } = manifestTotals(m.lines);
+  const budgetLeft = m.f.useBudget && m.f.budget > 0 ? m.f.budget - invest : Infinity;
+  return { scu, invest, cargoLeft: m.cargo - scu, budgetLeft };
+}
+
+/** Ce qu'on pourrait ajouter pour combler la place libre, dans ce contexte-là. */
+export const suggestionsFor = (m: ContexteManifeste) => suggestionsFrom(etat.MARKET, m, effVals);

--- a/manifeste-etat.ts
+++ b/manifeste-etat.ts
@@ -1,0 +1,109 @@
+// La COMPOSITION MANUELLE d'un chargement : sa persistance, et sa survie (ADR-012).
+//
+// Le PARCOURS va dans l'URL ; la composition qu'on ajuste à la main reste LOCALE. On ne persiste
+// que l'INTENTION — `[{ name, units }]` plus les deux bouts de la route — jamais un instantané de
+// marché : figé, il continuerait d'afficher le prix du jour de l'édition longtemps après qu'UEX
+// l'ait republié. Même règle que les manifestes de jambe (`voyage-donnees.ts`).
+//
+// ── LE RENDU N'ÉCRIT PLUS ─────────────────────────────────────────────────────────────────────
+// `compositionEnCours` faisait trois écritures d'état ET de `localStorage` en pleine phase de
+// rendu. C'est l'un des trois chemins que l'en-tête d'`etat.ts` cite pour refuser un magasin qui
+// notifierait à l'écriture — et sous React, une écriture pendant le rendu qui déclenche un rendu
+// est une boucle à deux passes.
+//
+// La réponse n'est pas « dérivation » ou « effet », c'est LES DEUX, scindés en trois :
+//   1. la SURVIE de la composition est une DÉRIVATION — `manifestIntentSurvives` (logic.ts) est
+//      déjà pure, et `destIdx` se relit à chaque fois ;
+//   2. la PURGE des commodités disparues d'UEX est une DÉRIVATION aussi : on filtre à l'affichage
+//      et on ne persiste rien. Le prochain geste de composition réécrit l'objet entier de toute
+//      façon, donc rien ne se perd ;
+//   3. l'ABANDON est un GESTE : c'est `oublierComposition()`, appelée par ce qui CHANGE de route.
+//      Le laisser au rendu, c'était faire décider par l'affichage ce que l'utilisateur avait fait.
+
+import { manifestIntent, manifestIntentSurvives } from "./logic.ts";
+import type { CompositionManifeste, LigneManifeste } from "./types.ts";
+import { etat } from "./etat.ts";
+
+const CLE_STOCKAGE = "best-hauling-manifest-edit";
+
+export function loadManifestEdit(): void {
+  try {
+    etat.MANIFEST_EDIT = JSON.parse(localStorage.getItem(CLE_STOCKAGE) || "null") || null;
+  } catch {
+    etat.MANIFEST_EDIT = null;
+  }
+  // Toute forme dont `lines` n'est pas un tableau est invalide : elle ferait planter le premier
+  // rendu qui la lit, et une composition illisible ne vaut pas mieux qu'aucune.
+  if (!etat.MANIFEST_EDIT || !Array.isArray(etat.MANIFEST_EDIT.lines)) etat.MANIFEST_EDIT = null;
+}
+
+export function saveManifestEdit(): void {
+  try {
+    if (etat.MANIFEST_EDIT) localStorage.setItem(CLE_STOCKAGE, JSON.stringify(etat.MANIFEST_EDIT));
+    else localStorage.removeItem(CLE_STOCKAGE);
+  } catch {}
+}
+
+/**
+ * Retient ce qui est à l'écran comme intention.
+ *
+ * Appelée par CHAQUE geste de composition — ajout suggéré, ajout libre, retrait, SCU ajustés —
+ * parce que c'est le GESTE qui fait la composition, pas son résultat : deux gestes qui se
+ * compensent laissent quand même une carte à soi.
+ */
+export function retenirComposition(m: {
+  origin: { name: string; system: string }; dest: { name: string; system: string };
+  lines: LigneManifeste[];
+} | null): void {
+  if (!m) return;
+  etat.MANIFEST_EDIT = {
+    from: m.origin.name, fromSystem: m.origin.system,
+    to: m.dest.name, toSystem: m.dest.system,
+    lines: manifestIntent(m.lines),
+  } as CompositionManifeste;
+  saveManifestEdit();
+}
+
+/** L'abandon. Un GESTE — ce qui change de route l'appelle, le rendu jamais. */
+export function oublierComposition(): void {
+  etat.MANIFEST_EDIT = null;
+  saveManifestEdit();
+}
+
+/**
+ * La composition vaut-elle pour la route demandée, et où va-t-elle ?
+ *
+ * PURE : elle ne lit que l'état et rend une réponse. Rien n'est écrit, rien n'est persisté — c'est
+ * ce qui la rend appelable depuis un rendu. Rend `null` quand la composition ne vaut pas pour cette
+ * route, ou qu'il n'en reste rien après la purge des commodités disparues.
+ *
+ * `lignes` est la composition EFFECTIVE : celle de l'utilisateur, moins ce qu'UEX ne publie plus.
+ * La purge est un FILTRE et non une écriture — mais les SCU sont adressés par index de ligne
+ * (`data-i`), donc l'écran et l'intention affichée doivent être le MÊME tableau, jamais deux.
+ */
+export function compositionValide(
+  origine: { name: string; system: string },
+  arrivee: { name: string; system: string } | null,
+  systemeArrivee: string,
+  indexDe: (nom: string, systeme: string) => number | null | undefined,
+  connait: (nom: string) => unknown,
+): { edit: CompositionManifeste; lignes: CompositionManifeste["lines"]; destIdx: number } | null {
+  const edit = etat.MANIFEST_EDIT;
+  if (!edit) return null;
+
+  const destIdx = indexDe(edit.to, edit.toSystem);
+  const vivante = destIdx != null && manifestIntentSurvives(edit, {
+    from: origine,
+    dest: arrivee,
+    destSystem: systemeArrivee,
+  });
+  if (!vivante) return null;
+
+  // Commodité disparue d'UEX : écartée plutôt qu'affichée en fantôme, comme sur une jambe.
+  const lignes = edit.lines.filter((e) => connait(e.name));
+  // Vidée par cette purge, et non par un geste : la composition ne parlait plus que de commodités
+  // qui n'existent plus, la carte reprend son calcul. Vidée à la main, elle reste (cf. logic.ts).
+  if (!lignes.length) return null;
+
+  return { edit, lignes, destIdx: destIdx as number };
+}

--- a/manifeste-etat.ts
+++ b/manifeste-etat.ts
@@ -107,3 +107,18 @@ export function compositionValide(
 
   return { edit, lignes, destIdx: destIdx as number };
 }
+
+// ── LA GÉNÉRATION DE LA CARTE ─────────────────────────────────────────────────────────────────
+// Elle distingue les DEUX façons de repeindre le chargement, et c'est tout ce qui reste du
+// comportement de l'ancien `innerHTML` :
+//   — un RECALCUL (départ changé, « ↺ optimal », prix corrigé…) : les champs SCU doivent adopter
+//     les nouvelles valeurs, donc ils se remontent — d'où la génération dans leur `key` ;
+//   — une FRAPPE : la génération ne bouge pas, le champ garde son nœud, sa valeur et son curseur.
+//
+// Sans elle, un champ non contrôlé garderait à jamais ce que l'utilisateur y a tapé : « ↺ optimal »
+// remettait `value="96"` dans l'attribut pendant que le champ affichait encore 30.
+let generation = 0;
+
+/** Appelée par le cycle de rendu complet, jamais par la frappe. */
+export const nouvelleGenerationManifeste = (): void => { generation++; };
+export const generationManifeste = (): number => generation;

--- a/marche.ts
+++ b/marche.ts
@@ -135,3 +135,15 @@ export function stationCourante(): number | null {
 /** Une commodité par son nom OU son code UEX. `null` si le marché n'est pas là ou si rien ne colle. */
 export const findCommodity = (name: string) =>
   etat.MARKET ? resolveCommodity(etat.MARKET.commodities, name) : null;
+
+/**
+ * Le terminal d'ARRIVÉE forcé de la vue « En route », dérivé du champ `#destTerminal`.
+ *
+ * Vif comme ses trois voisins ci-dessus, et pour la même raison : c'était une globale
+ * `enrouteDest` qu'une fonction `resolveDest()` rafraîchissait en tête de rendu. Tous ses lecteurs
+ * dépendaient donc d'avoir été appelés APRÈS elle.
+ */
+export const indexArriveeForcee = (): number | null => {
+  const v = champ("destTerminal");
+  return stationMap.has(v) ? (stationMap.get(v) as number) : null;
+};

--- a/types.ts
+++ b/types.ts
@@ -780,9 +780,21 @@ export type MetriquesTrajet = {
   fiabilite: number; fees: number; nLines: number; commodity: string; buyPrice: number; sellPrice: number;
 };
 
+/** Un chargement EN COURS, quel que soit le porteur : la carte d'« En route » ou une jambe du
+ *  parcours. `suggestionsFrom` (logic.ts) n'en lit que la moitié — `lines`, `destIdx`, `f` — mais
+ *  `manifestRemaining` (manifeste-donnees.ts) a besoin de `cargo` pour dire combien il reste, et
+ *  `legSuggestCtx` le fabrique complet. Le type porte donc la forme RÉELLE, pas le sous-ensemble
+ *  d'un seul lecteur : c'est ce qui permet aux deux porteurs de passer par les mêmes fonctions. */
 export type ContexteManifeste = {
   lines: Array<{ name: string }>; originIdx: number; destIdx: number;
-  origin: { name: string }; dest: { name: string }; f: Filtres;
+  /** Le `system` accompagne le nom parce que `legSuggestCtx` l'a sous la main et que la carte
+   *  l'affiche ; `suggestionsFrom` ne lit que le nom. */
+  origin: { name: string; system?: string }; dest: { name: string; system?: string }; f: Filtres;
+  /** Le plafond de soute retenu. `legSuggestCtx` refuse de fabriquer un contexte sans lui : sans
+   *  soute bornée, « SCU libres » n'a aucun sens. */
+  cargo: number;
+  /** Le contexte de frais de la paire, quand l'autoload est actif. */
+  fee?: PaireFrais | null;
 };
 
 export type ChiffrageSaut = { units: number; profit: number; lines: LigneManifeste[]; cargo: number };

--- a/voyage-donnees.ts
+++ b/voyage-donnees.ts
@@ -20,7 +20,7 @@
 import {
   bestManifest, legsToPin, manifestIntent, manifestIntentSurvives, hydrateManifestLine,
 } from "./logic.ts";
-import type { CoteMarche, Filtres, Jambe, LigneManifeste } from "./types.ts";
+import type { ContexteManifeste, CoteMarche, Filtres, Jambe, LigneManifeste } from "./types.ts";
 import { etat } from "./etat.ts";
 import { stationLabel } from "./logic.ts";
 import { readFilters } from "./filtres.ts";
@@ -146,4 +146,28 @@ export function journeyCarriedCommodities(): Set<string> {
   const f = readFilters();
   etat.JOURNEY.legs.forEach((leg, i) => legEffectiveLines(leg, i, f).forEach((l) => set.add(l.name)));
   return set;
+}
+
+/**
+ * Le contexte de chargement d'une JAMBE, à la forme que `suggestionsFor` et `manifestRemaining`
+ * attendent — la même que celle de la carte d'« En route ».
+ *
+ * Il vit ici et non dans le module du manifeste parce qu'il est lu par le RENDU du compagnon et par
+ * deux de ses actions : c'est de la donnée de parcours, pas de la donnée de carte.
+ *
+ * `null` sans soute bornée : « SCU libres » n'a alors aucun sens, et les suggestions non plus.
+ */
+export function legSuggestCtx(leg: Jambe, lines: LigneManifeste[], f: Filtres & { cargo?: number; useCargo?: boolean }): ContexteManifeste | null {
+  if (!etat.MARKET || !stationMap.size) return null;
+  if (!f.useCargo || !(f.cargo && f.cargo > 0)) return null;
+  const originIdx = stationMap.get(stationLabel(leg.from, leg.fromSystem));
+  const destIdx = stationMap.get(stationLabel(leg.to, leg.toSystem));
+  if (originIdx == null || destIdx == null) return null;
+  const ctx = legFeeCtx(leg, f);
+  return {
+    lines, originIdx, destIdx,
+    origin: { name: leg.from, system: leg.fromSystem },
+    dest: { name: leg.to, system: leg.toSystem },
+    cargo: f.cargo, f, fee: ctx && ctx.pair, // même filtrage des suggestions qu'« En route »
+  };
 }

--- a/vues/carte-vue.tsx
+++ b/vues/carte-vue.tsx
@@ -1,0 +1,49 @@
+// La CARTE DU PARCOURS : le composant qui décide s'il y a quelque chose à dessiner (ADR-012).
+//
+// `carte.tsx` garde la PRÉSENTATION — le SVG, les nœuds, le vaisseau. Ce fichier-ci décide : pas de
+// voyage, pas de marché, pas de starmap, ou pas de géométrie calculable → rien.
+//
+// ── UNE GARDE POSITIVE, ET C'EST L'INVERSE DU BANDEAU ─────────────────────────────────────────
+// `#journeyMap` vit DANS la section du Plan de vol (index.html), entre `#planHead` et `#planBody`.
+// Il n'est donc visible que là — une vue sur huit. Or `renderJourney()` le repeignait à CHAQUE
+// `refresh()`, depuis les huit vues : un `journeyMap()` complet, la géométrie de tous les arrêts
+// recalculée, pour un `<aside>` que sept vues sur huit n'affichent pas.
+//
+// Il prend donc `si="plan"`, la garde POSITIVE du patron des vues d'onglet. Le bandeau, lui, devra
+// faire l'inverse — il est visible partout SAUF dans le Plan.
+import { useLayoutEffect } from "react";
+
+import { journeyMap, journeyStations, stationLabel } from "../logic.ts";
+import { etat, notifier } from "../etat.ts";
+import { ensureStarmap } from "../donnees.ts";
+import { stationMap } from "../marche.ts";
+import { jambeChargee } from "../voyage-donnees.ts";
+import { carteParcours } from "./carte.tsx";
+
+export function CarteParcours() {
+  // `hidden` est un attribut du conteneur, pas un de ses enfants : un portail ne le gère pas. Il
+  // reste donc posé à la main, comme `#empty` — et en `useLayoutEffect`, avant la peinture.
+  const c = calculer();
+  useLayoutEffect(() => {
+    const box = document.getElementById("journeyMap");
+    if (box) box.hidden = !c;
+  });
+  return c ? carteParcours(c) : null;
+}
+
+function calculer() {
+  if (!etat.JOURNEY || !etat.MARKET) return null;
+  // La starmap est chargée à la demande, et son échec est SILENCIEUX : un panneau décoratif
+  // n'alarme personne. `notifier` et non un rendu ciblé — c'est l'arbre qui décidera quoi refaire.
+  if (!etat.STARMAP) { ensureStarmap(notifier); return null; }
+
+  const info = (nom: string) => {
+    const etape = journeyStations(etat.JOURNEY!).find((s) => s.name === nom);
+    const i = stationMap.get(stationLabel(nom, etape?.system || ""));
+    return i == null ? null : etat.MARKET!.terminals[i];
+  };
+  // Jambe courante chargée = on a payé et on est parti : le vaisseau quitte le quai sur la carte.
+  const legCourante = etat.JOURNEY.legs[etat.JOURNEY.current];
+  const enVol = !!legCourante && jambeChargee(legCourante, etat.JOURNEY.current);
+  return journeyMap(journeyStations(etat.JOURNEY), etat.JOURNEY.current, etat.STARMAP, info, enVol);
+}

--- a/vues/enroute-vue.tsx
+++ b/vues/enroute-vue.tsx
@@ -1,0 +1,119 @@
+// La VUE « En route » : le composant qui décide quoi afficher (ADR-011 étape 3, ADR-012).
+//
+// La HUITIÈME et dernière vue d'onglet. Après elle, `refresh()` n'a plus aucune branche de vue.
+//
+// Elle occupe DEUX conteneurs : la carte de chargement (`#manifest`) et la table du fret rentable
+// (`#enrouteRows`). Un seul composant, comme partout ailleurs — ils partagent `readFilters()`, le
+// départ, l'arrivée forcée, et l'ordre dans lequel ils sont calculés n'est pas indifférent : la
+// carte lit la composition manuelle, la table non.
+//
+// ── LES DÉLÉGATIONS RESTENT ───────────────────────────────────────────────────────────────────
+// Les trois écouteurs de `#manifest` (input, click, keydown) sont posés sur le CONTENEUR, que React
+// ne possède pas : il rend dedans. Les événements natifs y remontent à travers le portail. Les
+// convertir en `onClick` ne gagnerait rien et coûterait une réécriture de tests (ADR-012 §2).
+import { useLayoutEffect } from "react";
+import { createPortal } from "react-dom";
+
+import { bySort, enRouteDeals, routePasses } from "../logic.ts";
+import { etat, notifier } from "../etat.ts";
+import { readFilters } from "../filtres.ts";
+import { notifySuperseded } from "../corrections-actions.ts";
+import { withMarket } from "../donnees.ts";
+import { feeEndText, feeResolver } from "../frais.ts";
+import { fmt, scuBoxesLabel } from "../format.ts";
+import { tripMinutes } from "../logic.ts";
+import { isOv } from "../corrections.ts";
+import { corriger } from "../corrections-actions.ts";
+import { indexArriveeForcee, indexOrigine } from "../marche.ts";
+import { manifesteCourant, manifestRemaining, suggestionsFor } from "../manifeste-donnees.ts";
+import { generationManifeste } from "../manifeste-etat.ts";
+import { messageVide } from "./message-vide.ts";
+import { propsLignesSimples, propsTrajetsCommunes } from "./trajets-props.tsx";
+import { VueTrajets } from "./trajets.tsx";
+import { carteManifeste, indiceAucunChargement, indiceSouteInactive, indiceSoutePleine } from "./manifeste.tsx";
+import { evaluate } from "./trajets-vue.tsx";
+
+const champ = (id: string): string =>
+  (document.getElementById(id) as HTMLInputElement | null)?.value ?? "";
+
+function Portail({ id, children }: { id: string; children: React.ReactNode }) {
+  const cible = document.getElementById(id);
+  return cible ? createPortal(children, cible) : null;
+}
+
+export function VueEnRoute() {
+  useLayoutEffect(notifySuperseded);
+
+  const active = etat.view === "enroute";
+  let carte: React.ReactNode = null;
+  let carteVisible = false;
+  let table: React.ReactNode = null;
+  let message: string | null = null;
+
+  if (active && !etat.MARKET) {
+    // Cette vue n'a RIEN de vrai à écrire dans `#empty` tant que le marché manque : ce n'est pas un
+    // filtre qui vide la table, c'est la donnée qui n'est pas là (#26).
+    withMarket(notifier);
+  } else if (active) {
+    const f = readFilters();
+    const origin = indexOrigine();
+
+    // ── La carte de chargement ────────────────────────────────────────────────────────────────
+    const r = manifesteCourant(f);
+    carteVisible = r.etat !== "sans-depart";
+    if (r.etat === "soute-inactive") carte = indiceSouteInactive();
+    else if (r.etat === "soute-pleine") carte = indiceSoutePleine(fmt(r.aBord));
+    else if (r.etat === "aucun") carte = indiceAucunChargement(r.aBord > 0 ? fmt(r.libre) : null);
+    else if (r.etat === "ok") {
+      const m = r.m!;
+      carte = carteManifeste({
+        m,
+        generation: generationManifeste(),
+        compose: !!etat.MANIFEST_EDIT,
+        parcours: etat.JOURNEY,
+        suggestions: suggestionsFor(m),
+        restant: manifestRemaining(m),
+        libelleCaisses: (units: number) => scuBoxesLabel(units, m.origin.maxBox),
+        texteBoutFrais: feeEndText,
+        minutesTrajet: tripMinutes(0, m.cross),
+        estCorrige: isOv,
+        corriger, // six arguments dans le même ordre : passé nu, comme pour les Trajets
+      });
+    }
+
+    // ── La table du fret rentable ─────────────────────────────────────────────────────────────
+    if (origin == null) {
+      message = "Choisis un terminal de départ pour voir le fret à emporter.";
+    } else {
+      const destSystem = champ("destSystem");
+      // `sysFilter: ""` — le système d'arrivée est filtré par `destSystem` (ou le terminal forcé),
+      // pas par le menu « système d'achat ».
+      const ef = { ...f, sysFilter: "" };
+      // Le contexte de frais descend DANS `enRouteDeals` : elle ne garde qu'UNE vente par
+      // commodité, donc une destination meilleure en net n'entrerait jamais dans la liste — et la
+      // carte juste au-dessus afficherait la destination inverse.
+      const deals = enRouteDeals(etat.MARKET!, origin, destSystem, indexArriveeForcee(), f, feeResolver(f))
+        .filter((d) => routePasses(d, ef))
+        .map((d) => evaluate(d, f));
+      deals.sort(bySort(etat.sortKey, etat.sortDir));
+      table = <VueTrajets {...propsTrajetsCommunes()} {...propsLignesSimples()} lignes={deals} />;
+      message = deals.length ? null : "Aucun fret rentable depuis ce terminal avec ces filtres.";
+    }
+  }
+
+  // `#empty` et `hidden` sont des nœuds/attributs qu'aucun portail ne possède.
+  useLayoutEffect(() => {
+    if (!active) return;
+    messageVide(message);
+    const card = document.getElementById("manifest");
+    if (card) card.hidden = !carteVisible;
+  });
+
+  if (!active) return null;
+  return (
+    <>
+      <Portail id="manifest">{carte}</Portail>
+      <Portail id="enrouteRows">{table}</Portail>
+    </>
+  );
+}


### PR DESCRIPTION
## Ce que ça change

**Les huit vues sur huit vivent maintenant dans la racine React.** `refresh()` n'a plus une seule
branche de vue.

Rien ne change à l'écran. Ce qui change, c'est que la carte du parcours cesse d'être redessinée
sept fois pour rien, et que la dernière globale « écrite au rendu, relue au clic » du dépôt
disparaît.

## Pourquoi

### La carte du parcours : une garde POSITIVE, l'inverse du bandeau

`#journeyMap` vit **dans** la section du Plan de vol, entre `#planHead` et `#planBody` : il n'est
visible que là. Or `renderJourney()` le repeignait à **chaque** `refresh()`, depuis les huit vues —
géométrie de tous les arrêts recalculée pour un `<aside>` que sept vues sur huit n'affichent pas.

Il prend donc `si="plan"`. C'est la première fois que la garde sert dans ce sens, et ça vaut d'être
noté : elle n'est pas réservée aux vues d'onglet, elle sert tout conteneur dont la visibilité est
décidée par `switchView`.

### La plomberie du manifeste : deux fonctions qui n'étaient pas où on croyait

`manifestRemaining` et `suggestionsFor` avaient l'air d'appartenir à « En route » — leur paramètre
retombait sur `currentManifest`, la globale de cette vue. **C'est faux** : le compagnon de voyage
les appelle quatre fois avec un contexte de **jambe**. Les descendre dans le composant d'« En
route » aurait cassé le compagnon, et le symptôme serait arrivé tard — les suggestions ne sont
calculées que pour la jambe **dépliée**, donc un test qui ne déplie pas ne verrait rien.

Le contexte devient un paramètre **requis**, ce qui les rend testables : **quatre tests neufs**,
dont deux que l'ancienne signature rendait littéralement inécrivables.

### La composition manuelle : le rendu n'écrit plus

`compositionEnCours` faisait **trois écritures d'état — et de `localStorage`** — en pleine phase de
rendu. C'est l'un des trois chemins que l'en-tête d'`etat.ts` cite pour refuser un magasin qui
notifierait à l'écriture. Sous React, une écriture pendant le rendu qui déclenche un rendu est une
boucle à deux passes.

La réponse n'est pas « dérivation » **ou** « effet », c'est **les deux**, scindés en trois :
la **survie** devient une dérivation ; la **purge** des commodités disparues devient un filtre non
persisté (le prochain geste réécrit l'objet entier) ; l'**abandon** devient un **geste**, porté par
les trois écouteurs qui changent de route. Le laisser au rendu, c'était faire décider par
l'affichage ce que l'utilisateur avait fait — une correction de prix ailleurs pouvait effacer la
carte qu'on composait.

Mesure : `grep etat.MANIFEST_EDIT app.js` ne montre plus que **deux lectures et zéro écriture**.

### « En route » : la dernière globale tombe

`currentManifest` était la dernière « écrite au rendu, relue au clic », et la plus coûteuse : six
gestes de composition la lisaient, et un geste fait avant le premier rendu de la carte y trouvait
`null` sans rien dire. Elle devient une dérivation, sur le patron d'`indexOrigine`.

Les quatre retours anticipés de `renderManifest` deviennent quatre **états nommés** —
`sans-depart`, `soute-inactive`, `soute-pleine`, `aucun` — ce qui permet à la vue de choisir son
message sans reproduire la décision.

**La génération de la carte reste**, et c'est le point délicat. Elle distingue un **recalcul** — où
les champs SCU doivent adopter les nouvelles valeurs, donc se remonter — d'une **frappe**, où le
champ garde son nœud, sa valeur et son curseur. Elle bouge désormais dans `refresh()` et nulle part
ailleurs : un cycle complet **est** un recalcul, et `updateManifestTotals` n'appelle que
`notifier()`.

`ChargementCourant` nomme enfin les quatre propriétés qu'`app.js` accrochait à la main sur un objet
non typé (`originIdx`, `f`, `aBord`, `feeInfo`) : c'est ce qui a permis à `tsc` de voir cette carte
pour la première fois.

## Vérification

| commande | avant (#154) | après |
|---|---|---|
| `node --test` | 486 pass / 0 fail | **490 pass / 0 fail** |
| `npx playwright test` | 241 (239 passés, 2 ignorés) | **244 — 242 passés, 2 ignorés, 0 échec** |
| `npx tsc --noEmit` | silencieux | **silencieux** |
| `npm run build:site` | OK | **OK** |

`app.js` : **2 315 → 2 160 lignes** · **20 → 9 `peindre()`** · **7 → 8 vues sur 8** dans l'arbre.

`e2e/arbre.pw.mjs` compte **onze** tests de garde. Trois sont neufs ici : la carte du parcours hors
Plan de vol, la carte de chargement hors « En route », et la composition manuelle qui **survit** à
un rendu sans rapport tout en **disparaissant** au changement de route.

## Ce qui n'est pas couvert

- **Le bandeau** — soute, entrepôts, déclaration, compagnon de voyage, récapitulatif — reste dans
  `app.js` avec ses 9 `peindre()`. C'est le prochain lot, et le plus différent : il est visible dans
  six vues sur huit, donc il se montera **sans** garde ou avec un garde négatif. `ajusterRangeeVoyage`
  y mesure deux colonnes après les avoir peintes, ce qui impose de migrer le compagnon **avant** la
  soute — sinon la colonne de gauche se lit d'un tour en retard.
- **Le sélecteur de station** et la coquille (`switchView`, `init`) restent.
- Les deux tests ignorés sont **conditionnels aux données**, comme dans les PR précédentes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
