### PR TITLE
fix(rail): le rail cède quand la place manque, au lieu de laisser le tableau déborder

### DIFF
--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -2881,7 +2881,21 @@ test("score : le tableau n'écrit jamais une largeur hors [0, 100] (#39)", async
 // le conteneur qui défile tout seul. Un test au niveau page passerait à tort, et c'est exactement
 // pour ça que rien ne voyait le défaut. La tolérance de 1 px couvre `.table-shell::after`, dont le
 // crochet décoratif déborde en permanence (style.css:613) — même convention qu'à la ligne 219.
-for (const { largeur, hauteur } of [{ largeur: 1920, hauteur: 1080 }, { largeur: 1280, hauteur: 720 }]) {
+// #86 ajoute 1100×900 à la boucle, et c'est LUI qui la rendait rouge : mesuré à +133 px de
+// débordement sur Trajets, rail déplié — le rail lui-même. Replié à la main il tombait à +2, ce qui
+// veut dire que l'utilisateur devait le replier pour que la page tienne, sans que rien le lui dise.
+//
+// La TOLÉRANCE monte à 2 px au seul 1100, et il faut dire pourquoi plutôt que de l'arrondir : le
+// rail réglé, il reste 2 px de débordement dont il n'est pas la cause. Mesuré à cette largeur —
+// `.table-shell` fait 970, la table fait 970, les dix colonnes somment à 970, et `table.scrollWidth`
+// vaut 972. C'est donc le CONTENU d'une cellule qui sort de sa colonne, pas la table qui sort de son
+// cadre : c'est #81 (« en fenêtre réduite les chiffres sortent de leur colonne »), et le corriger ici
+// serait empiéter sur une autre issue. Le jour où #81 tombe, ce 2 redevient 1.
+for (const { largeur, hauteur, tolerance } of [
+  { largeur: 1920, hauteur: 1080, tolerance: 1 },
+  { largeur: 1280, hauteur: 720, tolerance: 1 },
+  { largeur: 1100, hauteur: 900, tolerance: 2 },
+]) {
   test(`tableaux : aucune barre horizontale en ${largeur}×${hauteur} (#54)`, async ({ page }) => {
     await page.setViewportSize({ width: largeur, height: hauteur });
     const debord = (sel) => page.locator(sel).evaluate((e) => {
@@ -2890,18 +2904,18 @@ for (const { largeur, hauteur } of [{ largeur: 1920, hauteur: 1080 }, { largeur:
     });
 
     await expect(page.locator("#rows tr").first()).toBeVisible();
-    expect(await debord("#routes"), "Trajets").toBeLessThanOrEqual(1);
+    expect(await debord("#routes"), "Trajets").toBeLessThanOrEqual(tolerance);
 
     await page.click("#viewLoops");
     await expect(page.locator("#loopRows tr").first()).toBeVisible();
-    expect(await debord("#loops"), "Boucles").toBeLessThanOrEqual(1);
+    expect(await debord("#loops"), "Boucles").toBeLessThanOrEqual(tolerance);
 
     // « En route » partage le rendu de Trajets ; il faut un terminal de départ pour qu'il peuple.
     await page.click("#viewEnroute");
     const depart = await page.locator("#originList option").first().getAttribute("value");
     await page.fill("#origin", depart);
     await expect(page.locator("#enrouteRows tr").first()).toBeVisible();
-    expect(await debord("#enroute"), "En route").toBeLessThanOrEqual(1);
+    expect(await debord("#enroute"), "En route").toBeLessThanOrEqual(tolerance);
   });
 }
 
@@ -3091,4 +3105,54 @@ test("Manifeste : « ⧉ Copier » sort le plan de chargement, sa route et son t
   // Le libellé REVIENT : « ✓ Copié » est un retour visuel, pas un état. Un bouton resté sur
   // « Copié » ferait croire à une seconde copie qui n'a pas eu lieu.
   await expect(page.locator("#copyManifest")).toHaveText(/Copier/, { timeout: 4000 });
+});
+
+// #86, second critère : le point de rupture ne doit PAS marcher sur la préférence de l'utilisateur.
+// C'est le piège de cette issue — une bascule automatique qui écrase un choix explicite est plus
+// agaçante que le défaut qu'elle corrige. Elle ne le peut pas ici, et c'est structurel : le repli
+// automatique est une media query, `rail.js` n'en sait rien et ne touche jamais à la largeur. Ce
+// test épingle cette séparation, qui se perdrait au premier « repli automatique en JavaScript ».
+test("Rail : le repli automatique ne mange pas la préférence manuelle (#86)", async ({ page }) => {
+  // Au large, le choix manuel commande.
+  await page.setViewportSize({ width: 1600, height: 900 });
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+  // `.rail` anime sa largeur sur 0,18 s : une mesure prise juste après le clic lit l'état d'AVANT.
+  // On attend que la valeur se pose, plutôt que de dormir un temps arbitraire.
+  const railVaut = (px) => expect.poll(
+    () => page.locator(".rail").evaluate((e) => Math.round(e.getBoundingClientRect().width)),
+    { timeout: 3000 }
+  ).toBe(px);
+  await railVaut(208);
+
+  await page.click("#railToggle");
+  await railVaut(68);
+  await expect(page.locator("#railToggle")).toHaveAttribute("aria-expanded", "false");
+
+  // On rétrécit : le rail est déjà replié, rien ne change.
+  await page.setViewportSize({ width: 1100, height: 900 });
+  await railVaut(68);
+
+  // Sous le point de rupture, le bouton est masqué — la fenêtre a déjà tranché, un contrôle qui ne
+  // fait rien n'a pas à s'afficher.
+  await expect(page.locator("#railToggle")).toBeHidden();
+
+  // On réélargit : la préférence REPLIÉE est toujours celle de l'utilisateur, elle reprend la main.
+  // C'est le sens qui compte : la media query n'a rien écrasé, elle s'est seulement superposée.
+  await page.setViewportSize({ width: 1600, height: 900 });
+  await railVaut(68);
+  await expect(page.locator("#railToggle")).toBeVisible();
+
+  // Et dans l'autre sens : on déplie AU LARGE, on rétrécit, on réélargit — le choix revient intact.
+  await page.click("#railToggle");
+  await railVaut(208);
+  await page.setViewportSize({ width: 1100, height: 900 });
+  await railVaut(68); // la fenêtre commande ici
+  await page.setViewportSize({ width: 1600, height: 900 });
+  await railVaut(208); // et le choix reprend là
+
+  // Il survit au rechargement, comme avant #86.
+  await page.reload();
+  await expect(page.locator("#rows tr").first()).toBeVisible();
+  await railVaut(208);
+  await expect(page.locator("#railToggle")).toHaveAttribute("aria-expanded", "true");
 });

--- a/style.css
+++ b/style.css
@@ -338,7 +338,33 @@ a:hover { color: #ffcf6b; text-decoration: underline; }
 .rail-status-head { display: flex; align-items: center; gap: 7px; font-size: 9px; letter-spacing: 1.5px; color: var(--muted); text-transform: uppercase; }
 .live-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--good); box-shadow: 0 0 8px var(--good); animation: hb-pulse 2.4s infinite; }
 
-/* Rail rétracté */
+/* Rail rétracté.
+   DEUX déclencheurs, et c'est tout l'objet de #86 : le clic (`.rail-collapsed`, posé par rail.js et
+   persisté), ET la fenêtre. Entre 821 px et 1250 px, la page a besoin des 140 px du rail et rien ne
+   les lui donnait : à 1100 px le tableau débordait de 133 px, c'est-à-dire exactement le rail.
+   L'utilisateur devait le replier À LA MAIN pour que la page tienne, sans que rien le lui dise.
+
+   Le point de rupture est en CSS et non en JavaScript, délibérément. Un repli automatique piloté par
+   un script devrait arbitrer entre la fenêtre et la préférence enregistrée — et une bascule qui
+   écrase un choix explicite est plus agaçante que le défaut qu'elle corrige. Ici il n'y a rien à
+   arbitrer : sous 1250 px c'est la fenêtre qui décide, au-dessus c'est le clic, et `rail.js` n'est
+   au courant de rien. Sa préférence survit intacte et reprend la main dès qu'on élargit.
+
+   1250 px et non 1100 : le débordement mesuré à 1100 vaut 133 px, donc il commence bien avant. La
+   marge évite une bande de largeurs où la page tient de justesse. */
+@media (max-width: 1250px) {
+  .rail { width: 68px; }
+  .rail .rl,
+  .brand-text,
+  .rail-status-head .rl { display: none; }
+  .vbtn { justify-content: center; padding-left: 0; padding-right: 0; }
+  .share-btn { padding: 11px 0; font-size: 15px; }
+  .brand { justify-content: center; padding-left: 0; padding-right: 0; }
+  /* Le bouton de repli n'a plus rien à commander : la fenêtre a déjà tranché. Le masquer évite un
+     contrôle qui ne fait rien — même règle que sous 820 px. */
+  .rail-toggle { display: none; }
+}
+
 .rail-collapsed .rail { width: 68px; }
 .rail-collapsed .rail .rl,
 .rail-collapsed .brand-text,


### PR DESCRIPTION
## Ce que ça change

À 1 100 px, le tableau de Trajets débordait de son cadre de **133 px**. Il ne déborde plus. Le rail
se replie tout seul quand la place manque, au lieu d'obliger l'utilisateur à le faire à la main sans
que rien le lui dise.

## Pourquoi

Cause racine : `style.css`, `.rail { width: 208px; flex-shrink: 0 }`, et **un seul point de rupture,
à 820 px** — là où le rail bascule à l'horizontale. Entre 821 px et l'infini, il valait 208 px et
rien ne modulait ce chiffre. Tout l'intervalle 821 → ~1 250 px, où la page a besoin de ces 140 px,
n'était couvert par personne.

Mesuré : à 1 100 px, rail déplié → **+133** ; rail replié à la main → **+2**. Les 133 px étaient
exactement le rail.

## Le correctif, et pourquoi il est en CSS et pas en JavaScript

Un `@media (max-width: 1250px)` qui applique au rail les règles de `.rail-collapsed`.

C'est le cœur de la décision, et c'est le piège que l'issue signalait : **une bascule automatique
qui écrase un choix explicite est plus agaçante que le défaut qu'elle corrige**. Un repli piloté par
un script devrait arbitrer entre la fenêtre et la préférence enregistrée. Ici il n'y a rien à
arbitrer — sous 1 250 px c'est la fenêtre qui décide, au-dessus c'est le clic, et `rail.js` n'est au
courant de rien. Sa préférence survit intacte et reprend la main dès qu'on élargit.

**1 250 et non 1 100** : le débordement vaut déjà 133 px à 1 100, il commence donc bien avant. La
marge évite une bande de largeurs où la page tient de justesse.

Le bouton de repli est masqué sous le seuil : la fenêtre a déjà tranché, et un contrôle qui ne fait
rien n'a pas à s'afficher — même règle que sous 820 px.

## Vérification

Le cas **1 100 × 900** rejoint la boucle de #54, et il était **rouge avant** le correctif :

```
Expected: <= 1
Received: 133
```

Après : **2**. Les cas 1920 et 1280 de #54 restent verts.

Un second test épingle la séparation entre la fenêtre et la préférence, **dans les deux sens** :
- replier au large → rétrécir → réélargir : le rail reste replié (le choix tient) ;
- déplier au large → rétrécir → réélargir : le rail revient déplié ;
- le rechargement conserve l'état, `aria-expanded` compris.

Il a fallu le faire **attendre** plutôt que mesurer : `.rail` anime sa largeur sur 0,18 s, et une
mesure prise juste après le clic lit l'état d'avant. C'est ce qui l'a fait échouer d'abord — le test
était faux, pas le code.

```
node --test          → tests 490 | pass 490 | fail 0
npx playwright test  → 246 tests (244 avant) | 244 passed | 2 skipped | 0 failed (1,5 min)
```

## Ce qui n'est pas couvert

**Les 2 px qui restent ne sont pas le rail.** Mesuré à 1 100 : `.table-shell` fait 970, la table fait
970, les dix colonnes somment à 970, et `table.scrollWidth` vaut **972**. C'est donc le *contenu*
d'une cellule qui sort de sa colonne, pas la table qui sort de son cadre — c'est **#81**, et le
corriger ici serait empiéter sur une autre issue. La tolérance du test est donc de 2 px à cette
largeur **seulement**, avec la mesure écrite sur place ; elle redeviendra 1 le jour où #81 tombera.

**La saccade pendant la bascule n'a pas été reproduite ni mesurée.** L'issue la signale comme une
piste à vérifier (transition sur `width` → recalcul de mise en page à chaque image) et demande
explicitement de ne pas « corriger » à l'aveugle. Elle reste ouverte.

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)
