### PR TITLE
refactor(coquille): les 35 écouteurs quittent l'amorce — il ne reste qu'une séquence

### DIFF
--- a/amorce.js
+++ b/amorce.js
@@ -33,93 +33,40 @@
 // qu'à l'exécution, par les tests Playwright.
 
 // Fonctions de calcul pures (testées par logic.test.mjs).
-import { ovKey, stationLabel } from "./logic.ts";
 import { etat } from "./etat.ts";
-import { esc } from "./format.ts";
-import { loadOverrides, saveOverrides, setOverride } from "./corrections.ts";
-import { effacerToutesLesCorrections, updateOvBadge } from "./corrections-actions.ts";
-import { enregistrerReleve, oublierReleve, oublierTousLesReleves } from "./frais-actions.ts";
+import { loadOverrides } from "./corrections.ts";
+import { updateOvBadge } from "./corrections-actions.ts";
 import { showToast } from "./messages.ts";
-import {
-  construireIndex, indexStationExacte, libellesOrigines, libellesStations, termByName,
-} from "./marche.ts";
 import { loadAutoloadK } from "./frais.ts";
-import { applyState, loadState, saveState } from "./persistance.ts";
-import { brancher, withMarket } from "./donnees.ts";
+import { applyState, loadState } from "./persistance.ts";
+import { brancher } from "./donnees.ts";
 import { basculerVue, brancherNavigation } from "./navigation.js";
 import { synchroniserReglages } from "./filtres.ts";
 import { brancherTri, poserIndicateursDeTri } from "./tri.js";
-import { debounce, rafraichir, rafraichirDifferee } from "./rendu.ts";
-import {
-  addManifestCommodity, addSuggestion, oublierCompositionSiRouteChangee, removeManifestLine,
-  resetManifeste, updateManifestTotals,
-} from "./manifeste-gestes.js";
-import {
-  copierCorrections, copierEntrepots, copierPlan, copyManifest, copyShareLink,
-} from "./presse-papiers.js";
-import {
-  addLegLine, addLegSuggestion, addStopByTerminal, beginJourney, clearJourney, delLegLine,
-  editLegQty, liveLegQty, manifestToJourney, removeJourneyStop, resetLeg, setJourneyStop,
-  toggleLegEditor,
-} from "./voyage-gestes.js";
-import {
-  basculerEcoulement, chargerJambe, declarerABord, deposerIci, fermerDeclaration, fermerVente,
-  loadChargements, loadDepots, loadSoute, ouvrirDeclaration, ouvrirVente, poserPosition,
-  reprendreIci, retirerLot, vendreIci, viderSoute,
-} from "./soute-actions.js";
+import { brancherControles } from "./controles.js";
+import { brancherGestesCorrections } from "./corrections-gestes.js";
+import { brancherGestesSoute } from "./soute-gestes.js";
+import { peuplerListes } from "./listes.js";
+import { rafraichir } from "./rendu.ts";
+import { loadChargements, loadDepots, loadSoute } from "./soute-actions.js";
 import { loadManifestEdit } from "./manifeste-etat.ts";
+import { brancherGestesManifeste } from "./manifeste-gestes.js";
+import { brancherPressePapiers } from "./presse-papiers.js";
+import { brancherGestesVoyage } from "./voyage-gestes.js";
 
 
-import {
-  chargerVaisseaux, memoriserStation, monterSelecteurStation, montrerCarteVaisseau, stationChangee,
-} from "./selecteur.js";
+import { chargerVaisseaux, montrerCarteVaisseau } from "./selecteur.js";
 import { monterRacine } from "./main.tsx";
-import { loadJourneyEdits, loadJourneyPins, pinLegsForVolume } from "./voyage-donnees.ts";
-// (`vues/tournee.tsx` et `vues/plan.tsx` ne sont plus importés ici : leurs vues vivent dans l'arbre
-// depuis #143 et #145, et seuls leurs composants de DÉCISION les consomment désormais.)
-// La vue Commodités n'expose plus sa présentation à app.js — seulement ses trois ACTIONS, comme
-// `plan-vue.tsx` expose `planData`. Les écouteurs de `#commSortModes` / `#commBoardModes` restent
-// ici : leurs conteneurs sont du markup d'index.html (ADR-012 §2).
-import { refletBoardCommodites, setCommBoard, setCommSort } from "./vues/commodites-vue.tsx";
+import { loadJourneyEdits, loadJourneyPins } from "./voyage-donnees.ts";
+// Une seule chose de la vue Commodités arrive ici : le REFLET de son segmenté, que le rappel de
+// restauration doit rejouer. Ses écouteurs, eux, sont partis dans `controles.js`.
+import { refletBoardCommodites } from "./vues/commodites-vue.tsx";
 
 
 const $ = (id) => document.getElementById(id);
 
-// ── LES TROIS LISTES DÉROULANTES, PEUPLÉES AU MARCHÉ ──────────────────────────────────────────
-// Elles ne valent pas un composant : ce sont des `<option>` nus, sans classe et sans événement,
-// posés une fois et jamais relus par React. Elles vivent ici et non dans `donnees.ts`, qui déclare
-// en tête ne rien savoir des `<datalist>` ni des messages — les deux crochets de `brancher()`
-// n'existent que pour ça.
-let listesPretes = false;
-
 /** Prévient que le marché est indisponible, plutôt que de laisser la vue vide ET muette. */
 const marcheIndisponible = () => showToast("⚠ Marché indisponible — vérifie ta connexion, puis réessaie");
