### PR TITLE
fix(corrections): les commodités d'une station sortent par ordre alphabétique

### DIFF
--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -3092,3 +3092,36 @@ test("Manifeste : « ⧉ Copier » sort le plan de chargement, sa route et son t
   // « Copié » ferait croire à une seconde copie qui n'a pas eu lieu.
   await expect(page.locator("#copyManifest")).toHaveText(/Copier/, { timeout: 4000 });
 });
+
+// #60 : les commodités d'une station sortaient dans l'ordre du tableau `commodities` de
+// market.json — c'est-à-dire l'ordre d'insertion d'une Map remplie en parcourant les prix UEX, qui
+// ne veut rien dire. Sur GrimHEX (3 achats, 89 ventes) il fallait balayer la grille à l'œil.
+//
+// L'incohérence sautait d'autant plus aux yeux que la BANDE de stations, elle, est rangée :
+// `groupOverridesByTerminal` départage par `localeCompare(terminal, "fr")`. On choisissait sa
+// station dans une liste ordonnée pour tomber dans un contenu qui ne l'était pas.
+//
+// Le tri est vérifié PAR SECTION : « On y achète » et « On y écoule » sont deux listes, et un tri
+// posé sur le parcours global les mêlerait. `localeCompare(…, "fr")` et non `<` : « Étain » se
+// range après « Estuarine », pas à la fin de l'alphabet.
+test("Corrections : les commodités d'une station sortent par ordre alphabétique (#60)", async ({ page }) => {
+  await page.click("#viewCorrections");
+  await expect(page.locator("#stationList option").first()).toBeAttached({ timeout: 15000 });
+
+  // La station la plus fournie du jeu de données : c'est là que le défaut se voit.
+  const labels = await page.locator("#stationList option").evaluateAll((os) => os.map((o) => o.value));
+  const grimhex = labels.find((l) => /GrimHEX/i.test(l)) || labels[0];
+  await page.fill("#station", grimhex);
+  await expect(page.locator("#correctionsStation .scomm").first()).toBeVisible();
+
+  for (const section of ["achat", "vente"]) {
+    // Le DERNIER `<span>` porte le nom ; le premier est l’icône de catégorie, et `.scomm-name` les
+    // contient tous deux. Trier le libellé décoré trierait par emoji — pas ce que l’œil cherche.
+    const noms = await page.locator(`#correctionsStation .scomm.${section} .scomm-name > span:last-child`).allInnerTexts();
+    if (noms.length < 2) continue; // une section à zéro ou une entrée ne prouve rien
+    // Le marqueur « ⛔ ILLÉGAL » est un frère du texte, dans le même span : il ne compte pas.
+    const propres = noms.map((n) => n.replace(/⛔.*$/, "").replace(/\s+/g, " ").trim());
+    const attendu = [...propres].sort((a, b) => a.localeCompare(b, "fr"));
+    expect(propres, `section ${section} (${propres.length} tuiles)`).toEqual(attendu);
+  }
+});

--- a/vues/corrections-vue.tsx
+++ b/vues/corrections-vue.tsx
@@ -70,7 +70,17 @@ function tuilesStation(S: number, q: string): TuileCommodite[] {
     // l'écran au défilement.
     tuiles.push({ nom: c.name, kind: c.kind, illegal: c.illegal, achat: !!b, cotes });
   });
-  return tuiles;
+  // PAR NOM, et en français (#60). L'ordre de `marche.commodities` est celui d'insertion d'une Map
+  // remplie en parcourant les prix UEX : il ne veut rien dire, et sur les gros comptoirs — GrimHEX
+  // en compte 92 — il fallait balayer la grille à l'œil pour retrouver une commodité.
+  //
+  // UN SEUL tri ici, pas un par section : `VueStation` sépare les tuiles par `filter`, qui préserve
+  // l'ordre. Deux tris seraient deux endroits à tenir d'accord.
+  //
+  // `localeCompare(…, "fr")` et non `<` : le second range « Étain » après tout l'alphabet, parce
+  // qu'il compare des points de code. C'est le même comparateur que la bande de stations, dont
+  // l'ordre rendait justement ce désordre-ci visible.
+  return tuiles.sort((a, b) => a.nom.localeCompare(b.nom, "fr"));
 }
 
 /** Les stations corrigées, la station affichée épinglée en tête. */


### PR DESCRIPTION
## Ce que ça change

Dans la vue **Corrections**, les commodités d'une station sortaient dans un ordre **arbitraire**.
Sur les gros comptoirs — GrimHEX en compte 92 — il fallait balayer la grille à l'œil, tuile par
tuile. Elles sortent maintenant par ordre alphabétique, dans chacune des deux sections.

## Pourquoi

Cause racine : `vues/corrections-vue.tsx:50`, `marche.commodities.forEach(...)`. L'itération suivait
l'ordre du tableau `commodities` de `market.json` — l'ordre d'insertion d'une `Map` remplie en
parcourant les prix UEX. Cet ordre ne veut **rien** dire : ni classement par volume, ni par
catégorie, ni par code. **Aucun tri n'était appliqué nulle part dans cette vue.**

L'incohérence sautait d'autant plus aux yeux que la **bande de stations**, elle, est rangée :
`groupOverridesByTerminal` départage par `localeCompare(terminal, "fr")`. On choisissait sa station
dans une liste ordonnée pour tomber dans un contenu qui ne l'était pas.

## Le correctif

Un tri, à la fin de `tuilesStation`. **Un seul**, pas un par section : `VueStation` sépare les
tuiles en « On y achète » / « On y écoule » par `filter`, qui préserve l'ordre. Deux tris seraient
deux endroits à tenir d'accord.

`localeCompare(…, "fr")` et non `<` : le second compare des points de code et rangerait « Étain »
après tout l'alphabet. C'est le même comparateur que la bande de stations, dont l'ordre rendait
justement ce désordre-ci visible.

## Vérification

Test **rouge avant, vert après**, et **revu rouge** en retirant le seul `sort` — un test de tri qui
ne mord pas ne vaut rien.

Il compare **par section**, et lit le **nom** et non le libellé affiché : `.scomm-name` contient
l'icône de catégorie *avant* le nom, et trier le texte décoré trierait par emoji. C'est d'ailleurs
comme ça que la première version du test était écrite — elle exigeait « ⛽ » avant « 📦 ».

```
npx tsc --noEmit     → aucune sortie
node --test          → tests 490 | pass 490 | fail 0
npx playwright test  → 247 tests (246 avant) | 245 passed | 2 skipped | 0 failed (1,7 min)
```

## Ce qui n'est pas couvert

L'ordre de `market.json` n'est **pas** touché à la source. Il n'a aucune signification, mais le
corriger dans le pipeline changerait un fichier que d'autres vues parcourent pour d'autres raisons.
Le tri est une décision de **présentation** : il reste dans la vue.

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)