### PR TITLE
fix(trajets): les chiffres restent dans leur colonne au lieu de se chevaucher

### DIFF
--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -3156,3 +3156,48 @@ test("Rail : le repli automatique ne mange pas la préférence manuelle (#86)", 
   await railVaut(208);
   await expect(page.locator("#railToggle")).toHaveAttribute("aria-expanded", "true");
 });
+
+// #81 : la mesure qui MANQUAIT. Celle de #54 porte sur `.table-shell` — le CADRE — et un chiffre
+// qui déborde de sa cellule sans élargir la table lui est invisible. C'est exactement ce qui s'est
+// produit : #54 a réduit le défaut sans le supprimer, et son critère « aucun nombre ne déborde de
+// sa colonne » n'a jamais été vérifié. Celle-ci porte sur la CELLULE. Les deux sont nécessaires.
+//
+// `td.num` est en `white-space: nowrap`, et c'est voulu : un « 6 315 398 » coupé en deux lignes est
+// illisible. Mais un nombre qui ne se coupe pas et dont la colonne rétrécit SORT de sa cellule et
+// passe sous la voisine. Ni `overflow: hidden` seul — on lirait « 1 759 » pour « 1 759 500 ».
+for (const { largeur, hauteur } of [
+  { largeur: 1920, hauteur: 1080 }, { largeur: 1280, hauteur: 720 },
+  { largeur: 1100, hauteur: 900 }, { largeur: 960, hauteur: 900 },
+]) {
+  test(`chiffres : aucun ne sort de sa colonne en ${largeur}×${hauteur} (#81)`, async ({ page }) => {
+    await page.setViewportSize({ width: largeur, height: hauteur });
+
+    // Rend les cellules numériques qui débordent, avec de quoi les nommer dans le rapport : sans le
+    // libellé de la colonne et la valeur, un « +17 » ne dit pas où regarder.
+    const debordements = (sel) => page.locator(sel).evaluate((table) => {
+      const titres = [...table.querySelectorAll("thead th")].map((h) => h.textContent.trim());
+      const sortis = [];
+      for (const td of table.querySelectorAll("tbody td.num")) {
+        const trop = td.scrollWidth - td.clientWidth;
+        if (trop <= 0) continue;
+        const rang = [...td.parentElement.children].indexOf(td);
+        sortis.push(`${titres[rang] || `col ${rang + 1}`} +${trop} (${td.textContent.trim().slice(0, 18)})`);
+      }
+      // Une entrée par COLONNE, pas par ligne : 316 lignes rendraient le rapport illisible.
+      return [...new Set(sortis.map((x) => x.split(" +")[0]))];
+    });
+
+    await expect(page.locator("#rows tr").first()).toBeVisible();
+    expect(await debordements("#routes"), "Trajets").toEqual([]);
+
+    await page.click("#viewLoops");
+    await expect(page.locator("#loopRows tr").first()).toBeVisible();
+    expect(await debordements("#loops"), "Boucles").toEqual([]);
+
+    await page.click("#viewEnroute");
+    const depart = await page.locator("#originList option").first().getAttribute("value");
+    await page.fill("#origin", depart);
+    await expect(page.locator("#enrouteRows tr").first()).toBeVisible();
+    expect(await debordements("#enroute"), "En route").toEqual([]);
+  });
+}