-
-/**
- * Peuple les trois `<datalist>` et monte le sélecteur de station. IDEMPOTENT.
- *
- * ATTENTION : `withMarket` enveloppe son rappel dans un `.catch()`. Toute exception jetée ici —
- * un identifiant libre, par exemple — s'affiche à l'écran comme « ⚠ Marché indisponible ». Et
- * `tsc` ne lit pas ce fichier : seul `e2e/arbre.pw.mjs` garde ce piège.
- */
-function peuplerListes() {
-  if (listesPretes) return;
-  // Les trois index viennent de `marche.ts` ; ici on ne fait plus que peindre les listes.
-  construireIndex(etat.MARKET);
-  // Départ d'« En route » : les terminaux où l'on peut ACHETER.
-  $("originList").innerHTML = libellesOrigines().map((l) => `<option value="${esc(l)}"></option>`).join("");
-  // Toutes les stations (achat ou vente) : c'est la vue Corrections qui l'exige.
-  $("stationList").innerHTML = libellesStations().map((l) => `<option value="${esc(l)}"></option>`).join("");
-  // Toutes les commodités, pour l'ajout libre au chargement.
-  $("commodityList").innerHTML = etat.MARKET.commodities
-    .map((c) => `<option value="${esc(c.name)}">${esc(c.code || "")}</option>`).join("");
-
-  // Le sélecteur de station (ADR-003) se monte ICI et une seule fois : il lui faut MARKET, et
-  // c'est le seul point du cycle où le marché est garanti présent.
-  monterSelecteurStation();
-
-  listesPretes = true;
-}
 
 async function init() {
   // Les deux crochets du chargement : `donnees.ts` sait charger, il ne sait rien des `<datalist>`
@@ -133,284 +80,23 @@ async function init() {
   monterRacine();
   brancherTri();
   poserIndicateursDeTri(); // aria-sort/classes du tri par défaut, sans dépendre des attributs du HTML
-  // Les champs à SAISIE LIBRE sont débouncés : sans ça, chaque caractère relançait un cycle
-  // complet calcul + réécriture de #rows par innerHTML. Mesuré à ~142 ms par frappe sur un CPU
-  // throttlé ×4 (le coût dominant est le relayout de la table, pas le calcul : ~2 ms), soit plus
-  // d'une seconde de thread bloqué pour taper « Laranite », et deux recalculs sur des valeurs
-  // absurdes quand on tape « 696 » dans la soute (6 puis 69 SCU).
-  // Menus et cases à cocher restent IMMÉDIATS : ils n'émettent qu'un seul événement.
-  ["cargo", "budget", "search", "alk"].forEach((id) => $(id).addEventListener("input", rafraichirDifferee));
-  ["system", "freshness", "sameSystem", "noOutpost", "legalOnly", "capStock", "multiMode"].forEach((id) =>
-    $(id).addEventListener("input", rafraichir)
-  );
-  // Ces deux-là commandent en plus l'affichage de leur propre sous-réglage (coefficient k, portée
-  // de la liste multi) : ils passent donc par synchroniserReglages avant de recalculer.
-  ["autoload", "multiCommodity"].forEach((id) =>
-    $(id).addEventListener("input", () => { synchroniserReglages(); rafraichir(); })
-  );
-  ["useCargo", "useBudget"].forEach((id) =>
-    $(id).addEventListener("change", () => {
-      synchroniserReglages();
-      rafraichir();
-    })
-  );
-  // Contrôles « Tournée ». Terminal à SAISIE LIBRE (datalist, mais rien n'oblige à choisir dedans) :
-  // même debounce que `#origin` et `#chainOrigin`, faute de quoi chaque frappe re-rendrait ET
-  // réécrirait le hash.
-  $("tourFrom").addEventListener("input", rafraichirDifferee);
-  $("tourScope").addEventListener("input", rafraichir); // <select> : un seul événement, immédiat
-  brancherNavigation(); // le rail, la marque et les touches 1…8
-  // Copie du récapitulatif : écouteur DÉLÉGUÉ sur `#planHead`, que React repeint à chaque rendu.
-  // Posé sur le CONTENEUR et non sur le bouton, il survit donc aux rendus — même règle qu'avant,
-  // pour une autre raison (c'était `renderPlan` qui réécrivait, c'est l'arbre maintenant).
-  $("planHead").addEventListener("click", (e) => {
-    if (e.target.closest("#planCopy")) copierPlan();
-  });
-  $("share").addEventListener("click", copyShareLink);
-  // Contrôles « Commodités » : modes de tri + sélection d'une tuile.
-  $("commSortModes").addEventListener("click", (e) => { const b = e.target.closest("button[data-sort]"); if (b) setCommSort(b.dataset.sort); });
-  $("commBoardModes").addEventListener("click", (e) => { const b = e.target.closest("button[data-board]"); if (b) setCommBoard(b.dataset.board); });
-  // La délégation sur `#commGrid` est partie avec la vue : la tuile est un vrai `<button>`, elle
-  // porte donc son propre `onClick`. La laisser doublerait l'action, ce que seul le compteur de
-  // propagations aurait vu. Les deux au-dessus restent : leurs `<div>` sont du markup d'index.html
-  // qu'aucun portail ne possède, et leurs boutons sont statiques (ADR-012 §2).
-  // Contrôles « En route ». Ces champs de terminal sont eux aussi à SAISIE LIBRE (datalist, mais
-  // rien n'oblige à choisir dans la liste) : même debounce que ci-dessus. Sans lui, chaque frappe
-  // re-rendait la vue ET réécrivait le hash — or WebKit plafonne history.replaceState à 100 appels
-  // par 10 s : taper deux noms de terminal suffisait à le franchir. Les résolveurs restent DANS le
-  // rappel, donc dans le même ordre qu'avant ; les vues de l'arbre les
-  // rejouent de toute façon avant de peindre.
-  // CHANGER DE ROUTE ABANDONNE LA COMPOSITION, et c'est un GESTE — plus une décision du rendu.
-  // `compositionValide` se contente désormais de dire qu'elle ne vaut plus ; c'est ici qu'on
-  // l'efface, parce que c'est ici que l'utilisateur a changé d'avis. La laisser en réserve la
-  // ferait ressurgir au retour sur cette route, longtemps après le geste qui l'avait écrite.
-  const changerDeRoute = () => { oublierCompositionSiRouteChangee(); rafraichir(); };
-  $("origin").addEventListener("input", debounce(changerDeRoute));
-  $("destSystem").addEventListener("input", changerDeRoute); // <select> : un seul événement, immédiat
-  $("destTerminal").addEventListener("input", debounce(changerDeRoute)); // terminal d'arrivée forcé
-  // Contrôles « Chaîne ».
-  $("chainOrigin").addEventListener("input", debounce(rafraichir));
-  $("hops").addEventListener("input", rafraichir);
-  // Contrôles « Corrections » : recherche de station + suppression / reset (délégué).
-  // Ne re-rend QUE si la station résolue a CHANGÉ. Le sélecteur, lui, rend immédiatement au choix :
-  // sans ce garde, le rendu différé du debounce arrivait ~300 ms après et refaisait le même écran
-  // pour rien — en détachant au passage l'éditeur d'un chiffre ouvert entre les deux. Même famille
-  // que #24 : tout re-rendu gratuit de cette vue efface une saisie en cours.
-  $("station").addEventListener("input", debounce(() => { if (stationChangee()) rafraichir(); }));
-  $("corrections").addEventListener("click", (e) => {
-    // Les relevés d'autoload se testent AVANT les corrections : leur ✕ porte aussi `.corr-del`
-    // (même bouton à l'écran) et tomberait sinon dans la branche qui écrit dans OVERRIDES.
-    const alDel = e.target.closest(".al-del");
-    if (alDel) { oublierReleve(alDel.dataset.key); return; }
-    // Vignette de la bande : recharge sa station. Écrit le LIBELLÉ CANONIQUE, comme le sélecteur —
-    // la résolution est exacte, et c'est ce libellé-là que le permalien transporte.
-    const tuile = e.target.closest(".stn-tile");
-    if (tuile && !tuile.disabled) {
-      const t = termByName.get(tuile.dataset.terminal);
-      if (t) { $("station").value = stationLabel(t.name, t.system); memoriserStation(); rafraichir(); saveState(); }
-      return;
-    }
-    // Retour à la valeur UEX d'un chiffre corrigé.
-    const undo = e.target.closest(".scomm-undo");
-    if (undo) {
-      const { c, t: term, s: side, f: field } = undo.dataset;
-      // Rendre son stock à UEX reste un changement de volume : sans ce gel, un voyage déjà planifié
-      // se rebattrait tout seul. Même règle que startEdit et que l'ancien ✕ de la liste plate.
-      if (field === "vol") pinLegsForVolume(c, term, side);
-      const o = etat.OVERRIDES[ovKey(c, term, side)];
-      setOverride(c, term, side, field, null, o ? o.base : 0);
-      updateOvBadge();
-      rafraichir();
-      return;
-    }
-    // Efface les corrections de la SEULE station affichée (bouton du bandeau).
-    if (e.target.closest("#stnClear")) {
-      const S = indexStationExacte();
-      const nom = S != null ? etat.MARKET.terminals[S].name : null;
-      if (nom) {
-        for (const k of Object.keys(etat.OVERRIDES)) {
-          const [commodity, terminal, side] = k.split("|");
-          if (terminal !== nom) continue;
-          if (etat.OVERRIDES[k].vol != null) pinLegsForVolume(commodity, terminal, side);
-          delete etat.OVERRIDES[k];
-        }
-        saveOverrides(); updateOvBadge(); rafraichir();
-      }
-      return;
-    }
-    // La branche `.corr-del` générique est partie : elle était MORTE. Les deux seuls producteurs de
-    // cette classe (`vues/frais-station.tsx`) posent aussi `.al-del`, interceptée trois lignes plus
-    // haut avec un `return`. Elle datait de la liste plate de corrections, remplacée par la bande de
-    // vignettes. La garder « par prudence » rouvrirait un chemin d'écriture d'OVERRIDES qui n'existe
-    // plus — et un test asserte au contraire qu'aucun `.corr-item:not(.autoload)` ne subsiste.
-    if (e.target.closest("#alSave")) { enregistrerReleve(); return; }
-    if (e.target.closest("#resetAllK")) { oublierTousLesReleves(); return; }
-    // Avant « Tout réinitialiser » ici aussi : rien ne doit s'effacer sans qu'on ait pu l'emporter.
-    if (e.target.closest("#exportCorrections")) { copierCorrections(); return; }
-    if (e.target.closest("#resetAll")) effacerToutesLesCorrections();
-  });
-  // Validation du relevé d'autoload à la touche Entrée (les deux champs sont dans le même panneau).
-  $("corrections").addEventListener("keydown", (e) => {
-    if ((e.target.id === "alAmount" || e.target.id === "alScu") && e.key === "Enter") { e.preventDefault(); enregistrerReleve(); }
-  });
-  // Manifeste : ajustement des SCU + ajout (suggéré ou libre) + retrait d'une ligne.
-  $("manifest").addEventListener("input", (e) => {
-    if (e.target.classList.contains("mqty-input")) updateManifestTotals();
-  });
-  $("manifest").addEventListener("click", (e) => {
-    // Ici et pas dans le délégué global du compagnon. La raison d'origine a disparu avec la
-    // délégation `.journey-pick` (elle lisait `pick.closest("table").id`, qui levait depuis une
-    // carte) ; ce qui reste vaut toujours : cet écouteur est posé sur `#manifest`, donc il ne voit
-    // que sa carte, là où le délégué global voit toute la page.
-    if (e.target.closest("#manifestToJourney")) { manifestToJourney(); return; }
-    if (e.target.closest("#copyManifest")) { copyManifest(); return; }
-    if (e.target.closest("#manifestAddBtn")) { addManifestCommodity($("manifestAddInput").value); return; }
-    if (e.target.closest("#manifestReset")) { resetManifeste(); return; }
-    const del = e.target.closest(".mline-del");
-    if (del) { removeManifestLine(del.dataset.name); return; }
-    const add = e.target.closest(".suggest-add");
-    if (add) addSuggestion(add.dataset.name);
-  });
-  $("manifest").addEventListener("keydown", (e) => {
-    if (e.target.id === "manifestAddInput" && e.key === "Enter") { e.preventDefault(); addManifestCommodity(e.target.value); }
-  });
-  // La soute : vider, écouler, déposer, vendre, retirer un lot.
-  $("holdCard").addEventListener("click", (e) => {
-    if (e.target.closest("#holdClear")) { viderSoute(); return; }
-    if (e.target.closest("#holdOffload")) { basculerEcoulement(); return; }
-    // La quantité ET la station se lisent sur le MÊME conteneur : celui que le rendu a produit.
-    // `dataset.idx` absent -> undefined -> NaN -> repli sur stationCourante() ; jamais 0.
-    const deposer = e.target.closest(".hold-store");
-    if (deposer) { const b = deposer.closest(".hold-sell"); deposerIci(deposer.dataset.name, Number(b.querySelector(".hold-sell-qty").value), Number(b.dataset.idx)); return; }
-    const ouvrir = e.target.closest(".hold-sell-btn");
-    if (ouvrir) { ouvrirVente(ouvrir.dataset.name); return; }
-    if (e.target.closest(".hold-sell-no")) { fermerVente(); return; }
-    const ok = e.target.closest(".hold-sell-ok");
-    if (ok) { const b = ok.closest(".hold-sell"); vendreIci(ok.dataset.name, Number(b.querySelector(".hold-sell-qty").value), Number(b.dataset.idx)); return; }
-    const del = e.target.closest(".hold-del");
-    if (del) retirerLot(Number(del.dataset.i));
-  });
-  // Entrée valide la vente, Échap l'annule — même patron que les corrections inline.
-  $("holdCard").addEventListener("keydown", (e) => {
-    if (!e.target.classList.contains("hold-sell-qty")) return;
-    // Entrée doit encaisser à la même station que le bouton ✓ : même index figé, lu sur le conteneur.
-    if (e.key === "Enter") { e.preventDefault(); vendreIci(etat.venteEnCours, Number(e.target.value), Number(e.target.closest(".hold-sell")?.dataset.idx)); }
-    else if (e.key === "Escape") { e.preventDefault(); fermerVente(); }
-  });
-  // Déclarer « j'ai ça à bord » (#55) : le seul chemin qui fait entrer du fret sans jambe.
-  $("holdDeclare").addEventListener("click", (e) => {
-    if (e.target.closest("#holdAddOpen")) { ouvrirDeclaration(); return; }
-    if (e.target.closest("#holdAddNo")) { fermerDeclaration(); return; }
-    if (e.target.closest("#holdAddOk")) declarerABord();
-  });
-  // Entrée valide depuis n'importe lequel des trois champs, Échap abandonne — même patron que la
-  // vente inline de la soute et que les corrections.
-  $("holdDeclare").addEventListener("keydown", (e) => {
-    if (!e.target.closest(".hold-add")) return;
-    if (e.key === "Enter") { e.preventDefault(); declarerABord(); }
-    else if (e.key === "Escape") { e.preventDefault(); fermerDeclaration(); }
-  });
-  // La position se résout à la frappe, DÉBOUNCÉE comme le champ de départ d'« En route » : c'est le
-  // même champ derrière, et une résolution par caractère repeindrait toute la page à chaque lettre.
-  // On capture la valeur tout de suite : l'événement, lui, sera périmé quand le timer se déclenchera.
-  const poserPositionDifferee = debounce(poserPosition);
-  $("holdDeclare").addEventListener("input", (e) => {
-    if (e.target.id === "holdWhere") poserPositionDifferee(e.target.value);
-  });
-  // Entrepôts : « reprendre » remet le lot en soute. Un seul geste, pas de champ de quantité — on
-  // reprend ce qu'on a laissé ; une reprise partielle se ferait en redéposant. La fonction pure,
-  // elle, accepte déjà des SCU : l'UI pourra suivre sans la toucher.
-  $("depotsCard").addEventListener("click", (e) => {
-    if (e.target.closest("#copyDepots")) { copierEntrepots(); return; }
-    const b = e.target.closest(".depot-take");
-    if (b) reprendreIci(b.dataset.station, b.dataset.name, Number(b.dataset.units));
-  });
-  // Carte du parcours : cliquer une escale déplace « je suis ici », comme le fil d'étapes.
-  $("journeyMap").addEventListener("click", (e) => {
-    const a = e.target.closest(".jm-arret");
-    if (a) setJourneyStop(Number(a.dataset.i));
-  });
-  $("journeyMap").addEventListener("keydown", (e) => {
-    const a = e.target.closest(".jm-arret");
-    if (a && (e.key === "Enter" || e.key === " ")) { e.preventDefault(); setJourneyStop(Number(a.dataset.i)); }
-  });
-  // Compagnon de voyage : ✕ efface le parcours, ▶ n'est plus ici.
+  // LE CÂBLAGE, en sept lignes. Chaque module pose SES écouteurs sur le markup d'`index.html` qui
+  // le concerne. Aucun n'est converti en `onClick` React : posés sur des conteneurs que les portails
+  // remplissent sans les posséder, ils traversent les rendus (ADR-012 §2), et les convertir
+  // doublerait les gestes non idempotents.
   //
-  // Le ▶ était la dernière lecture par rang DES TABLES DE TRAJETS : la délégation lisait
-  // `pick.dataset.row` puis indexait l'un des quatre tableaux `shown*` selon
-  // `pick.closest("table").id`. Un tableau rempli au RENDU et relu au CLIC, avec ce que ça suppose :
-  // que les deux soient d'accord. Chaque îlot ferme désormais son bouton sur SA ligne.
-  //
-  // Le motif SURVIT ailleurs, et il faut le dire pour ne pas croire le dossier clos : la soute
-  // (`retirerLot`), le fil d'étapes, la carte du parcours et surtout l'autocomplétion
-  // (`matches[Number(li.dataset.i)]`) lisent tous un rang posé au rendu. Ce lot ne traite que les
-  // tables de trajets.
-  //
-  // Trois choses partent avec la délégation : le `closest("table").id` (et son TypeError si un ▶
-  // naissait hors table), le `else` fourre-tout qui faisait retomber toute table inconnue sur
-  // `shownRoutes`, et la garde `isMultiRoutes()` qui rattrapait le mode déjà changé au moment du
-  // clic (#25) — un rappel fermé sur SON trajet ne peut pas se tromper de tableau.
-  document.addEventListener("click", (e) => {
-    if (e.target.closest("#journeyClear")) { clearJourney(); return; }
-    // Démarrer un voyage « de zéro » : bouton « Commencer » depuis l'invite.
-    if (e.target.closest("#journeyStartBtn")) { beginJourney($("journeyStart").value); return; }
-    // Ajout d'arrêt : bouton « + Arrêt » ou une suggestion.
-    if (e.target.closest("#journeyAddBtn")) { addStopByTerminal($("journeyAddStop").value); return; }
-    const sug = e.target.closest(".jstop-suggest");
-    if (sug) { addStopByTerminal(sug.dataset.label); return; }
-    // Retirer un arrêt (✕ sur une étape) -> reconnexion des voisins.
-    const del = e.target.closest(".jstep-del");
-    if (del) { removeJourneyStop(Number(del.dataset.i)); return; }
-    // Édition du manifeste d'une jambe : déplier / retirer / ajouter / réinitialiser.
-    const legSug = e.target.closest(".jman-suggest .suggest-add");
-    if (legSug) { addLegSuggestion(Number(legSug.dataset.leg), legSug.dataset.name); return; }
-    const legDel = e.target.closest(".jman-del");
-    if (legDel) { delLegLine(Number(legDel.dataset.leg), legDel.dataset.name); return; }
-    const load = e.target.closest(".jleg-load");
-    if (load) { chargerJambe(Number(load.dataset.leg)); return; } // AVANT .jleg-head : le bouton y vit
-    if (e.target.closest(".jman-reset")) { resetLeg(Number(e.target.closest(".jman-reset").dataset.leg)); return; }
-    const addBtn = e.target.closest(".jman-add-btn");
-    if (addBtn) { addLegLine(Number(addBtn.dataset.leg), addBtn.closest(".jman-add").querySelector(".jman-add-input").value); return; }
-    const head = e.target.closest(".jleg-head");
-    if (head) { toggleLegEditor(Number(head.dataset.leg)); return; }
-    // Parcours interactif : clic sur une étape (⦿) = « je suis ici » -> recale les vues.
-    const step = e.target.closest(".jstep");
-    if (step) setJourneyStop(Number(step.dataset.i));
-  });
-  // L'en-tête d'une jambe est annoncé `role="button"` : Entrée/Espace doivent l'activer comme le clic
-  // (même corps, cf. `enTeteTriable` dans tri.js). On teste `e.target` LUI-MÊME et non `closest()` — modèle
-  // `.editv` plutôt que `.jm-arret` : le bouton « ✓ chargé » vit DANS l'en-tête, et un closest()
-  // déplierait l'éditeur EN PLUS de charger la soute à chaque Entrée sur ce bouton.
-  $("journeyCard").addEventListener("keydown", (e) => {
-    if (!e.target.classList || !e.target.classList.contains("jleg-head")) return;
-    if (e.key !== "Enter" && e.key !== " ") return;
-    e.preventDefault(); // Espace ne doit pas défiler la page
-    toggleLegEditor(Number(e.target.dataset.leg));
-  });
-  // Ajout d'arrêt / de commodité à la touche Entrée.
-  document.addEventListener("keydown", (e) => {
-    if (e.target.id === "journeyStart" && e.key === "Enter") { e.preventDefault(); beginJourney(e.target.value); }
-    else if (e.target.id === "journeyAddStop" && e.key === "Enter") { e.preventDefault(); addStopByTerminal(e.target.value); }
-    else if (e.target.classList && e.target.classList.contains("jman-add-input") && e.key === "Enter") { e.preventDefault(); addLegLine(Number(e.target.dataset.leg), e.target.value); }
-  });
-  // Précharge le marché quand on focus un champ terminal du compagnon -> peuple le datalist.
-  document.addEventListener("focusin", (e) => {
-    if ((e.target.id === "journeyStart" || e.target.id === "journeyAddStop") && !listesPretes) {
-      if (etat.MARKET) peuplerListes();
-      else withMarket(() => {});
-    }
-  });
-  // SCU d'une ligne de jambe : suggestions/profit en direct à la frappe, persistance au blur/Entrée.
-  document.addEventListener("input", (e) => {
-    if (e.target.classList && e.target.classList.contains("jman-qty")) liveLegQty(Number(e.target.dataset.leg), Number(e.target.dataset.i), e.target);
-  });
-  document.addEventListener("change", (e) => {
-    if (e.target.classList && e.target.classList.contains("jman-qty")) editLegQty(Number(e.target.dataset.leg), Number(e.target.dataset.i), e.target.value);
-  });
-  // Les deux délégations qui ouvraient l'édition (clic, Entrée/Espace) ont disparu avec
-  // `startEdit` : `ValeurEditable` porte ses propres `onClick`/`onKeyDown`. Le garde `data-react`
-  // qu'elles consultaient n'a plus rien à garder — mais l'attribut RESTE sur le composant, c'est
-  // lui que `e2e/edition.pw.mjs` interroge pour vérifier qu'aucun `.editv` n'échappe à React.
+  // L'ORDRE COMPTE POUR UN SEUL COUPLE, et il est écrit des deux côtés : `navigation.js` et
+  // `voyage-gestes.js` posent chacun un `keydown` sur `document`. Ils ne se recouvrent pas — celui
+  // des raccourcis sort si `activeElement` est un champ de saisie — mais leur ordre d'exécution est
+  // devenu leur ordre de branchement ici.
+  brancherControles();
+  brancherNavigation();
+  brancherPressePapiers();
+  brancherGestesCorrections();
+  brancherGestesManifeste();
+  brancherGestesSoute();
+  brancherGestesVoyage();
+
   loadOverrides();
   loadAutoloadK();
   loadJourneyEdits();

--- a/controles.js
+++ b/controles.js
@@ -1,0 +1,83 @@
+// LES CONTRÔLES : la barre de filtres et les réglages propres à chaque vue (ADR-011, ADR-012).
+//
+// Tous ces champs sont du markup statique d'`index.html`, hors de `#racine`. Aucun portail ne les
+// possède, et leur valeur n'entre pas dans `etat.ts` : c'est `readFilters()` (filtres.ts) qui les
+// LIT au moment où une vue en a besoin. Les recopier dans l'état créerait une seconde vérité à
+// tenir d'accord sur les valeurs les plus lues de l'application.
+//
+// Chaque champ n'a donc qu'un geste : relancer le cycle. Ce qui les distingue tient en trois règles.
+//
+// ── SAISIE LIBRE = DÉBOUNCÉ, MENU = IMMÉDIAT ──────────────────────────────────────────────────
+// Sans debounce, chaque caractère relançait un cycle complet : mesuré à ~142 ms par frappe sur un
+// CPU throttlé ×4 (le coût dominant est le relayout de la table, pas le calcul, ~2 ms), soit plus
+// d'une seconde de fil bloqué pour taper « Laranite ». Et `saveState()` réécrit le hash à chaque
+// cycle, or WebKit plafonne `history.replaceState` à 100 appels / 10 s : deux noms de terminaux
+// tapés d'affilée suffisaient à le franchir, et le partage de lien mourait.
+//
+// Un `<select>` ou une case n'émettent qu'un événement par geste : ils appellent `rafraichir()` nu.
+//
+// ── `rafraichirDifferee` EST PARTAGÉE, `debounce()` NE L'EST PAS ──────────────────────────────
+// Les six champs de la barre partagent la MÊME instance (rendu.ts) : taper dans « Rechercher » puis
+// dans « Soute » ne déclenche qu'un cycle. En refabriquer une par module donnerait six timers, donc
+// six rendus, sans qu'aucun test ne bronche.
+// À l'inverse, `#origin` et `#destTerminal` ont chacun le LEUR : les fusionner ferait qu'une frappe
+// dans l'un annulerait celle en cours dans l'autre.
+//
+// ── `change` ET `input` NE SONT PAS INTERCHANGEABLES ──────────────────────────────────────────
+// Les deux cases maîtresses écoutent `change`, les deux autres `input`. C'est délibéré sur une
+// `<input type="checkbox">` ; ne pas uniformiser en passant par ici.
+import { debounce, rafraichir, rafraichirDifferee } from "./rendu.ts";
+import { synchroniserReglages } from "./filtres.ts";
+import { oublierCompositionSiRouteChangee } from "./manifeste-gestes.js";
+import { setCommBoard, setCommSort } from "./vues/commodites-vue.tsx";
+
+const $ = (id) => document.getElementById(id);
+
+/** Branche les cinq barres de réglages. Appelé une fois, à l'amorçage. */
+export function brancherControles() {
+  // La barre de filtres, partagée par toutes les vues.
+  ["cargo", "budget", "search", "alk"].forEach((id) => $(id).addEventListener("input", rafraichirDifferee));
+  ["system", "freshness", "sameSystem", "noOutpost", "legalOnly", "capStock", "multiMode"].forEach((id) =>
+    $(id).addEventListener("input", rafraichir)
+  );
+  // Ces deux-là commandent en plus l'affichage de leur propre sous-réglage (coefficient k, portée
+  // de la liste multi) : ils passent donc par `synchroniserReglages` AVANT de recalculer, parce que
+  // `readFilters()` relit `#multiMode` et `#multiCommodity` pendant le cycle.
+  ["autoload", "multiCommodity"].forEach((id) =>
+    $(id).addEventListener("input", () => { synchroniserReglages(); rafraichir(); })
+  );
+  ["useCargo", "useBudget"].forEach((id) =>
+    $(id).addEventListener("change", () => { synchroniserReglages(); rafraichir(); })
+  );
+
+  // « En route ». CHANGER DE ROUTE ABANDONNE LA COMPOSITION, et c'est un GESTE — plus une décision
+  // du rendu. `compositionValide` se contente de dire qu'elle ne vaut plus ; c'est ici qu'on
+  // l'efface, parce que c'est ici que l'utilisateur a changé d'avis. La laisser en réserve la ferait
+  // ressurgir au retour sur cette route, longtemps après le geste qui l'avait écrite.
+  const changerDeRoute = () => { oublierCompositionSiRouteChangee(); rafraichir(); };
+  $("origin").addEventListener("input", debounce(changerDeRoute));
+  $("destSystem").addEventListener("input", changerDeRoute); // <select> : un seul événement, immédiat
+  $("destTerminal").addEventListener("input", debounce(changerDeRoute)); // terminal d'arrivée forcé
+
+  // « Chaîne ».
+  $("chainOrigin").addEventListener("input", debounce(rafraichir));
+  $("hops").addEventListener("input", rafraichir);
+
+  // « Tournée ». Terminal à saisie libre lui aussi, malgré sa `<datalist>` : rien n'oblige à choisir
+  // dedans.
+  $("tourFrom").addEventListener("input", rafraichirDifferee);
+  $("tourScope").addEventListener("input", rafraichir);
+
+  // « Commodités » : les deux segmentés de mode. Leurs `<div>` sont du markup d'`index.html` et
+  // leurs boutons sont STATIQUES — la délégation traverse (ADR-012 §2). Ne pas généraliser à
+  // `#commGrid` : sa tuile est un vrai `<button>` React qui porte son propre `onClick`, et la
+  // délégation qui vivait là doublait l'action — seul un compteur de propagations l'avait vu.
+  $("commSortModes").addEventListener("click", (e) => {
+    const b = e.target.closest("button[data-sort]");
+    if (b) setCommSort(b.dataset.sort);
+  });
+  $("commBoardModes").addEventListener("click", (e) => {
+    const b = e.target.closest("button[data-board]");
+    if (b) setCommBoard(b.dataset.board);
+  });
+}

--- a/corrections-actions.ts
+++ b/corrections-actions.ts
@@ -19,9 +19,11 @@
 // Une copie qui rate le point 1 ne casse aucun test — elle laisse simplement un voyage se recalculer
 // sur un stock qu'on vient de contredire.
 
-import { DUREE_VOL } from "./logic.ts";
+import { DUREE_VOL, ovKey } from "./logic.ts";
 import type { ChampCorrection, CoteMarche } from "./types.ts";
-import { ovCount, relevePerimees, resetOverrides, setOverride } from "./corrections.ts";
+import { ovCount, relevePerimees, resetOverrides, saveOverrides, setOverride } from "./corrections.ts";
+import { etat } from "./etat.ts";
+import { indexStationExacte } from "./marche.ts";
 import { pinLegsForVolume } from "./voyage-donnees.ts";
 import { showToast } from "./messages.ts";
 import { rafraichir } from "./rendu.ts";
@@ -110,6 +112,41 @@ export function effacerToutesLesCorrections(): void {
   if (!ovCount()) return;
   if (!confirm("Effacer toutes tes corrections locales de prix et de stock ?")) return;
   resetOverrides();
+  updateOvBadge();
+  rafraichir();
+}
+
+/**
+ * Efface les corrections de la SEULE station affichée — le bouton du bandeau collant.
+ *
+ * Chaque volume effacé fige d'abord les jambes qui en dépendaient : rendre son stock à UEX reste un
+ * changement de volume, et sans ce gel un voyage déjà planifié se rebattrait tout seul (#48).
+ */
+export function effacerStation(): void {
+  const S = indexStationExacte();
+  const nom = S != null ? etat.MARKET!.terminals[S].name : null;
+  if (!nom) return;
+  for (const cle of Object.keys(etat.OVERRIDES)) {
+    const [commodite, terminal, cote] = cle.split("|");
+    if (terminal !== nom) continue;
+    if (etat.OVERRIDES[cle].vol != null) pinLegsForVolume(commodite, terminal, cote as CoteMarche);
+    delete etat.OVERRIDES[cle];
+  }
+  saveOverrides();
+  updateOvBadge();
+  rafraichir();
+}
+
+/**
+ * Rend UN chiffre à sa valeur UEX — le contrôle dédié posé dans la tuile, hors du `.editv`.
+ *
+ * Même règle de gel que ci-dessus, et pour la même raison : un volume qui revient à UEX est un
+ * volume qui CHANGE.
+ */
+export function revenirAUEX(commodite: string, terminal: string, cote: CoteMarche, champ: ChampCorrection): void {
+  if (champ === "vol") pinLegsForVolume(commodite, terminal, cote);
+  const o = etat.OVERRIDES[ovKey(commodite, terminal, cote)];
+  setOverride(commodite, terminal, cote, champ, null, o ? o.base : 0);
   updateOvBadge();
   rafraichir();
 }

--- a/corrections-gestes.js
+++ b/corrections-gestes.js
@@ -1,0 +1,77 @@
+// LES GESTES DE LA VUE CORRECTIONS (ADR-012 §2).
+//
+// UNE délégation sur `#corrections`, qui est le PARENT des trois conteneurs de portail de la vue
+// (`#correctionsBand`, `#correctionsStation`, `#correctionsFees`). React rend DEDANS sans posséder
+// le nœud : l'écouteur posé ici une fois traverse tous les rendus à venir. Le convertir en `onClick`
+// sur les boutons ne gagnerait rien et doublerait `pinLegsForVolume`, qui n'est pas idempotent.
+//
+// ── L'ORDRE DES BRANCHES EST UN CONTRAT, ET AUCUN TEST NE LE TESTE ────────────────────────────
+// Les tests exercent chaque bouton isolément ; c'est l'enchaînement qui porte les deux règles :
+//   1. `.al-del` en PREMIER. Le ✕ d'un relevé d'autoload porte AUSSI `.corr-del` (c'est le même
+//      bouton à l'écran) et tomberait sinon dans une branche qui écrit dans `OVERRIDES` ;
+//   2. `#exportCorrections` AVANT `#resetAll` — rien ne s'efface sans qu'on ait pu l'emporter.
+//
+// La branche `.corr-del` générique a disparu : elle était MORTE. Les deux seuls producteurs de
+// cette classe (`vues/frais-station.tsx`) posent aussi `.al-del`, interceptée plus haut avec un
+// `return`. Elle datait de la liste plate, remplacée par la bande de vignettes ; la garder « par
+// prudence » rouvrirait un chemin d'écriture qui n'existe plus.
+import { stationLabel } from "./logic.ts";
+import { debounce, rafraichir } from "./rendu.ts";
+import { effacerStation, effacerToutesLesCorrections, revenirAUEX } from "./corrections-actions.ts";
+import { enregistrerReleve, oublierReleve, oublierTousLesReleves } from "./frais-actions.ts";
+import { copierCorrections } from "./presse-papiers.js";
+import { termByName } from "./marche.ts";
+import { saveState } from "./persistance.ts";
+import { memoriserStation, stationChangee } from "./selecteur.js";
+
+const $ = (id) => document.getElementById(id);
+
+/** Branche le champ de station et la délégation de la vue. Appelé une fois, à l'amorçage. */
+export function brancherGestesCorrections() {
+  // Le champ de recherche ne re-rend QUE si la station résolue a CHANGÉ. Le sélecteur, lui, rend
+  // immédiatement au choix : sans ce garde, le rendu différé du debounce arrivait ~300 ms après et
+  // refaisait le même écran pour rien — en détachant au passage l'éditeur d'un chiffre ouvert entre
+  // les deux. Même famille que #24 : tout re-rendu gratuit de cette vue efface une saisie en cours.
+  //
+  // Il est branché ICI et non dans `selecteur.js` : celui-ci ne monte qu'à l'arrivée du marché,
+  // alors que ce garde doit exister dès l'amorçage.
+  $("station").addEventListener("input", debounce(() => { if (stationChangee()) rafraichir(); }));
+
+  $("corrections").addEventListener("click", (e) => {
+    const relDel = e.target.closest(".al-del"); // EN PREMIER : voir l'en-tête
+    if (relDel) { oublierReleve(relDel.dataset.key); return; }
+
+    // Vignette de la bande : recharge sa station. Écrit le LIBELLÉ CANONIQUE, comme le sélecteur —
+    // la résolution est exacte, et c'est ce libellé-là que le permalien transporte.
+    const tuile = e.target.closest(".stn-tile");
+    if (tuile && !tuile.disabled) {
+      const t = termByName.get(tuile.dataset.terminal);
+      if (t) { $("station").value = stationLabel(t.name, t.system); memoriserStation(); rafraichir(); saveState(); }
+      return;
+    }
+
+    const undo = e.target.closest(".scomm-undo");
+    if (undo) {
+      const { c, t: terminal, s: cote, f: champ } = undo.dataset;
+      revenirAUEX(c, terminal, cote, champ);
+      return;
+    }
+
+    if (e.target.closest("#stnClear")) { effacerStation(); return; }
+    if (e.target.closest("#alSave")) { enregistrerReleve(); return; }
+    if (e.target.closest("#resetAllK")) { oublierTousLesReleves(); return; }
+    if (e.target.closest("#exportCorrections")) { copierCorrections(); return; } // AVANT #resetAll
+    if (e.target.closest("#resetAll")) effacerToutesLesCorrections();
+  });
+
+  // Validation du relevé d'autoload à la touche Entrée. Testé par `e.target.id` et non par
+  // `closest()` : les deux `<input>` sont rendus NON CONTRÔLÉS (`defaultValue`) par
+  // `vues/frais-station.tsx`, dont la `key` porte le relevé lui-même. Les passer à `value=` les
+  // gèlerait — c'est écrit en toutes lettres dans l'en-tête de ce composant.
+  $("corrections").addEventListener("keydown", (e) => {
+    if ((e.target.id === "alAmount" || e.target.id === "alScu") && e.key === "Enter") {
+      e.preventDefault();
+      enregistrerReleve();
+    }
+  });
+}

--- a/e2e/autoload.pw.mjs
+++ b/e2e/autoload.pw.mjs
@@ -473,3 +473,51 @@ test("frais de station : « Tarif retenu » suit le coefficient global (#alk)", 
   const apres = await page.locator("#correctionsFees .fee-note").innerText();
   expect(apres).not.toBe(avant);
 });
+
+// « Tout oublier » — le SEUL geste du panneau de frais qu'aucun test n'exerçait, mesuré au moment de
+// démonter la coquille : `grep -rn resetAllK e2e/` ne rendait rien. Un geste qu'on s'apprête à
+// déménager sans filet est un geste qu'on déménagera mal.
+//
+// Deux choses à tenir, et la seconde est celle qui casse en silence :
+//   1. le `confirm()` passe AVANT la moindre écriture — annuler ne doit rien effacer ;
+//   2. il n'efface que le store des RELEVÉS. Les corrections de prix ont le leur, et le badge du
+//      rail les compte : si les deux stores se mélangeaient un jour, « Tout oublier » emporterait
+//      des corrections que l'utilisateur n'a pas désignées.
+test("relevés : « Tout oublier » demande d'abord, et n'emporte QUE les relevés (#resetAllK)", async ({ page }) => {
+  await enrichMarket(page, "all", 32);
+  await page.goto("/index.html");
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+  await page.check("#autoload");
+
+  await page.click("#viewCorrections");
+  await expect(page.locator("#stationList option").first()).toBeAttached({ timeout: 15000 });
+  const label = await page.locator("#stationList option").first().getAttribute("value");
+  await page.fill("#station", label);
+  await expect(page.locator("#alAmount")).toBeVisible();
+
+  // Un relevé, et une correction de PRIX sur la même station : les deux stores, côte à côte.
+  await page.fill("#alAmount", "1159");
+  await page.fill("#alScu", "32");
+  await page.click("#alSave");
+  await expect(page.locator(".corr-item.autoload")).toHaveCount(1);
+
+  const valeur = page.locator("#correctionsStation .editv").first();
+  await valeur.click();
+  await page.locator("#correctionsStation input").first().fill("42");
+  await page.locator("#correctionsStation input").first().press("Enter");
+  await expect(page.locator("#viewCorrections .rl")).toHaveText(/\(\d+\)/); // le badge compte
+
+  const badgeAvant = await page.locator("#viewCorrections .rl").innerText();
+
+  // ANNULER n'efface rien. Le `confirm()` bloque le fil : un rendu optimiste posé avant lui
+  // peindrait une liste vide qu'il faudrait ensuite défaire.
+  page.once("dialog", (d) => d.dismiss());
+  await page.click("#resetAllK");
+  await expect(page.locator(".corr-item.autoload")).toHaveCount(1);
+
+  // ACCEPTER efface les relevés — et EUX SEULS.
+  page.once("dialog", (d) => d.accept());
+  await page.click("#resetAllK");
+  await expect(page.locator(".corr-item.autoload")).toHaveCount(0);
+  await expect(page.locator("#viewCorrections .rl")).toHaveText(badgeAvant);
+});

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -3063,3 +3063,32 @@ test("Soute : une déclaration en cours de saisie survit à un geste fait ailleu
   await expect(page.locator("#holdAddName")).toHaveValue("Titanium");
   await expect(page.locator("#holdAddScu")).toHaveValue("42");
 });
