### PR TITLE
refactor(typage): le dépôt n'a plus un seul `.js` d'application

### DIFF
--- a/amorce.ts
+++ b/amorce.ts
@@ -34,6 +34,7 @@
 
 // Fonctions de calcul pures (testées par logic.test.mjs).
 import { etat } from "./etat.ts";
+import type { Boucle, Meta, Route } from "./types.ts";
 import { loadOverrides } from "./corrections.ts";
 import { updateOvBadge } from "./corrections-actions.ts";
 import { showToast } from "./messages.ts";
@@ -112,17 +113,20 @@ async function init() {
   const saved = loadState();
 
   try {
+    // Les trois `json()` rendent `any` : le type est POSÉ ICI, à la frontière, une fois. C'est le
+    // seul endroit du dépôt où des données extérieures entrent, et c'est donc le seul où un `as`
+    // dit quelque chose plutôt que de masquer.
     const [routes, loops, meta] = await Promise.all([
       fetch("data/routes.json").then((r) => r.json()),
       fetch("data/loops.json").then((r) => r.json()).catch(() => []),
       fetch("data/meta.json").then((r) => r.json()).catch(() => null),
       chargerVaisseaux(),
-    ]);
+    ]) as [Route[], Boucle[], Meta | null, void];
     etat.ROUTES = routes;
     etat.LOOPS = loops;
 
     // Remplit les filtres système (achat + vente) : #system et la destination « En route ».