--- a/style.css
+++ b/style.css
@@ -899,23 +899,32 @@ th.sorted-desc::after { content: " ▾"; color: var(--acc); }
 th.sorted-asc::after { content: " ▴"; color: var(--acc); }
 
 /* Largeurs de colonnes (Trajets & En route : 10 colonnes)
-   Rééquilibrage de #54, mesuré au plancher de 960 px — le seul cas où ça se joue, puisque au-delà
-   tout le monde est à l'aise. Les quatre colonnes de droite étaient contraintes par leur INTITULÉ
-   et non par leurs chiffres (« Unités à acheter » : 142 px de titre pour 44 px de données), pendant
-   qu'« Acheter » et « Vendre » se partageaient 40 % de la table. Les titres ont été raccourcis et
-   leur sens mis en `title=` (index.html) ; ces pourcentages rendent le reste aux chiffres.
-   À 960 px, chaque colonne couvre désormais son intitulé : Marge/SCU 86 pour 84 exigés,
-   Profit/h 72 pour 67, Unités 62 pour 60, Coût 53 pour 51, Profit 58 pour 55, ROI 48 pour 45. */
+   #54 a rééquilibré une première fois sur l'INTITULÉ des colonnes de droite ; #81 rééquilibre sur
+   leur CONTENU, qui est le vrai plancher — et qui débordait encore : à 960 px, ROI +11, Coût +10,
+   Profit +17, Profit/h +3. Un `td.num` est en `nowrap` (voir plus bas, et c'est voulu : un
+   « 6 315 398 » coupé en deux lignes est illisible), donc un nombre trop large ne se replie pas —
+   il SORT de sa cellule et passe sous la voisine.
+
+   La place vient d'« Acheter » et « Vendre ». Ces deux-là ENVELOPPENT (`overflow-wrap: anywhere`),
+   donc leur plancher réel n'est pas la ligne complète mais le mot le plus long — 129 px et 115 px
+   mesurés. Elles recevaient 20 % et 17,5 %, soit 37,5 % de la table pour 244 px de plancher
+   combiné. Elles passent à 15 % et 14 % : 8,5 points rendus aux colonnes qui, elles, ne peuvent
+   pas envelopper.
+
+   Ces 8,5 points ne sont pas répartis au hasard, ils suivent le débordement mesuré : Profit et
+   Profit/h en prennent le plus, ROI et Coût 1,5 chacun, Marge/SCU une demi-marge de sécurité.
+   Ce qui n'est PAS fait, et délibérément : `overflow: hidden` seul remplacerait un chevauchement
+   par un nombre silencieusement amputé — on lirait « 1 759 » pour « 1 759 500 », ce qui est pire. */
 #routes th:nth-child(1), #enroute th:nth-child(1) { width: 15%; }
-#routes th:nth-child(2), #enroute th:nth-child(2) { width: 20%; }
-#routes th:nth-child(3), #enroute th:nth-child(3) { width: 17.5%; }
+#routes th:nth-child(2), #enroute th:nth-child(2) { width: 15%; }
+#routes th:nth-child(3), #enroute th:nth-child(3) { width: 14%; }
 #routes th:nth-child(4), #enroute th:nth-child(4) { width: 8%; text-align: center; }
-#routes th:nth-child(5), #enroute th:nth-child(5) { width: 9%; }
-#routes th:nth-child(6), #enroute th:nth-child(6) { width: 5%; }
+#routes th:nth-child(5), #enroute th:nth-child(5) { width: 9.5%; }
+#routes th:nth-child(6), #enroute th:nth-child(6) { width: 6.5%; }
 #routes th:nth-child(7), #enroute th:nth-child(7) { width: 6.5%; }