+
+// « ⧉ Copier » de la carte de chargement — le dernier bouton de copie sans aucun test, mesuré au
+// moment de démonter la coquille : `grep -rn copyManifest e2e/` ne rendait rien, alors que ses trois
+// frères (`#planCopy`, `#copyDepots`, `#exportCorrections`) en avaient. Un geste qu'on s'apprête à
+// déménager sans filet est un geste qu'on déménagera mal.
+//
+// Ce que le texte doit porter, et qui n'est vérifiable QUE là : le couple de terminaux en tête (une
+// liste de commodités sans sa route ne se relit pas), une ligne par commodité avec ses SCU, et le
+// total. C'est un plan qu'on lit sur un second écran en pilotant — pas un export de données.
+test("Manifeste : « ⧉ Copier » sort le plan de chargement, sa route et son total (#copyManifest)", async ({ page, context }) => {
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+  await manifesteDepuis(page, "Megumi — Pyro");
+
+  // `.mname` porte AUSSI le ✕ de retrait de la ligne : on ne garde que le nom.
+  const premiere = (await page.locator("#manifest .mname").first().innerText()).replace(/\s*✕\s*$/, "").trim();
+  await page.click("#copyManifest");
+  await expect(page.locator("#copyManifest")).toHaveText(/Copié/);
+
+  const texte = await page.evaluate(() => navigator.clipboard.readText());
+  expect(texte).toContain("Manifeste");
+  expect(texte).toContain("Megumi");                    // le départ, en tête
+  expect(texte).toContain(premiere);                    // la première commodité chargée
+  expect(texte).toMatch(/\d+ SCU/);                     // des quantités, pas seulement des noms
+  expect(texte).toMatch(/Total : .*SCU.*profit/);       // et la ligne qui conclut
+
+  // Le libellé REVIENT : « ✓ Copié » est un retour visuel, pas un état. Un bouton resté sur
+  // « Copié » ferait croire à une seconde copie qui n'a pas eu lieu.
+  await expect(page.locator("#copyManifest")).toHaveText(/Copier/, { timeout: 4000 });
+});