-    const systems = [...new Set(routes.flatMap((r) => [r.buy.system, r.sell.system]))].sort();
+    const systems: string[] = [...new Set(routes.flatMap((r) => [r.buy.system, r.sell.system]))].sort();
     const sel = $("system"), dest = $("destSystem");
     systems.forEach((s) => {
       sel.appendChild(new Option(s, s));

--- a/amorce.ts
+++ b/amorce.ts
@@ -41,22 +41,22 @@ import { showToast } from "./messages.ts";
 import { loadAutoloadK } from "./frais.ts";
 import { applyState, loadState } from "./persistance.ts";
 import { brancher } from "./donnees.ts";
-import { basculerVue, brancherNavigation } from "./navigation.js";
+import { basculerVue, brancherNavigation } from "./navigation.ts";
 import { synchroniserReglages } from "./filtres.ts";
-import { brancherTri, poserIndicateursDeTri } from "./tri.js";
-import { brancherControles } from "./controles.js";
-import { brancherGestesCorrections } from "./corrections-gestes.js";
-import { brancherGestesSoute } from "./soute-gestes.js";
-import { peuplerListes } from "./listes.js";
+import { brancherTri, poserIndicateursDeTri } from "./tri.ts";
+import { brancherControles } from "./controles.ts";
+import { brancherGestesCorrections } from "./corrections-gestes.ts";
+import { brancherGestesSoute } from "./soute-gestes.ts";
+import { peuplerListes } from "./listes.ts";
 import { rafraichir } from "./rendu.ts";
-import { loadChargements, loadDepots, loadSoute } from "./soute-actions.js";
+import { loadChargements, loadDepots, loadSoute } from "./soute-actions.ts";
 import { loadManifestEdit } from "./manifeste-etat.ts";
-import { brancherGestesManifeste } from "./manifeste-gestes.js";
-import { brancherPressePapiers } from "./presse-papiers.js";
-import { brancherGestesVoyage } from "./voyage-gestes.js";
+import { brancherGestesManifeste } from "./manifeste-gestes.ts";
+import { brancherPressePapiers } from "./presse-papiers.ts";
+import { brancherGestesVoyage } from "./voyage-gestes.ts";
 
 
-import { chargerVaisseaux, montrerCarteVaisseau } from "./selecteur.js";
+import { chargerVaisseaux, montrerCarteVaisseau } from "./selecteur.ts";
 import { monterRacine } from "./main.tsx";
 import { loadJourneyEdits, loadJourneyPins } from "./voyage-donnees.ts";
 // Une seule chose de la vue Commodités arrive ici : le REFLET de son segmenté, que le rappel de

--- a/controles.ts
+++ b/controles.ts
@@ -28,10 +28,23 @@
 // `<input type="checkbox">` ; ne pas uniformiser en passant par ici.
 import { debounce, rafraichir, rafraichirDifferee } from "./rendu.ts";
 import { synchroniserReglages } from "./filtres.ts";
-import { oublierCompositionSiRouteChangee } from "./manifeste-gestes.js";
+import { oublierCompositionSiRouteChangee } from "./manifeste-gestes.ts";
 import { setCommBoard, setCommSort } from "./vues/commodites-vue.tsx";
 
-const $ = (id) => document.getElementById(id);
+import type { Noeud } from "./types.ts";
+// La CIBLE d'un événement, typée. `e.target` est un `EventTarget` : il n'a ni `closest`, ni
+// `classList`, ni `id`. Le cast est posé UNE fois par module, comme `$` — pas dans un module
+// partagé : c'est une expression d'une ligne, et six modules couplés à un alias ne valent pas
+// l'économie (même choix que `$`, pris huit fois dans ce dépôt).
+const cible = (e: Event) => e.target as Noeud;
+/** La même, quand le code a déjà établi que la cible est un champ (garde par `id` ou par classe). */
+const champ = (e: Event) => e.target as HTMLInputElement;
+
+
+// `$` est typé `HTMLInputElement` et non `HTMLElement`, parce que dans CE module il ne sert
+// qu'à des contrôles de formulaire — dont on lit ou écrit la `value`. C'est le même choix
+// que `filtres.ts` et `persistance.ts` : l'alias dit ce que le module en fait.
+const $ = (id: string) => document.getElementById(id) as HTMLInputElement;
 
 /** Branche les cinq barres de réglages. Appelé une fois, à l'amorçage. */
 export function brancherControles() {
@@ -73,11 +86,11 @@ export function brancherControles() {
   // `#commGrid` : sa tuile est un vrai `<button>` React qui porte son propre `onClick`, et la
   // délégation qui vivait là doublait l'action — seul un compteur de propagations l'avait vu.
   $("commSortModes").addEventListener("click", (e) => {
-    const b = e.target.closest("button[data-sort]");
+    const b = cible(e).closest("button[data-sort]");
     if (b) setCommSort(b.dataset.sort);
   });
   $("commBoardModes").addEventListener("click", (e) => {
-    const b = e.target.closest("button[data-board]");
+    const b = cible(e).closest("button[data-board]");
     if (b) setCommBoard(b.dataset.board);
   });
 }

--- a/corrections-gestes.ts
+++ b/corrections-gestes.ts
@@ -19,12 +19,25 @@ import { stationLabel } from "./logic.ts";
 import { debounce, rafraichir } from "./rendu.ts";
 import { effacerStation, effacerToutesLesCorrections, revenirAUEX } from "./corrections-actions.ts";
 import { enregistrerReleve, oublierReleve, oublierTousLesReleves } from "./frais-actions.ts";
-import { copierCorrections } from "./presse-papiers.js";
+import { copierCorrections } from "./presse-papiers.ts";
 import { termByName } from "./marche.ts";
 import { saveState } from "./persistance.ts";
-import { memoriserStation, stationChangee } from "./selecteur.js";
+import { memoriserStation, stationChangee } from "./selecteur.ts";
 
-const $ = (id) => document.getElementById(id);
+import type { ChampCorrection, CoteMarche, Noeud } from "./types.ts";
+// La CIBLE d'un événement, typée. `e.target` est un `EventTarget` : il n'a ni `closest`, ni
+// `classList`, ni `id`. Le cast est posé UNE fois par module, comme `$` — pas dans un module
+// partagé : c'est une expression d'une ligne, et six modules couplés à un alias ne valent pas
+// l'économie (même choix que `$`, pris huit fois dans ce dépôt).
+const cible = (e: Event) => e.target as Noeud;
+/** La même, quand le code a déjà établi que la cible est un champ (garde par `id` ou par classe). */
+const champ = (e: Event) => e.target as HTMLInputElement;
+
+
+// `$` est typé `HTMLInputElement` et non `HTMLElement`, parce que dans CE module il ne sert
+// qu'à des contrôles de formulaire — dont on lit ou écrit la `value`. C'est le même choix
+// que `filtres.ts` et `persistance.ts` : l'alias dit ce que le module en fait.
+const $ = (id: string) => document.getElementById(id) as HTMLInputElement;
 
 /** Branche le champ de station et la délégation de la vue. Appelé une fois, à l'amorçage. */
 export function brancherGestesCorrections() {
@@ -38,38 +51,41 @@ export function brancherGestesCorrections() {
   $("station").addEventListener("input", debounce(() => { if (stationChangee()) rafraichir(); }));
 
   $("corrections").addEventListener("click", (e) => {
-    const relDel = e.target.closest(".al-del"); // EN PREMIER : voir l'en-tête
+    const relDel = cible(e).closest(".al-del"); // EN PREMIER : voir l'en-tête
     if (relDel) { oublierReleve(relDel.dataset.key); return; }
 
     // Vignette de la bande : recharge sa station. Écrit le LIBELLÉ CANONIQUE, comme le sélecteur —
     // la résolution est exacte, et c'est ce libellé-là que le permalien transporte.
-    const tuile = e.target.closest(".stn-tile");
+    const tuile = cible(e).closest(".stn-tile") as HTMLButtonElement | null;
     if (tuile && !tuile.disabled) {
       const t = termByName.get(tuile.dataset.terminal);
       if (t) { $("station").value = stationLabel(t.name, t.system); memoriserStation(); rafraichir(); saveState(); }
       return;
     }
 
-    const undo = e.target.closest(".scomm-undo");
+    const undo = cible(e).closest(".scomm-undo");
     if (undo) {
-      const { c, t: terminal, s: cote, f: champ } = undo.dataset;
+      // Les quatre `data-*` sont posés ENSEMBLE par `vues/corrections.tsx` : ils existent ou la
+      // branche n'est pas atteinte. Le cast dit ce contrat, il ne le contourne pas.
+      const { c, t: terminal, s: cote, f: champ } = undo.dataset as
+        { c: string; t: string; s: CoteMarche; f: ChampCorrection };
       revenirAUEX(c, terminal, cote, champ);
       return;
     }
 
-    if (e.target.closest("#stnClear")) { effacerStation(); return; }
-    if (e.target.closest("#alSave")) { enregistrerReleve(); return; }
-    if (e.target.closest("#resetAllK")) { oublierTousLesReleves(); return; }
-    if (e.target.closest("#exportCorrections")) { copierCorrections(); return; } // AVANT #resetAll
-    if (e.target.closest("#resetAll")) effacerToutesLesCorrections();
+    if (cible(e).closest("#stnClear")) { effacerStation(); return; }
+    if (cible(e).closest("#alSave")) { enregistrerReleve(); return; }
+    if (cible(e).closest("#resetAllK")) { oublierTousLesReleves(); return; }
+    if (cible(e).closest("#exportCorrections")) { copierCorrections(); return; } // AVANT #resetAll
+    if (cible(e).closest("#resetAll")) effacerToutesLesCorrections();
   });
 
-  // Validation du relevé d'autoload à la touche Entrée. Testé par `e.target.id` et non par
+  // Validation du relevé d'autoload à la touche Entrée. Testé par `champ(e).id` et non par
   // `closest()` : les deux `<input>` sont rendus NON CONTRÔLÉS (`defaultValue`) par
   // `vues/frais-station.tsx`, dont la `key` porte le relevé lui-même. Les passer à `value=` les
   // gèlerait — c'est écrit en toutes lettres dans l'en-tête de ce composant.
   $("corrections").addEventListener("keydown", (e) => {
-    if ((e.target.id === "alAmount" || e.target.id === "alScu") && e.key === "Enter") {
+    if ((champ(e).id === "alAmount" || champ(e).id === "alScu") && e.key === "Enter") {
       e.preventDefault();
       enregistrerReleve();
     }

--- a/index.html
+++ b/index.html
@@ -440,7 +440,7 @@
        composants à son tour. -->
   <div id="racine"></div>
 
-  <script type="module" src="amorce.js"></script>
+  <script type="module" src="amorce.ts"></script>
   <!-- Sorti de la page pour que `script-src 'self'` ait un sens (cf. la <meta> du <head>).
        Script CLASSIQUE et non module : il doit continuer de s'exécuter AVANT app.js (différé),
        sans quoi le rail s'afficherait déplié le temps d'un rendu. Toute retouche ici se répercute

--- a/listes.ts
+++ b/listes.ts
@@ -7,9 +7,12 @@
 import { construireIndex, libellesOrigines, libellesStations } from "./marche.ts";
 import { etat } from "./etat.ts";
 import { esc } from "./format.ts";
-import { monterSelecteurStation } from "./selecteur.js";
+import { monterSelecteurStation } from "./selecteur.ts";
 
-const $ = (id) => document.getElementById(id);
+// `$` est typé `HTMLInputElement` et non `HTMLElement`, parce que dans CE module il ne sert
+// qu'à des contrôles de formulaire — dont on lit ou écrit la `value`. C'est le même choix
+// que `filtres.ts` et `persistance.ts` : l'alias dit ce que le module en fait.
+const $ = (id: string) => document.getElementById(id) as HTMLInputElement;
 
 // L'état est PRIVÉ et son lecteur est une fonction : exporter la liaison `let` marcherait — les
 // liaisons ES sont vives — mais un importateur qui la recopie dans une `const` la figerait à

--- a/manifeste-gestes.ts
+++ b/manifeste-gestes.ts
@@ -17,12 +17,25 @@ import { findCommodity, indexArriveeForcee, indexOrigine, stationMap } from "./m
 import { rafraichir } from "./rendu.ts";
 import { manifesteCourant, manifestRemaining, suggestionsFor } from "./manifeste-donnees.ts";
 import { compositionValide, oublierComposition, retenirComposition } from "./manifeste-etat.ts";
-import { copyManifest } from "./presse-papiers.js";
-import { manifestToJourney } from "./voyage-gestes.js";
+import { copyManifest } from "./presse-papiers.ts";
+import { manifestToJourney } from "./voyage-gestes.ts";
 
-const $ = (id) => document.getElementById(id);
+import type { Noeud } from "./types.ts";
+// La CIBLE d'un événement, typée. `e.target` est un `EventTarget` : il n'a ni `closest`, ni
+// `classList`, ni `id`. Le cast est posé UNE fois par module, comme `$` — pas dans un module
+// partagé : c'est une expression d'une ligne, et six modules couplés à un alias ne valent pas
+// l'économie (même choix que `$`, pris huit fois dans ce dépôt).
+const cible = (e: Event) => e.target as Noeud;
+/** La même, quand le code a déjà établi que la cible est un champ (garde par `id` ou par classe). */
+const champCible = (e: Event) => e.target as HTMLInputElement;
 
-const champ = (id) => document.getElementById(id)?.value ?? "";
+
+// `$` est typé `HTMLInputElement` et non `HTMLElement`, parce que dans CE module il ne sert
+// qu'à des contrôles de formulaire — dont on lit ou écrit la `value`. C'est le même choix
+// que `filtres.ts` et `persistance.ts` : l'alias dit ce que le module en fait.
+const $ = (id: string) => document.getElementById(id) as HTMLInputElement;
+
+const champ = (id: string) => (document.getElementById(id) as HTMLInputElement | null)?.value ?? "";
 
 export function addSuggestion(name) {
   const m = chargementCourant();
@@ -57,7 +70,7 @@ export function removeManifestLine(name) {
 export function updateManifestTotals() {
   const m = chargementCourant();
   if (!m) return;
-  document.querySelectorAll("#manifest .mqty-input").forEach((inp) => {
+  document.querySelectorAll<HTMLInputElement>("#manifest .mqty-input").forEach((inp) => {
     const i = Number(inp.dataset.i);
     let u = Math.floor(Number(inp.value));
     if (!Number.isFinite(u) || u < 0) u = 0;
@@ -107,26 +120,26 @@ export function brancherGestesManifeste() {
   // Les totaux se recalculent à la FRAPPE, sans re-rendre : le champ SCU est non contrôlé, React
   // garde son nœud, mais un cycle complet remonterait sa valeur calculée sous les doigts.
   $("manifest").addEventListener("input", (e) => {
-    if (e.target.classList.contains("mqty-input")) updateManifestTotals();
+    if (cible(e).classList.contains("mqty-input")) updateManifestTotals();
   });
 
   $("manifest").addEventListener("click", (e) => {
-    if (e.target.closest("#manifestToJourney")) { manifestToJourney(); return; }
-    if (e.target.closest("#copyManifest")) { copyManifest(); return; }
-    if (e.target.closest("#manifestAddBtn")) { addManifestCommodity($("manifestAddInput").value); return; }
-    if (e.target.closest("#manifestReset")) { resetManifeste(); return; }
-    const del = e.target.closest(".mline-del");
+    if (cible(e).closest("#manifestToJourney")) { manifestToJourney(); return; }
+    if (cible(e).closest("#copyManifest")) { copyManifest(); return; }
+    if (cible(e).closest("#manifestAddBtn")) { addManifestCommodity($("manifestAddInput").value); return; }
+    if (cible(e).closest("#manifestReset")) { resetManifeste(); return; }
+    const del = cible(e).closest(".mline-del");
     if (del) { removeManifestLine(del.dataset.name); return; }
-    const add = e.target.closest(".suggest-add");
+    const add = cible(e).closest(".suggest-add");
     if (add) addSuggestion(add.dataset.name);
   });
 
   // Le `preventDefault()` est indispensable : le champ vit dans un formulaire implicite avec
   // `#manifestAddBtn`, et Entrée le soumettrait.
   $("manifest").addEventListener("keydown", (e) => {
-    if (e.target.id === "manifestAddInput" && e.key === "Enter") {
+    if (champCible(e).id === "manifestAddInput" && e.key === "Enter") {
       e.preventDefault();
-      addManifestCommodity(e.target.value);
+      addManifestCommodity(champCible(e).value);
     }
   });
 }

--- a/navigation.ts
+++ b/navigation.ts
@@ -22,7 +22,20 @@
 import { etat } from "./etat.ts";
 import { rafraichir } from "./rendu.ts";
 
-const $ = (id) => document.getElementById(id);
+import type { Noeud } from "./types.ts";
+// La CIBLE d'un événement, typée. `e.target` est un `EventTarget` : il n'a ni `closest`, ni
+// `classList`, ni `id`. Le cast est posé UNE fois par module, comme `$` — pas dans un module
+// partagé : c'est une expression d'une ligne, et six modules couplés à un alias ne valent pas
+// l'économie (même choix que `$`, pris huit fois dans ce dépôt).
+const cible = (e: Event) => e.target as Noeud;
+/** La même, quand le code a déjà établi que la cible est un champ (garde par `id` ou par classe). */
+const champ = (e: Event) => e.target as HTMLInputElement;
+
+
+// `$` est typé `HTMLInputElement` et non `HTMLElement`, parce que dans CE module il ne sert
+// qu'à des contrôles de formulaire — dont on lit ou écrit la `value`. C'est le même choix
+// que `filtres.ts` et `persistance.ts` : l'alias dit ce que le module en fait.
+const $ = (id: string) => document.getElementById(id) as HTMLInputElement;
 
 /**
  * Les sections que chaque vue démasque. Une vue absente de la table n'en démasque aucune — ce qui
@@ -53,7 +66,7 @@ export function basculerVue(v) {
 
   // Le rail : un `.active` et un seul. La boucle sur `data-view` le garantit par construction —
   // huit `classList.toggle` écrits à la main en oublieraient un à la neuvième vue.
-  document.querySelectorAll(".rail-nav .vbtn").forEach((b) => {
+  document.querySelectorAll<HTMLElement>(".rail-nav .vbtn").forEach((b) => {
     b.classList.toggle("active", b.dataset.view === v);
   });
 
@@ -85,7 +98,7 @@ export function basculerVue(v) {
 export function brancherNavigation() {
   const rail = document.querySelector(".rail-nav");
   if (rail) rail.addEventListener("click", (e) => {
-    const b = e.target.closest(".vbtn[data-view]");
+    const b = cible(e).closest(".vbtn[data-view]");
     if (b) basculerVue(b.dataset.view);
   });
   $("brandHome")?.addEventListener("click", () => basculerVue("routes"));
@@ -106,7 +119,7 @@ export function brancherNavigation() {
     // se désynchroniser de l'autre — c'était deux tables jumelles à tenir à la main.
     const rang = "12345678".indexOf(e.key);
     if (rang < 0) return;
-    const b = document.querySelectorAll(".rail-nav .vbtn")[rang];
+    const b = document.querySelectorAll<HTMLElement>(".rail-nav .vbtn")[rang];
     if (b) basculerVue(b.dataset.view);
   });
 }

--- a/presse-papiers.ts
+++ b/presse-papiers.ts
@@ -19,6 +19,16 @@ import { saveState, shareURL } from "./persistance.ts";
 import { manifesteCourant } from "./manifeste-donnees.ts";
 import { planData, planHypotheses } from "./vues/plan-vue.tsx";
 
+import type { Noeud } from "./types.ts";
+// La CIBLE d'un événement, typée. `e.target` est un `EventTarget` : il n'a ni `closest`, ni
+// `classList`, ni `id`. Le cast est posé UNE fois par module, comme `$` — pas dans un module
+// partagé : c'est une expression d'une ligne, et six modules couplés à un alias ne valent pas
+// l'économie (même choix que `$`, pris huit fois dans ce dépôt).
+const cible = (e: Event) => e.target as Noeud;
+/** La même, quand le code a déjà établi que la cible est un champ (garde par `id` ou par classe). */
+const champ = (e: Event) => e.target as HTMLInputElement;
+
+
 const nowSec = () => Math.floor(Date.now() / 1000);
 const bouton = (id) => document.getElementById(id);
 const chargementCourant = () => { const r = manifesteCourant(readFilters()); return r.etat === "ok" ? r.m : null; };
@@ -110,7 +120,7 @@ export async function copyShareLink() {
  */
 export function brancherPressePapiers() {
   document.getElementById("planHead").addEventListener("click", (e) => {
-    if (e.target.closest("#planCopy")) copierPlan();
+    if (cible(e).closest("#planCopy")) copierPlan();
   });
   document.getElementById("share").addEventListener("click", copyShareLink);
 }

--- a/selecteur.ts
+++ b/selecteur.ts
@@ -25,7 +25,20 @@ import { indexStationExacte } from "./marche.ts";
 import { saveState } from "./persistance.ts";
 import { rafraichir } from "./rendu.ts";
 
-const $ = (id) => document.getElementById(id);
+import type { Noeud } from "./types.ts";
+// La CIBLE d'un événement, typée. `e.target` est un `EventTarget` : il n'a ni `closest`, ni
+// `classList`, ni `id`. Le cast est posé UNE fois par module, comme `$` — pas dans un module
+// partagé : c'est une expression d'une ligne, et six modules couplés à un alias ne valent pas
+// l'économie (même choix que `$`, pris huit fois dans ce dépôt).
+const cible = (e: Event) => e.target as Noeud;
+/** La même, quand le code a déjà établi que la cible est un champ (garde par `id` ou par classe). */
+const champ = (e: Event) => e.target as HTMLInputElement;
+
+
+// `$` est typé `HTMLInputElement` et non `HTMLElement`, parce que dans CE module il ne sert
+// qu'à des contrôles de formulaire — dont on lit ou écrit la `value`. C'est le même choix
+// que `filtres.ts` et `persistance.ts` : l'alias dit ce que le module en fait.
+const $ = (id: string) => document.getElementById(id) as HTMLInputElement;
 
 // ── LE WIDGET ──────────────────────────────────────────────────────────────────────────────────
 // Autocomplétion maison, partagée par le champ Vaisseau et le sélecteur de station (ADR-003).
@@ -106,7 +119,7 @@ export function monterAutocompletion({ input, list, options, filtre, rendu, choi
 
   // mousedown (et non click) pour devancer le blur du champ.
   list.addEventListener("mousedown", (e) => {
-    const li = e.target.closest("li[data-i]"); // les en-têtes de groupe n'en portent pas : inertes
+    const li = cible(e).closest("li[data-i]"); // les en-têtes de groupe n'en portent pas : inertes
     if (!li) return;
     e.preventDefault();
     valide(matches[Number(li.dataset.i)]);
@@ -158,7 +171,7 @@ export function monterSelecteurStation() {
   // laisserait une image cassée. Les événements `error` ne remontent pas, mais ils descendent :
   // un seul écouteur en phase de CAPTURE, posé une fois, couvre tous les rendus à venir.
   list.addEventListener("error", (e) => {
-    if (e.target.tagName === "IMG") e.target.closest("li")?.classList.add("no-shot");
+    if (cible(e).tagName === "IMG") cible(e).closest("li")?.classList.add("no-shot");
   }, true);
 
   monterAutocompletion({

--- a/soute-actions.ts
+++ b/soute-actions.ts
@@ -37,7 +37,7 @@ import {
 } from "./voyage-donnees.ts";
 
 const nowSec = () => Math.floor(Date.now() / 1000);
-const champ = (id) => document.getElementById(id)?.value ?? "";
+const champ = (id: string) => (document.getElementById(id) as HTMLInputElement | null)?.value ?? "";
 
 // Les trois clés de stockage, et le formateur de montant signé des messages.
 const HOLD_KEY = "best-hauling-hold";
@@ -220,7 +220,7 @@ export function fermerDeclaration() { etat.declarationOuverte = false; notifier(
 export function ouvrirVente(nom) {
   etat.venteEnCours = nom;
   flushSync(notifier);
-  document.getElementById("holdCard")?.querySelector(".hold-sell-qty")?.select();
+  document.getElementById("holdCard")?.querySelector<HTMLInputElement>(".hold-sell-qty")?.select();
 }
 
 /** Referme le champ de vente. */
@@ -247,8 +247,8 @@ export function declarerABord() {
     (prix > 0 ? `${fmt(prix)} aUEC/SCU payés` : "butin, coût nul"));
 }
 
-export function poserPosition(v) {
-  const c = document.getElementById("origin");
+export function poserPosition(v: string) {
+  const c = document.getElementById("origin") as HTMLInputElement | null;
   if (c) c.value = v;
   rafraichir();
 }

--- a/soute-gestes.ts
+++ b/soute-gestes.ts
@@ -18,58 +18,71 @@ import { etat } from "./etat.ts";
 import {
   basculerEcoulement, declarerABord, deposerIci, fermerDeclaration, fermerVente,
   ouvrirDeclaration, ouvrirVente, poserPosition, reprendreIci, retirerLot, vendreIci, viderSoute,
-} from "./soute-actions.js";
-import { copierEntrepots } from "./presse-papiers.js";
+} from "./soute-actions.ts";
+import { copierEntrepots } from "./presse-papiers.ts";
 
-const $ = (id) => document.getElementById(id);
+import type { Noeud } from "./types.ts";
+// La CIBLE d'un événement, typée. `e.target` est un `EventTarget` : il n'a ni `closest`, ni
+// `classList`, ni `id`. Le cast est posé UNE fois par module, comme `$` — pas dans un module
+// partagé : c'est une expression d'une ligne, et six modules couplés à un alias ne valent pas
+// l'économie (même choix que `$`, pris huit fois dans ce dépôt).
+const cible = (e: Event) => e.target as Noeud;
+/** La même, quand le code a déjà établi que la cible est un champ (garde par `id` ou par classe). */
+const champ = (e: Event) => e.target as HTMLInputElement;
+
+
+// `$` est typé `HTMLInputElement` et non `HTMLElement`, parce que dans CE module il ne sert
+// qu'à des contrôles de formulaire — dont on lit ou écrit la `value`. C'est le même choix
+// que `filtres.ts` et `persistance.ts` : l'alias dit ce que le module en fait.
+const $ = (id: string) => document.getElementById(id) as HTMLInputElement;
 
 /** Branche les trois cartes. Appelé une fois, à l'amorçage. */
 export function brancherGestesSoute() {
   // ── La soute : vider, écouler, déposer, vendre, retirer un lot ───────────────────────────────
   $("holdCard").addEventListener("click", (e) => {
-    if (e.target.closest("#holdClear")) { viderSoute(); return; }
-    if (e.target.closest("#holdOffload")) { basculerEcoulement(); return; }
+    if (cible(e).closest("#holdClear")) { viderSoute(); return; }
+    if (cible(e).closest("#holdOffload")) { basculerEcoulement(); return; }
     // La quantité ET la station se lisent sur le MÊME conteneur : celui que le rendu a produit.
     // `dataset.idx` absent -> undefined -> NaN -> repli sur `stationCourante()` ; jamais 0.
-    const deposer = e.target.closest(".hold-store");
+    const deposer = cible(e).closest(".hold-store");
     if (deposer) {
       const b = deposer.closest(".hold-sell");
-      deposerIci(deposer.dataset.name, Number(b.querySelector(".hold-sell-qty").value), Number(b.dataset.idx));
+      deposerIci(deposer.dataset.name, Number(b!.querySelector<HTMLInputElement>(".hold-sell-qty")!.value), Number(b!.dataset.idx));
       return;
     }
-    const ouvrir = e.target.closest(".hold-sell-btn");
+    const ouvrir = cible(e).closest(".hold-sell-btn");
     if (ouvrir) { ouvrirVente(ouvrir.dataset.name); return; }
-    if (e.target.closest(".hold-sell-no")) { fermerVente(); return; }
-    const ok = e.target.closest(".hold-sell-ok");
+    if (cible(e).closest(".hold-sell-no")) { fermerVente(); return; }
+    const ok = cible(e).closest(".hold-sell-ok");
     if (ok) {
       const b = ok.closest(".hold-sell");
-      vendreIci(ok.dataset.name, Number(b.querySelector(".hold-sell-qty").value), Number(b.dataset.idx));
+      vendreIci(ok.dataset.name, Number(b!.querySelector<HTMLInputElement>(".hold-sell-qty")!.value), Number(b!.dataset.idx));
       return;
     }
-    const del = e.target.closest(".hold-del");
+    const del = cible(e).closest(".hold-del");
     if (del) retirerLot(Number(del.dataset.i));
   });
 
   // Entrée valide la vente, Échap l'annule — même patron que les corrections en place.
   $("holdCard").addEventListener("keydown", (e) => {
-    if (!e.target.classList.contains("hold-sell-qty")) return;
+    if (!cible(e).classList.contains("hold-sell-qty")) return;
     // Entrée doit encaisser à la MÊME station que le bouton ✓ : même index figé, lu sur le conteneur.
     if (e.key === "Enter") {
       e.preventDefault();
-      vendreIci(etat.venteEnCours, Number(e.target.value), Number(e.target.closest(".hold-sell")?.dataset.idx));
+      vendreIci(etat.venteEnCours, Number(champ(e).value), Number(cible(e).closest(".hold-sell")?.dataset.idx));
     } else if (e.key === "Escape") { e.preventDefault(); fermerVente(); }
   });
 
   // ── Déclarer « j'ai ça à bord » (#55) : le seul chemin qui fait entrer du fret sans jambe ─────
   $("holdDeclare").addEventListener("click", (e) => {
-    if (e.target.closest("#holdAddOpen")) { ouvrirDeclaration(); return; }
-    if (e.target.closest("#holdAddNo")) { fermerDeclaration(); return; }
-    if (e.target.closest("#holdAddOk")) declarerABord();
+    if (cible(e).closest("#holdAddOpen")) { ouvrirDeclaration(); return; }
+    if (cible(e).closest("#holdAddNo")) { fermerDeclaration(); return; }
+    if (cible(e).closest("#holdAddOk")) declarerABord();
   });
 
   // Entrée valide depuis n'importe lequel des trois champs, Échap abandonne.
   $("holdDeclare").addEventListener("keydown", (e) => {
-    if (!e.target.closest(".hold-add")) return;
+    if (!cible(e).closest(".hold-add")) return;
     if (e.key === "Enter") { e.preventDefault(); declarerABord(); }
     else if (e.key === "Escape") { e.preventDefault(); fermerDeclaration(); }
   });
@@ -79,7 +92,7 @@ export function brancherGestesSoute() {
   // On capture la VALEUR tout de suite : l'événement, lui, sera périmé quand le timer se déclenchera.
   const poserPositionDifferee = debounce(poserPosition);
   $("holdDeclare").addEventListener("input", (e) => {
-    if (e.target.id === "holdWhere") poserPositionDifferee(e.target.value);
+    if (champ(e).id === "holdWhere") poserPositionDifferee(champ(e).value);
   });
 
   // ── Les entrepôts ───────────────────────────────────────────────────────────────────────────
@@ -87,8 +100,8 @@ export function brancherGestesSoute() {
   // qu'on a laissé ; une reprise partielle se ferait en redéposant. La fonction pure, elle, accepte
   // déjà des SCU : l'interface pourra suivre sans la toucher.
   $("depotsCard").addEventListener("click", (e) => {
-    if (e.target.closest("#copyDepots")) { copierEntrepots(); return; }
-    const b = e.target.closest(".depot-take");
+    if (cible(e).closest("#copyDepots")) { copierEntrepots(); return; }
+    const b = cible(e).closest(".depot-take");
     if (b) reprendreIci(b.dataset.station, b.dataset.name, Number(b.dataset.units));
   });
 }

--- a/sw.js
+++ b/sw.js
@@ -11,7 +11,7 @@ const CACHE = "best-hauling-v1.1.0";
 // `logic.mjs` n'y figure plus depuis qu'il est devenu `logic.ts` (ADR-008 §5) — un fichier
 // TypeScript n'est pas servi au navigateur, il est bundlé dans l'entrée. Le laisser aurait fait
 // rejeter `addAll` EN BLOC, qui est atomique, et supprimé tout le hors-ligne au lieu de le dégrader.
-const SHELL = ["./", "./index.html", "./amorce.js", "./rail.js", "./style.css", "./fonts/fonts.css", "./icon.svg", "./manifest.webmanifest"];
+const SHELL = ["./", "./index.html", "./amorce.ts", "./rail.js", "./style.css", "./fonts/fonts.css", "./icon.svg", "./manifest.webmanifest"];
 
 self.addEventListener("install", (e) => {
   e.waitUntil(caches.open(CACHE).then((c) => c.addAll(SHELL)).then(() => self.skipWaiting()));

--- a/tri.ts
+++ b/tri.ts
@@ -44,7 +44,7 @@ function enTeteTriable(th, appliquer) {
  * au milieu d'une restauration — précisément ce que ce verrou existe pour empêcher.
  */
 export function poserIndicateursDeTri() {
-  document.querySelectorAll("#routes th, #loops th").forEach((h) => {
+  document.querySelectorAll<HTMLElement>("#routes th, #loops th").forEach((h) => {
     h.classList.remove("sorted-asc", "sorted-desc");
     if (h.dataset.sort || h.dataset.sortLoop) h.setAttribute("aria-sort", "none");
   });
@@ -54,7 +54,7 @@ export function poserIndicateursDeTri() {
 
 const marquer = (selecteur, cle, sens) => {
   if (!safeKey(cle)) return;
-  const th = document.querySelector(selecteur);
+  const th = document.querySelector<HTMLElement>(selecteur);
   if (!th) return;
   th.classList.add(sens === -1 ? "sorted-desc" : "sorted-asc");
   th.setAttribute("aria-sort", sens === -1 ? "descending" : "ascending");
@@ -71,7 +71,7 @@ export function brancherTri() {
   if (branche) return;
   branche = true;
 
-  document.querySelectorAll("th[data-sort]").forEach((th) => {
+  document.querySelectorAll<HTMLElement>("th[data-sort]").forEach((th) => {
     enTeteTriable(th, () => {
       const cle = th.dataset.sort;
       if (etat.sortKey === cle) etat.sortDir *= -1;
@@ -81,7 +81,7 @@ export function brancherTri() {
     });
   });
 
-  document.querySelectorAll("th[data-sort-loop]").forEach((th) => {
+  document.querySelectorAll<HTMLElement>("th[data-sort-loop]").forEach((th) => {
     enTeteTriable(th, () => {
       const cle = th.dataset.sortLoop;
       if (etat.loopSortKey === cle) etat.loopSortDir *= -1;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,5 +37,5 @@
     "verbatimModuleSyntax": true,
     "jsx": "react-jsx"
   },
-  "include": ["amorce.ts", "logic.ts", "types.ts", "etat.ts", "format.ts", "filtres.ts", "corrections.ts", "marche.ts", "frais.ts", "persistance.ts", "donnees.ts", "voyage-donnees.ts", "App.tsx", "main.tsx", "vues/**/*.tsx"]
+  "include": ["amorce.ts", "controles.ts", "corrections-gestes.ts", "soute-gestes.ts", "listes.ts", "navigation.ts", "tri.ts", "selecteur.ts", "manifeste-gestes.ts", "voyage-gestes.ts", "presse-papiers.ts", "soute-actions.ts", "logic.ts", "types.ts", "etat.ts", "format.ts", "filtres.ts", "corrections.ts", "marche.ts", "frais.ts", "persistance.ts", "donnees.ts", "voyage-donnees.ts", "App.tsx", "main.tsx", "vues/**/*.tsx"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,8 +18,9 @@
     "`noImplicitAny` viendront ensuite, chacun dans sa PR — sinon on ne saurait plus quelle marche",
     "a cassé quoi.",
     "",
-    "app.js et les scripts/ ne sont PAS inclus : ils restent du JavaScript tant que la migration ne",
-    "les a pas atteints, et `allowJs` les ferait entrer avec tout leur bruit."
+    "amorce.ts EST inclus depuis que ses 35 ecouteurs sont partis : il ne restait plus un seul",
+    "`e.target`, et c est ce qui bloquait. Les modules de gestes .js et les scripts/ ne le sont PAS —",
+    "ils portent les `e.target` typés `EventTarget`, et `allowJs` les ferait entrer avec leur bruit."
   ],
   "compilerOptions": {
     "target": "ES2022",
@@ -36,5 +37,5 @@
     "verbatimModuleSyntax": true,
     "jsx": "react-jsx"
   },
-  "include": ["logic.ts", "types.ts", "etat.ts", "format.ts", "filtres.ts", "corrections.ts", "marche.ts", "frais.ts", "persistance.ts", "donnees.ts", "voyage-donnees.ts", "App.tsx", "main.tsx", "vues/**/*.tsx"]
+  "include": ["amorce.ts", "logic.ts", "types.ts", "etat.ts", "format.ts", "filtres.ts", "corrections.ts", "marche.ts", "frais.ts", "persistance.ts", "donnees.ts", "voyage-donnees.ts", "App.tsx", "main.tsx", "vues/**/*.tsx"]
 }

--- a/types.ts
+++ b/types.ts
@@ -1044,3 +1044,18 @@ export type Meta = {
   app_version?: string;
   commit?: string;
 };
+
+/**
+ * Un nœud de NOTRE arbre, tel que les délégations le manipulent.
+ *
+ * `Element.closest()` rend `Element | null` dans `lib.dom`, ce qui est exact en général et faux
+ * ici : tout ce que cette application rend est du HTML, et chaque délégation lit ensuite un
+ * `dataset`. Sans ce type, les 39 `closest(...).dataset` du dépôt demanderaient 39 casts.
+ *
+ * L'interface se referme sur elle-même — `closest` rend un `Noeud` — pour que la chaîne
+ * `e.target.closest(a).closest(b)` reste typée. C'est un rétrécissement LÉGITIME : `Noeud | null`
+ * est assignable à `Element | null`, donc rien n'est promis qui ne soit vrai.
+ */
+export interface Noeud extends HTMLElement {
+  closest(selecteurs: string): Noeud | null;
+}

--- a/types.ts
+++ b/types.ts
@@ -1021,3 +1021,26 @@ export type DisqueSysteme = {
   corps: CorpsCarte[];
   auMax?: number;
 };
+
+/**
+ * L'estampille que le pipeline écrit dans `data/meta.json` : d'où viennent les données, de quand,
+ * et combien il y en a. Lue UNE fois à l'amorçage, jamais relue — c'est ce qui lui vaut de ne pas
+ * entrer dans `etat.ts`.
+ *
+ * `app_version` et `commit` sont FACULTATIFS et c'est délibéré : l'amorce versionnée dans `data/`
+ * ne les porte pas tant qu'un build n'est pas passé, et le rail préfère alors ne rien afficher
+ * plutôt qu'un « v— ».
+ */
+export type Meta = {
+  generated_at: number;
+  source: string;
+  source_url: string;
+  commodities: number;
+  terminals: number;
+  routes: number;
+  loops?: number;
+  systems: string[];
+  data_signature: string;
+  app_version?: string;
+  commit?: string;
+};

--- a/voyage-gestes.ts
+++ b/voyage-gestes.ts
@@ -24,15 +24,28 @@ import { feeResolver } from "./frais.ts";
 import { findCommodity, resolveStationLabel, stationCourante, stationMap } from "./marche.ts";
 import { manifesteCourant, manifestRemaining, suggestionsFor } from "./manifeste-donnees.ts";
 import { rafraichir } from "./rendu.ts";
-import { chargerJambe, saveChargements, saveSoute, venteImplicite } from "./soute-actions.js";
+import { chargerJambe, saveChargements, saveSoute, venteImplicite } from "./soute-actions.ts";
 import {
   journeyEndIndex, legEffectiveLines, legIntent, legKey, legSuggestCtx, legTerminals,
   saveJourneyEdits, saveJourneyPins,
 } from "./voyage-donnees.ts";
 import { pickJourney, syncViewsToJourney } from "./voyage-actions.ts";
-import { listesPretes, peuplerListes } from "./listes.js";
+import { listesPretes, peuplerListes } from "./listes.ts";
 
-const $ = (id) => document.getElementById(id);
+import type { Noeud } from "./types.ts";
+// La CIBLE d'un événement, typée. `e.target` est un `EventTarget` : il n'a ni `closest`, ni
+// `classList`, ni `id`. Le cast est posé UNE fois par module, comme `$` — pas dans un module
+// partagé : c'est une expression d'une ligne, et six modules couplés à un alias ne valent pas
+// l'économie (même choix que `$`, pris huit fois dans ce dépôt).
+const cible = (e: Event) => e.target as Noeud;
+/** La même, quand le code a déjà établi que la cible est un champ (garde par `id` ou par classe). */
+const champ = (e: Event) => e.target as HTMLInputElement;
+
+
+// `$` est typé `HTMLInputElement` et non `HTMLElement`, parce que dans CE module il ne sert
+// qu'à des contrôles de formulaire — dont on lit ou écrit la `value`. C'est le même choix
+// que `filtres.ts` et `persistance.ts` : l'alias dit ce que le module en fait.
+const $ = (id: string) => document.getElementById(id) as HTMLInputElement;
 
 // Le chargement courant de la carte « En route », dérivé à la demande (cf. manifeste-donnees.ts).
 const chargementCourant = () => { const r = manifesteCourant(readFilters()); return r.etat === "ok" ? r.m : null; };
@@ -99,7 +112,7 @@ export function toggleLegEditor(i) {
   // Le compagnon réécrit : l'en-tête qu'on vient d'activer n'existe plus et le
   // focus retombe sur <body>. À la souris ça ne se voit pas ; au clavier on perdait sa place, la
   // deuxième Entrée (replier) ne partait plus de nulle part et Tab reprenait au début du document.
-  document.getElementById("journeyCard")?.querySelector(`.jleg-head[data-leg="${i}"]`)?.focus();
+  document.getElementById("journeyCard")?.querySelector<HTMLElement>(`.jleg-head[data-leg="${i}"]`)?.focus();
 }
 
 export function editLegQty(i, li, val) {
@@ -241,59 +254,59 @@ export function removeJourneyStop(stopIndex) {
  */
 export function brancherGestesVoyage() {
   document.addEventListener("click", (e) => {
-    if (e.target.closest("#journeyClear")) { clearJourney(); return; }
+    if (cible(e).closest("#journeyClear")) { clearJourney(); return; }
     // Démarrer un voyage « de zéro » : bouton « Commencer » depuis l'invite.
-    if (e.target.closest("#journeyStartBtn")) { beginJourney($("journeyStart").value); return; }
+    if (cible(e).closest("#journeyStartBtn")) { beginJourney($("journeyStart").value); return; }
     // Ajout d'arrêt : bouton « + Arrêt » ou une suggestion.
-    if (e.target.closest("#journeyAddBtn")) { addStopByTerminal($("journeyAddStop").value); return; }
-    const sug = e.target.closest(".jstop-suggest");
+    if (cible(e).closest("#journeyAddBtn")) { addStopByTerminal($("journeyAddStop").value); return; }
+    const sug = cible(e).closest(".jstop-suggest");
     if (sug) { addStopByTerminal(sug.dataset.label); return; }
     // Retirer un arrêt (✕ sur une étape) -> reconnexion des voisins.
-    const del = e.target.closest(".jstep-del");
+    const del = cible(e).closest(".jstep-del");
     if (del) { removeJourneyStop(Number(del.dataset.i)); return; }
     // Édition du manifeste d'une jambe : déplier / retirer / ajouter / réinitialiser.
     // `.jman-suggest .suggest-add` et NON `.suggest-add` nu : la carte de chargement pose le second
     // et a sa propre délégation. Les deux ne se croisent que par cette qualification.
-    const legSug = e.target.closest(".jman-suggest .suggest-add");
+    const legSug = cible(e).closest(".jman-suggest .suggest-add");
     if (legSug) { addLegSuggestion(Number(legSug.dataset.leg), legSug.dataset.name); return; }
-    const legDel = e.target.closest(".jman-del");
+    const legDel = cible(e).closest(".jman-del");
     if (legDel) { delLegLine(Number(legDel.dataset.leg), legDel.dataset.name); return; }
-    const load = e.target.closest(".jleg-load");
+    const load = cible(e).closest(".jleg-load");
     if (load) { chargerJambe(Number(load.dataset.leg)); return; } // AVANT .jleg-head : le bouton y vit
-    if (e.target.closest(".jman-reset")) { resetLeg(Number(e.target.closest(".jman-reset").dataset.leg)); return; }
-    const addBtn = e.target.closest(".jman-add-btn");
-    if (addBtn) { addLegLine(Number(addBtn.dataset.leg), addBtn.closest(".jman-add").querySelector(".jman-add-input").value); return; }
-    const head = e.target.closest(".jleg-head");
+    if (cible(e).closest(".jman-reset")) { resetLeg(Number(cible(e).closest(".jman-reset").dataset.leg)); return; }
+    const addBtn = cible(e).closest(".jman-add-btn");
+    if (addBtn) { addLegLine(Number(addBtn.dataset.leg), addBtn.closest(".jman-add")!.querySelector<HTMLInputElement>(".jman-add-input")!.value); return; }
+    const head = cible(e).closest(".jleg-head");
     if (head) { toggleLegEditor(Number(head.dataset.leg)); return; }
     // Parcours interactif : clic sur une étape (⦿) = « je suis ici » -> recale les vues.
-    const step = e.target.closest(".jstep");
+    const step = cible(e).closest(".jstep");
     if (step) setJourneyStop(Number(step.dataset.i));
   });
 
   // L'en-tête d'une jambe est annoncé `role="button"` : Entrée/Espace doivent l'activer comme le
-  // clic. On teste `e.target` LUI-MÊME et non `closest()` — modèle `.editv` plutôt que `.jm-arret` :
+  // clic. On teste `cible(e)` LUI-MÊME et non `closest()` — modèle `.editv` plutôt que `.jm-arret` :
   // le bouton « ✓ chargé » vit DANS l'en-tête, et un `closest()` déplierait l'éditeur EN PLUS de
   // charger la soute à chaque Entrée sur ce bouton.
   $("journeyCard").addEventListener("keydown", (e) => {
-    if (!e.target.classList || !e.target.classList.contains("jleg-head")) return;
+    if (!cible(e).classList || !cible(e).classList.contains("jleg-head")) return;
     if (e.key !== "Enter" && e.key !== " ") return;
     e.preventDefault(); // Espace ne doit pas défiler la page
-    toggleLegEditor(Number(e.target.dataset.leg));
+    toggleLegEditor(Number(cible(e).dataset.leg));
   });
 
   // Ajout d'arrêt / de commodité à la touche Entrée.
   document.addEventListener("keydown", (e) => {
-    if (e.target.id === "journeyStart" && e.key === "Enter") { e.preventDefault(); beginJourney(e.target.value); }
-    else if (e.target.id === "journeyAddStop" && e.key === "Enter") { e.preventDefault(); addStopByTerminal(e.target.value); }
-    else if (e.target.classList && e.target.classList.contains("jman-add-input") && e.key === "Enter") {
+    if (champ(e).id === "journeyStart" && e.key === "Enter") { e.preventDefault(); beginJourney(champ(e).value); }
+    else if (champ(e).id === "journeyAddStop" && e.key === "Enter") { e.preventDefault(); addStopByTerminal(champ(e).value); }
+    else if (cible(e).classList && cible(e).classList.contains("jman-add-input") && e.key === "Enter") {
       e.preventDefault();
-      addLegLine(Number(e.target.dataset.leg), e.target.value);
+      addLegLine(Number(cible(e).dataset.leg), champ(e).value);
     }
   });
 
   // Précharge le marché quand on focalise un champ terminal du compagnon -> peuple sa datalist.
   document.addEventListener("focusin", (e) => {
-    if ((e.target.id === "journeyStart" || e.target.id === "journeyAddStop") && !listesPretes()) {
+    if ((champ(e).id === "journeyStart" || champ(e).id === "journeyAddStop") && !listesPretes()) {
       if (etat.MARKET) peuplerListes();
       else withMarket(() => {});
     }
@@ -301,11 +314,11 @@ export function brancherGestesVoyage() {
 
   // La carte 2D du parcours : cliquer une escale déplace « je suis ici », comme le fil d'étapes.
   $("journeyMap").addEventListener("click", (e) => {
-    const a = e.target.closest(".jm-arret");
+    const a = cible(e).closest(".jm-arret");
     if (a) setJourneyStop(Number(a.dataset.i));
   });
   $("journeyMap").addEventListener("keydown", (e) => {
-    const a = e.target.closest(".jm-arret");
+    const a = cible(e).closest(".jm-arret");
     if (a && (e.key === "Enter" || e.key === " ")) { e.preventDefault(); setJourneyStop(Number(a.dataset.i)); }
   });
 
@@ -314,13 +327,13 @@ export function brancherGestesVoyage() {
   // input/change est la contrepartie exacte l'un de l'autre — les fusionner persisterait à chaque
   // caractère.
   document.addEventListener("input", (e) => {
-    if (e.target.classList && e.target.classList.contains("jman-qty")) {
-      liveLegQty(Number(e.target.dataset.leg), Number(e.target.dataset.i), e.target);
+    if (cible(e).classList && cible(e).classList.contains("jman-qty")) {
+      liveLegQty(Number(cible(e).dataset.leg), Number(cible(e).dataset.i), cible(e));
     }
   });
   document.addEventListener("change", (e) => {
-    if (e.target.classList && e.target.classList.contains("jman-qty")) {
-      editLegQty(Number(e.target.dataset.leg), Number(e.target.dataset.i), e.target.value);
+    if (cible(e).classList && cible(e).classList.contains("jman-qty")) {
+      editLegQty(Number(cible(e).dataset.leg), Number(cible(e).dataset.i), champ(e).value);
     }
   });
 }


### PR DESCRIPTION
## Ce que ça change

Rien à l'écran. **Le dépôt n'a plus un seul `.js` d'application.** Douze fichiers passent en
TypeScript et entrent dans `include` de `tsconfig.json` : `amorce`, `controles`,
`corrections-gestes`, `soute-gestes`, `listes`, `navigation`, `tri`, `selecteur`,
`manifeste-gestes`, `voyage-gestes`, `presse-papiers`, `soute-actions`.

Restent deux `.js`, et les deux sont hors module par décision : `rail.js`, script **classique**
sorti de la page pour que `script-src 'self'` ait un sens, et `sw.js`, le service worker.

## Pourquoi

`tsc` ne lisait pas les `.js` hors `include`, et `vite build` non plus : un identifiant **libre**
n'y apparaissait qu'à l'exécution, dans un écouteur, sans erreur visible. Ça a coûté **deux
régressions aujourd'hui** — `refresh` passé par référence dans un `addEventListener`, et trois
`brancher*` appelés sans être importés. La première n'a été vue que par Playwright.

Le point d'entrée est celui où le défaut est fatal : ses `brancher*()` s'exécutent dans `init()`,
**hors** du `try/catch`, donc avant le premier `fetch`.

Vérifié en ajoutant un appel à une fonction inexistante, puis restauré à l'identique :
```
amorce.ts(94,3): error TS2304: Cannot find name 'brancherQuiNExistePas'.
```

## Pourquoi maintenant, et pas ce matin

Essayé ce matin sur `amorce.js` à 500 lignes : impossible. `e.target` est typé `EventTarget` — il
n'a ni `closest`, ni `dataset`, ni `value` — et les 35 délégations du fichier produisaient une
cinquantaine de `TS2339`. La PR #160 a sorti ces écouteurs vers leurs modules. Le suffixe devient
possible parce que le démontage a eu lieu, pas l'inverse.

Les modules, eux, portent maintenant ces `e.target` : **66 erreurs** au premier `tsc`. Trois
leviers, du plus général au plus précis :

**1. Deux aides par module.** `cible(e)` et `champCible(e)` posent le cast une fois, comme `$`. Pas
dans un module partagé : c'est une expression d'une ligne, et coupler onze modules à un alias ne
vaut pas l'économie — même choix que `$`, pris huit fois dans ce dépôt.

**2. Le type `Noeud` (`types.ts`) — 39 erreurs d'un coup.** `Element.closest()` rend
`Element | null` dans `lib.dom`, ce qui est exact en général et faux ici : tout ce que cette
application rend est du HTML, et chaque délégation lit ensuite un `dataset`. L'interface se referme
sur elle-même — `closest` rend un `Noeud` — pour que `e.target.closest(a).closest(b)` reste typée.
C'est un rétrécissement **légitime** : `Noeud | null` est assignable à `Element | null`, donc rien
n'est promis qui ne soit vrai.

**3. Le reste, un par un.** `querySelectorAll<HTMLInputElement>` là où le sélecteur vise un champ,
`HTMLButtonElement` pour la vignette de station qui lit `disabled`, et un cast **nommé** sur les
quatre `data-*` de `.scomm-undo` — posés *ensemble* par `vues/corrections.tsx`, donc présents ou la
branche n'est pas atteinte. Le cast dit ce contrat ; il ne le contourne pas.

`$` est typé `HTMLInputElement` dans les modules qui ne s'en servent que pour des contrôles de
formulaire : patron déjà retenu par `filtres.ts` et `persistance.ts` — l'alias dit ce que le module
en fait.

## Un type qui manquait

`Meta` (`types.ts`) : l'estampille de `data/meta.json`. `app_version` et `commit` y sont
**facultatifs**, et c'est délibéré — l'amorce versionnée dans `data/` ne les porte pas tant qu'un
build n'est pas passé, et le rail préfère alors ne rien afficher qu'un « v— ».

Les trois `fetch(...).json()` rendent `any`. Le type est posé **à la frontière**, en un seul `as`
sur le tuple de `Promise.all` : c'est le seul endroit du dépôt où des données extérieures entrent,
donc le seul où un `as` dit quelque chose au lieu de masquer.

## Vérification

```
npx tsc --noEmit     → aucune sortie (66 erreurs au départ)
node --test          → tests 490 | pass 490 | fail 0
npx playwright test  → 246 tests | 244 passed | 2 skipped | 0 failed (1,6 min)
npm run build:site   → ✓ built | précache 20 entrées
```

## Ce qui n'est pas couvert

- `strictNullChecks` puis `noImplicitAny` (ADR-011 point 7) restent **entiers**. Ce lot fait entrer
  les fichiers dans `include` ; il ne monte pas la sévérité. Les deux marches se prennent une par
  PR, sinon on ne saura plus laquelle a cassé quoi.
- Les `.ts` nouvellement inclus portent encore des paramètres implicitement `any` : ils passeront à
  `noImplicitAny`, pas avant.
- Le point 6 (la moitié « mise en page » de `style.css`) : entier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