-#routes th:nth-child(8), #enroute th:nth-child(8) { width: 5.5%; }
-#routes th:nth-child(9), #enroute th:nth-child(9) { width: 6%; }
-#routes th:nth-child(10), #enroute th:nth-child(10) { width: 7.5%; }
+#routes th:nth-child(8), #enroute th:nth-child(8) { width: 7%; }
+#routes th:nth-child(9), #enroute th:nth-child(9) { width: 8.5%; }
+#routes th:nth-child(10), #enroute th:nth-child(10) { width: 10%; }
 /* Boucles : 8 colonnes. Même maladie que Trajets, en plus petit et pour une autre raison : ici
    c'est le CHIFFRE qui déborde, pas l'intitulé — « Profit/h » recevait 61 px pour un `6 315 398`
    qui en réclame 91, et `td.num` est en `nowrap`. Les quatre premières colonnes enveloppent, elles


### PR DESCRIPTION
> Empilée sur #162 (`fix/rail-cede-quand-la-place-manque`) : les deux touchent `style.css` et
> `e2e/smoke.pw.mjs`. À fusionner après elle.

## Ce que ça change

En fenêtre réduite — typiquement en demi-écran sur un 1920, soit **960 px** — les nombres du tableau
sortaient de leur cellule et passaient **sous la voisine**. Ils y restent maintenant.

Mesuré à 960 avant correctif : **ROI +11, Coût +10, Profit +17, Profit/h +3**. Le défaut apparaissait
dès **1 280**.

## Cause racine

`style.css` — `td.num { white-space: nowrap }`. C'est **voulu** : un « 6 315 398 » coupé en deux
lignes est illisible. Mais un nombre qui ne se replie pas et dont la colonne rétrécit ne se replie
pas non plus — il sort de sa cellule.

## Pourquoi personne ne le voyait

Le test de #54 mesure `.table-shell.scrollWidth - clientWidth`, c'est-à-dire le **cadre**. Un chiffre
qui déborde de sa cellule sans élargir la table lui est **invisible**.

#54 portait pourtant le critère « les cellules `td.num` gardent `nowrap` sans déborder de leur
colonne ». Il n'a jamais été vérifié. Ce lot ajoute la mesure qui manquait, sur la **cellule**. Les
deux sont nécessaires, et elles mesurent deux choses différentes.

## Le correctif

La place vient d'« Acheter » et « Vendre ». Ces deux-là **enveloppent**
(`overflow-wrap: anywhere`), donc leur plancher réel n'est pas la ligne complète mais le **mot le
plus long** — 129 px et 115 px mesurés. Elles recevaient 20 % et 17,5 %, soit **37,5 % de la table
pour 244 px de plancher combiné**. Elles passent à 15 % et 14 %.

Les 8,5 points rendus suivent le débordement mesuré : Profit +2,5, Profit/h +2,5, ROI et Coût +1,5
chacun, Marge/SCU +0,5 de marge.

**Ce qui n'est pas fait, délibérément** : `overflow: hidden` seul remplacerait un chevauchement par
un nombre silencieusement amputé — on lirait « 1 759 » pour « 1 759 500 », ce qui est pire qu'un
chevauchement, parce qu'il ne se voit pas.

## Vérification

Le nouveau test couvre Trajets, Boucles et « En route » à **1920, 1280, 1100 et 960**. Il nomme les
colonnes fautives plutôt que de rendre un nombre, pour que l'échec dise où regarder.

**Rouge avant :**
```
1280        → ["ROI", "Coût", "Profit"]
1100 et 960 → ["ROI", "Coût", "Profit", "Profit/h"]
1920        → déjà vert
```

**Vert après**, aux quatre viewports, `#loops` compris — sans avoir eu à toucher ses largeurs.

Les noms de terminaux restent **lisibles en entier** : vérifié sur le plus long de
`data/market.json` (« Terra Gateway (Stanton) »), `scrollWidth - clientWidth = 0` à 1920, 1280 et
960. Ils enveloppent, ils ne se tronquent pas.

```
node --test          → tests 490 | pass 490 | fail 0
npx playwright test  → 250 tests (246 avant) | 248 passed | 2 skipped | 0 failed (1,7 min)
```

## Ce qui n'est pas couvert

**À 960 px, le cadre déborde encore de 130 px.** Il en faisait **273** avant ce lot et #162. Aucune
issue ne couvre cette largeur — #54 s'arrête à 1280, et le défilement horizontal n'est assumé qu'en
dessous de 820 px. C'est un défaut réel, **réduit ici par ricochet, pas résolu**. Il mériterait sa
propre issue.

La piste 2 de l'issue (abréger les montants avec `compactValue`, « 1,76 M ») n'a **pas** été
retenue : elle change ce que l'utilisateur lit, et le rééquilibrage suffit d'après les planchers
mesurés.

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)