--- a/listes.js
+++ b/listes.js
@@ -1,0 +1,47 @@
+// LES TROIS LISTES DÉROULANTES, peuplées à l'arrivée du marché (ADR-011).
+//
+// Elles ne valent pas un composant : ce sont des `<option>` nus, sans classe et sans événement,
+// posés une fois et jamais relus par React. Elles ne peuvent pas non plus vivre dans `donnees.ts`,
+// qui déclare en tête ne rien savoir des `<datalist>` ni des messages — les deux crochets de
+// `brancher()` n'existent que pour ça. Ni dans `marche.ts`, qui ferait cycle avec `selecteur.js`.
+import { construireIndex, libellesOrigines, libellesStations } from "./marche.ts";
+import { etat } from "./etat.ts";
+import { esc } from "./format.ts";
+import { monterSelecteurStation } from "./selecteur.js";
+
+const $ = (id) => document.getElementById(id);
+
+// L'état est PRIVÉ et son lecteur est une fonction : exporter la liaison `let` marcherait — les
+// liaisons ES sont vives — mais un importateur qui la recopie dans une `const` la figerait à
+// `false`. Rien ne casserait, `peuplerListes` étant idempotente ; on reconstruirait juste 114 + 92
+// `<option>` à chaque focus, et personne ne le verrait.
+let pretes = false;
+
+/** Les listes sont-elles peuplées ? Le compagnon s'en sert pour précharger le marché au focus. */
+export const listesPretes = () => pretes;
+
+/**
+ * Peuple les trois `<datalist>` et monte le sélecteur de station. IDEMPOTENT.
+ *
+ * ATTENTION : `withMarket` enveloppe son rappel dans un `.catch()`. Toute exception jetée ici —
+ * un identifiant libre, par exemple — s'affiche à l'écran comme « ⚠ Marché indisponible ». Et
+ * `tsc` ne lit pas ce fichier : seul `e2e/arbre.pw.mjs` garde ce piège.
+ */
+export function peuplerListes() {
+  if (pretes) return;
+  // Les trois index viennent de `marche.ts` ; ici on ne fait plus que peindre les listes.
+  construireIndex(etat.MARKET);
+  // Départ d'« En route » : les terminaux où l'on peut ACHETER.
+  $("originList").innerHTML = libellesOrigines().map((l) => `<option value="${esc(l)}"></option>`).join("");
+  // Toutes les stations (achat ou vente) : c'est la vue Corrections qui l'exige.
+  $("stationList").innerHTML = libellesStations().map((l) => `<option value="${esc(l)}"></option>`).join("");
+  // Toutes les commodités, pour l'ajout libre au chargement.
+  $("commodityList").innerHTML = etat.MARKET.commodities
+    .map((c) => `<option value="${esc(c.name)}">${esc(c.code || "")}</option>`).join("");
+
+  // Le sélecteur de station (ADR-003) se monte ICI et une seule fois : il lui faut MARKET, et
+  // c'est le seul point du cycle où le marché est garanti présent.
+  monterSelecteurStation();
+
+  pretes = true;
+}

--- a/manifeste-gestes.js
+++ b/manifeste-gestes.js
@@ -17,6 +17,10 @@ import { findCommodity, indexArriveeForcee, indexOrigine, stationMap } from "./m
 import { rafraichir } from "./rendu.ts";
 import { manifesteCourant, manifestRemaining, suggestionsFor } from "./manifeste-donnees.ts";
 import { compositionValide, oublierComposition, retenirComposition } from "./manifeste-etat.ts";
+import { copyManifest } from "./presse-papiers.js";
+import { manifestToJourney } from "./voyage-gestes.js";
+
+const $ = (id) => document.getElementById(id);
 
 const champ = (id) => document.getElementById(id)?.value ?? "";
 
@@ -91,3 +95,38 @@ export function oublierCompositionSiRouteChangee() {
 export function resetManifeste() { oublierComposition(); rafraichir(); }
 
 const chargementCourant = () => { const r = manifesteCourant(readFilters()); return r.etat === "ok" ? r.m : null; };
+
+/**
+ * Branche les trois délégations de la carte de chargement.
+ *
+ * Elles sont posées sur `#manifest`, et pas dans le délégué global du compagnon : cet écouteur-ci
+ * ne voit que SA carte, là où le délégué global voit toute la page. C'est ce qui garde `.suggest-add`
+ * sans ambiguïté — le délégué global, lui, ne le teste que sous `.jman-suggest`.
+ */
+export function brancherGestesManifeste() {
+  // Les totaux se recalculent à la FRAPPE, sans re-rendre : le champ SCU est non contrôlé, React
+  // garde son nœud, mais un cycle complet remonterait sa valeur calculée sous les doigts.
+  $("manifest").addEventListener("input", (e) => {
+    if (e.target.classList.contains("mqty-input")) updateManifestTotals();
+  });
+
+  $("manifest").addEventListener("click", (e) => {
+    if (e.target.closest("#manifestToJourney")) { manifestToJourney(); return; }
+    if (e.target.closest("#copyManifest")) { copyManifest(); return; }
+    if (e.target.closest("#manifestAddBtn")) { addManifestCommodity($("manifestAddInput").value); return; }
+    if (e.target.closest("#manifestReset")) { resetManifeste(); return; }
+    const del = e.target.closest(".mline-del");
+    if (del) { removeManifestLine(del.dataset.name); return; }
+    const add = e.target.closest(".suggest-add");
+    if (add) addSuggestion(add.dataset.name);
+  });
+
+  // Le `preventDefault()` est indispensable : le champ vit dans un formulaire implicite avec
+  // `#manifestAddBtn`, et Entrée le soumettrait.
+  $("manifest").addEventListener("keydown", (e) => {
+    if (e.target.id === "manifestAddInput" && e.key === "Enter") {
+      e.preventDefault();
+      addManifestCommodity(e.target.value);
+    }
+  });
+}

--- a/presse-papiers.js
+++ b/presse-papiers.js
@@ -100,3 +100,17 @@ export async function copyShareLink() {
     // Presse-papiers indisponible (contexte non sécurisé) : on laisse l'URL dans la barre.
   }
 }
+
+/**
+ * Branche les deux boutons de copie qui ne vivent pas dans une carte déjà déléguée.
+ *
+ * `#planCopy` passe par une délégation sur `#planHead` — le conteneur, pas le bouton : React le
+ * repeint à chaque rendu, et un écouteur posé sur le bouton lui-même mourrait au premier. C'est le
+ * précédent de la FRONTIÈRE (ADR-012 §2). `#share`, lui, est un bouton statique du rail.
+ */
+export function brancherPressePapiers() {
+  document.getElementById("planHead").addEventListener("click", (e) => {
+    if (e.target.closest("#planCopy")) copierPlan();
+  });
+  document.getElementById("share").addEventListener("click", copyShareLink);
+}

--- a/soute-gestes.js
+++ b/soute-gestes.js
@@ -1,0 +1,94 @@
+// LES GESTES DES TROIS CARTES DE LA SOUTE (ADR-012 §2).
+//
+// `#holdCard`, `#holdDeclare` et `#depotsCard` sont des conteneurs d'`index.html` que les portails
+// du bandeau REMPLISSENT sans les POSSÉDER. Les délégations posées ici une fois traversent donc
+// tous les rendus de l'arbre — et les convertir en `onClick` doublerait des gestes qui ne sont pas
+// idempotents.
+//
+// Les GESTES eux-mêmes vivent tous dans `soute-actions.js` ; ce module ne fait que les brancher.
+// Y compris les quatre qui portent un contrat de rendu synchrone (`ouvrirDeclaration`,
+// `ouvrirVente`) — ils sont là-bas parce que c'est là que vit `flushSync`, pas ici.
+//
+// ── DEUX ORDRES DE BRANCHES À NE PAS « RANGER » ───────────────────────────────────────────────
+//   — `.hold-sell-btn` avant `.hold-sell-no` et `.hold-sell-ok` ;
+//   — dans `#holdDeclare`, le keydown se garde par `closest(".hold-add")` — la CLASSE, pas les trois
+//     ids : `e2e/declaration.pw.mjs` l'épingle nommément.
+import { debounce } from "./rendu.ts";
+import { etat } from "./etat.ts";
+import {
+  basculerEcoulement, declarerABord, deposerIci, fermerDeclaration, fermerVente,
+  ouvrirDeclaration, ouvrirVente, poserPosition, reprendreIci, retirerLot, vendreIci, viderSoute,
+} from "./soute-actions.js";
+import { copierEntrepots } from "./presse-papiers.js";
+
+const $ = (id) => document.getElementById(id);
+
+/** Branche les trois cartes. Appelé une fois, à l'amorçage. */
+export function brancherGestesSoute() {
+  // ── La soute : vider, écouler, déposer, vendre, retirer un lot ───────────────────────────────
+  $("holdCard").addEventListener("click", (e) => {
+    if (e.target.closest("#holdClear")) { viderSoute(); return; }
+    if (e.target.closest("#holdOffload")) { basculerEcoulement(); return; }
+    // La quantité ET la station se lisent sur le MÊME conteneur : celui que le rendu a produit.
+    // `dataset.idx` absent -> undefined -> NaN -> repli sur `stationCourante()` ; jamais 0.
+    const deposer = e.target.closest(".hold-store");
+    if (deposer) {
+      const b = deposer.closest(".hold-sell");
+      deposerIci(deposer.dataset.name, Number(b.querySelector(".hold-sell-qty").value), Number(b.dataset.idx));
+      return;
+    }
+    const ouvrir = e.target.closest(".hold-sell-btn");
+    if (ouvrir) { ouvrirVente(ouvrir.dataset.name); return; }
+    if (e.target.closest(".hold-sell-no")) { fermerVente(); return; }
+    const ok = e.target.closest(".hold-sell-ok");
+    if (ok) {
+      const b = ok.closest(".hold-sell");
+      vendreIci(ok.dataset.name, Number(b.querySelector(".hold-sell-qty").value), Number(b.dataset.idx));
+      return;
+    }
+    const del = e.target.closest(".hold-del");
+    if (del) retirerLot(Number(del.dataset.i));
+  });
+
+  // Entrée valide la vente, Échap l'annule — même patron que les corrections en place.
+  $("holdCard").addEventListener("keydown", (e) => {
+    if (!e.target.classList.contains("hold-sell-qty")) return;
+    // Entrée doit encaisser à la MÊME station que le bouton ✓ : même index figé, lu sur le conteneur.
+    if (e.key === "Enter") {
+      e.preventDefault();
+      vendreIci(etat.venteEnCours, Number(e.target.value), Number(e.target.closest(".hold-sell")?.dataset.idx));
+    } else if (e.key === "Escape") { e.preventDefault(); fermerVente(); }
+  });
+
+  // ── Déclarer « j'ai ça à bord » (#55) : le seul chemin qui fait entrer du fret sans jambe ─────
+  $("holdDeclare").addEventListener("click", (e) => {
+    if (e.target.closest("#holdAddOpen")) { ouvrirDeclaration(); return; }
+    if (e.target.closest("#holdAddNo")) { fermerDeclaration(); return; }
+    if (e.target.closest("#holdAddOk")) declarerABord();
+  });
+
+  // Entrée valide depuis n'importe lequel des trois champs, Échap abandonne.
+  $("holdDeclare").addEventListener("keydown", (e) => {
+    if (!e.target.closest(".hold-add")) return;
+    if (e.key === "Enter") { e.preventDefault(); declarerABord(); }
+    else if (e.key === "Escape") { e.preventDefault(); fermerDeclaration(); }
+  });
+
+  // La position se résout à la frappe, DÉBOUNCÉE comme le champ de départ d'« En route » : c'est le
+  // même champ derrière, et une résolution par caractère repeindrait toute la page à chaque lettre.
+  // On capture la VALEUR tout de suite : l'événement, lui, sera périmé quand le timer se déclenchera.
+  const poserPositionDifferee = debounce(poserPosition);
+  $("holdDeclare").addEventListener("input", (e) => {
+    if (e.target.id === "holdWhere") poserPositionDifferee(e.target.value);
+  });
+
+  // ── Les entrepôts ───────────────────────────────────────────────────────────────────────────
+  // « Reprendre » remet le lot en soute. Un seul geste, pas de champ de quantité — on reprend ce
+  // qu'on a laissé ; une reprise partielle se ferait en redéposant. La fonction pure, elle, accepte
+  // déjà des SCU : l'interface pourra suivre sans la toucher.
+  $("depotsCard").addEventListener("click", (e) => {
+    if (e.target.closest("#copyDepots")) { copierEntrepots(); return; }
+    const b = e.target.closest(".depot-take");
+    if (b) reprendreIci(b.dataset.station, b.dataset.name, Number(b.dataset.units));
+  });
+}

--- a/voyage-gestes.js
+++ b/voyage-gestes.js
@@ -24,12 +24,15 @@ import { feeResolver } from "./frais.ts";
 import { findCommodity, resolveStationLabel, stationCourante, stationMap } from "./marche.ts";
 import { manifesteCourant, manifestRemaining, suggestionsFor } from "./manifeste-donnees.ts";
 import { rafraichir } from "./rendu.ts";
-import { saveChargements, saveSoute, venteImplicite } from "./soute-actions.js";
+import { chargerJambe, saveChargements, saveSoute, venteImplicite } from "./soute-actions.js";
 import {
   journeyEndIndex, legEffectiveLines, legIntent, legKey, legSuggestCtx, legTerminals,
   saveJourneyEdits, saveJourneyPins,
 } from "./voyage-donnees.ts";
 import { pickJourney, syncViewsToJourney } from "./voyage-actions.ts";
+import { listesPretes, peuplerListes } from "./listes.js";
+
+const $ = (id) => document.getElementById(id);
 
 // Le chargement courant de la carte « En route », dérivé à la demande (cf. manifeste-donnees.ts).
 const chargementCourant = () => { const r = manifesteCourant(readFilters()); return r.etat === "ok" ? r.m : null; };
@@ -221,4 +224,103 @@ export function removeJourneyStop(stopIndex) {
   etat.JOURNEY = r.start ? { legs: [], current: 0, start: r.start } : { legs: r.legs, current: r.current };
   syncViewsToJourney();
   rafraichir();
+}
+
+/**
+ * Branche les huit délégations du compagnon de voyage. Six d'entre elles vivent sur `document`.
+ *
+ * ── L'ORDRE DES BRANCHES DU CLIC EST UN CONTRAT ───────────────────────────────────────────────
+ * `.jleg-load` DOIT passer avant `.jleg-head` : le bouton « ✓ chargé » vit DANS l'en-tête de jambe,
+ * et l'inverse déplierait l'éditeur en plus de charger la soute.
+ *
+ * ── DEUX `document` keydown DANS DEUX MODULES ─────────────────────────────────────────────────
+ * Celui-ci (Entrée dans les trois champs d'ajout) et celui des raccourcis 1…8 (`navigation.js`) ne
+ * se recouvrent pas : le second sort si `activeElement` est un INPUT. Mais l'ordre d'enregistrement
+ * est devenu l'ordre d'IMPORT dans l'amorce — c'est écrit ici et là-bas, même si c'est aujourd'hui
+ * sans effet.
+ */
+export function brancherGestesVoyage() {
+  document.addEventListener("click", (e) => {
+    if (e.target.closest("#journeyClear")) { clearJourney(); return; }
+    // Démarrer un voyage « de zéro » : bouton « Commencer » depuis l'invite.
+    if (e.target.closest("#journeyStartBtn")) { beginJourney($("journeyStart").value); return; }
+    // Ajout d'arrêt : bouton « + Arrêt » ou une suggestion.
+    if (e.target.closest("#journeyAddBtn")) { addStopByTerminal($("journeyAddStop").value); return; }
+    const sug = e.target.closest(".jstop-suggest");
+    if (sug) { addStopByTerminal(sug.dataset.label); return; }
+    // Retirer un arrêt (✕ sur une étape) -> reconnexion des voisins.
+    const del = e.target.closest(".jstep-del");
+    if (del) { removeJourneyStop(Number(del.dataset.i)); return; }
+    // Édition du manifeste d'une jambe : déplier / retirer / ajouter / réinitialiser.
+    // `.jman-suggest .suggest-add` et NON `.suggest-add` nu : la carte de chargement pose le second
+    // et a sa propre délégation. Les deux ne se croisent que par cette qualification.
+    const legSug = e.target.closest(".jman-suggest .suggest-add");
+    if (legSug) { addLegSuggestion(Number(legSug.dataset.leg), legSug.dataset.name); return; }
+    const legDel = e.target.closest(".jman-del");
+    if (legDel) { delLegLine(Number(legDel.dataset.leg), legDel.dataset.name); return; }
+    const load = e.target.closest(".jleg-load");
+    if (load) { chargerJambe(Number(load.dataset.leg)); return; } // AVANT .jleg-head : le bouton y vit
+    if (e.target.closest(".jman-reset")) { resetLeg(Number(e.target.closest(".jman-reset").dataset.leg)); return; }
+    const addBtn = e.target.closest(".jman-add-btn");
+    if (addBtn) { addLegLine(Number(addBtn.dataset.leg), addBtn.closest(".jman-add").querySelector(".jman-add-input").value); return; }
+    const head = e.target.closest(".jleg-head");
+    if (head) { toggleLegEditor(Number(head.dataset.leg)); return; }
+    // Parcours interactif : clic sur une étape (⦿) = « je suis ici » -> recale les vues.
+    const step = e.target.closest(".jstep");
+    if (step) setJourneyStop(Number(step.dataset.i));
+  });
+
+  // L'en-tête d'une jambe est annoncé `role="button"` : Entrée/Espace doivent l'activer comme le
+  // clic. On teste `e.target` LUI-MÊME et non `closest()` — modèle `.editv` plutôt que `.jm-arret` :
+  // le bouton « ✓ chargé » vit DANS l'en-tête, et un `closest()` déplierait l'éditeur EN PLUS de
+  // charger la soute à chaque Entrée sur ce bouton.
+  $("journeyCard").addEventListener("keydown", (e) => {
+    if (!e.target.classList || !e.target.classList.contains("jleg-head")) return;
+    if (e.key !== "Enter" && e.key !== " ") return;
+    e.preventDefault(); // Espace ne doit pas défiler la page
+    toggleLegEditor(Number(e.target.dataset.leg));
+  });
+
+  // Ajout d'arrêt / de commodité à la touche Entrée.
+  document.addEventListener("keydown", (e) => {
+    if (e.target.id === "journeyStart" && e.key === "Enter") { e.preventDefault(); beginJourney(e.target.value); }
+    else if (e.target.id === "journeyAddStop" && e.key === "Enter") { e.preventDefault(); addStopByTerminal(e.target.value); }
+    else if (e.target.classList && e.target.classList.contains("jman-add-input") && e.key === "Enter") {
+      e.preventDefault();
+      addLegLine(Number(e.target.dataset.leg), e.target.value);
+    }
+  });
+
+  // Précharge le marché quand on focalise un champ terminal du compagnon -> peuple sa datalist.
+  document.addEventListener("focusin", (e) => {
+    if ((e.target.id === "journeyStart" || e.target.id === "journeyAddStop") && !listesPretes()) {
+      if (etat.MARKET) peuplerListes();
+      else withMarket(() => {});
+    }
+  });
+
+  // La carte 2D du parcours : cliquer une escale déplace « je suis ici », comme le fil d'étapes.
+  $("journeyMap").addEventListener("click", (e) => {
+    const a = e.target.closest(".jm-arret");
+    if (a) setJourneyStop(Number(a.dataset.i));
+  });
+  $("journeyMap").addEventListener("keydown", (e) => {
+    const a = e.target.closest(".jm-arret");
+    if (a && (e.key === "Enter" || e.key === " ")) { e.preventDefault(); setJourneyStop(Number(a.dataset.i)); }
+  });
+
+  // Les SCU d'une ligne de jambe : suggestions et profit en direct à la frappe (`liveLegQty`
+  // n'appelle que `notifier()`), persistance au blur ou à Entrée (`editLegQty`). Le couple
+  // input/change est la contrepartie exacte l'un de l'autre — les fusionner persisterait à chaque
+  // caractère.
+  document.addEventListener("input", (e) => {
+    if (e.target.classList && e.target.classList.contains("jman-qty")) {
+      liveLegQty(Number(e.target.dataset.leg), Number(e.target.dataset.i), e.target);
+    }
+  });
+  document.addEventListener("change", (e) => {
+    if (e.target.classList && e.target.classList.contains("jman-qty")) {
+      editLegQty(Number(e.target.dataset.leg), Number(e.target.dataset.i), e.target.value);
+    }
+  });
 }


### PR DESCRIPTION
## Ce que ça change

Rien à l'écran. `amorce.js` passe de **501 à 187 lignes** et ne porte plus qu'**un seul**
`addEventListener` — celui du service worker. Les 35 autres vivent désormais avec le code qu'ils
appellent, et le câblage tient en sept lignes.

## Pourquoi

Un point d'entrée qui déclare 35 délégations n'est plus un point d'entrée, c'est l'ancienne coquille
sous un autre nom. Quatre modules naissent, chacun avec une raison qui tient en une phrase — et pour
chacun, ce qui n'est pas devinable est écrit sur place :

**`controles.js`** (83 l.) — la barre de filtres et les réglages de chaque vue. Trois règles :
- saisie libre = débouncé, menu = immédiat (~142 ms par frappe sur CPU throttlé ×4, et WebKit
  plafonne `history.replaceState` à 100 appels / 10 s) ;
- `rafraichirDifferee` est **une** instance partagée par les six champs de la barre — en refabriquer
  une par module donnerait six timers, donc six rendus, sans qu'aucun test ne bronche. Mais `#origin`
  et `#destTerminal` ont chacun **le leur** : les fusionner ferait qu'une frappe dans l'un annule
  celle en cours dans l'autre ;
- `change` (cases maîtresses) et `input` (les deux autres) ne sont pas interchangeables.

**`corrections-gestes.js`** (77 l.) — la délégation sur `#corrections`, parent des trois portails de
la vue. L'ordre de ses branches est un contrat qu'**aucun test ne teste**, parce qu'ils exercent
chaque bouton isolément : `.al-del` en premier (le ✕ d'un relevé porte *aussi* `.corr-del` — c'est
le même bouton à l'écran), et `#exportCorrections` avant `#resetAll`.

**`soute-gestes.js`** (94 l.) — les trois cartes du bandeau.

**`listes.js`** (47 l.) — les trois `<datalist>` et leur drapeau. L'état y est **privé** derrière
`listesPretes()` : exporter la liaison `let` marcherait (les liaisons ES sont vives), mais un
importateur qui la recopie dans une `const` la figerait à `false`. Rien ne casserait — on
reconstruirait juste 114 + 92 `<option>` à chaque focus, et personne ne le verrait.

Trois modules existants reçoivent les délégations qui appellent leurs propres gestes :
`manifeste-gestes.js` (`#manifest`), `voyage-gestes.js` (les huit du compagnon, dont six sur
`document`), `presse-papiers.js` (`#planCopy` et `#share`).

Deux corps de geste montent dans `corrections-actions.ts` — `effacerStation()` et `revenirAUEX()` —
parce qu'ils étaient écrits **dans** un écouteur alors qu'ils portent une règle : geler les jambes
avant d'effacer un volume (#48).

**Aucune délégation ne devient un `onClick`.** Elles sont posées sur des conteneurs que les portails
remplissent sans les posséder : elles traversent les rendus (ADR-012 §2), et les convertir
doublerait `pinLegsForVolume`, `addLegLine` et `addSuggestion`, qui ne sont pas idempotents.

## Vérification

```
node --test          → tests 490 | pass 490 | fail 0
npx playwright test  → 246 tests | 244 passed | 2 skipped | 0 failed (1,6 min)
npx tsc --noEmit     → aucune sortie
npm run build:site   → ✓ built | précache 20 entrées
```

Le compte passe de 244 à 246 tests : le premier commit ajoute les deux qui manquaient (voir plus bas).

**Trois identifiants libres ont été attrapés avant les tests** — `brancherPressePapiers`,
`brancherGestesManifeste`, `brancherGestesVoyage`, appelés sans être importés. Par un contrôle
explicite « chaque `brancher*` appelé est-il importé ? », pas par chance : `tsc` ne lit pas ce
fichier et `vite build` non plus. C'est la classe de défaut qui a coûté deux régressions au lot
précédent, et elle se cherche à la main.

## Le filet posé d'abord

`#resetAllK` (« Tout oublier » les relevés) et `#copyManifest` n'étaient exercés par **aucun** test
e2e — mesuré par `grep`, alors que les trois autres boutons de copie en avaient un chacun. Le lot
allait les déplacer. Les deux tests sont écrits **avant**, et vus **rouges** sur le vrai code :

- en retirant le `confirm()` d'`oublierTousLesReleves` → le relevé s'efface malgré l'annulation ;
- en retirant l'en-tête de route de `copyManifest` → le texte copié n'est plus relisible.

Les deux sources ont été restaurées à l'identique (`git diff --numstat` vide, vérifié).

## Ce qui n'est pas couvert

- **`amorce.js` reste du JavaScript**, et c'est ce qui laisse passer les identifiants libres.
  Le passer en `.ts` bute sur ~50 `e.target.closest(...)`, `e.target` étant typé `EventTarget` :
  c'est un lot à part entière, pas un ajout de suffixe.
- **L'ordre de branchement des deux `keydown` sur `document`** (`navigation.js` et
  `voyage-gestes.js`) est devenu leur ordre d'exécution. Ils ne se recouvrent pas aujourd'hui — le
  premier sort si `activeElement` est un champ de saisie — et c'est écrit des deux côtés. Rien ne le
  teste.
- **`#meta` et `#railStatus` restent sans aucun test.** Ils n'ont pas bougé dans ce lot.
- ADR-011 point 6 (`style.css`) et point 7 (`strictNullChecks`) : entiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
