### PR TITLE
fix(voyage): « ✓ chargé » se lit comme l'action de la jambe, pas comme une note de bas de page

### DIFF
--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -3092,3 +3092,46 @@ test("Manifeste : « ⧉ Copier » sort le plan de chargement, sa route et son t
   // « Copié » ferait croire à une seconde copie qui n'a pas eu lieu.
   await expect(page.locator("#copyManifest")).toHaveText(/Copier/, { timeout: 4000 });
 });
+
+// #53 : « ✓ chargé » est le geste le PLUS engageant de l'application — il crée les lots de la soute
+// au prix affiché, retranche le stock du terminal d'achat et fige les autres jambes qui achètent au
+// même point. C'était aussi l'élément le plus effacé de sa rangée : 9,5 px en `var(--muted)`, sur
+// 19 px de haut, entre deux libellés de 11,5 px. L'emphase allait à l'état DÉJÀ ACQUIS (« ⬢ à bord »,
+// vert plein) et pas à l'action à faire.
+//
+// Les quatre mesures ci-dessous sont celles de l'issue, dans son ordre. La dernière est la
+// contrainte à ne pas casser en grossissant : à 460 px, l'en-tête s'empilait sur deux lignes et le
+// centre de la zone cliquable tombait sur le bouton au lieu du dépliement (style.css).
+test("Voyage : « ✓ chargé » se lit comme l'action de la jambe (#53)", async ({ page }) => {
+  await jambeChargeable(page);
+  const bouton = page.locator("#journeyCard .jleg-load").first();
+  const route = page.locator("#journeyCard .jleg-route").first();
+
+  // 1. La cible tactile : même règle que ▶ (WCAG 2.2 SC 2.5.8), déjà tenue ailleurs dans ce fichier.
+  const b = await bouton.boundingBox();
+  expect(b.height, "hauteur de « ✓ chargé »").toBeGreaterThanOrEqual(24);
+  expect(b.width, "largeur de « ✓ chargé »").toBeGreaterThanOrEqual(24);
+
+  // 2. Il ne peut plus être le plus petit texte de sa rangée.
+  const px = (l) => l.evaluate((e) => parseFloat(getComputedStyle(e).fontSize));
+  expect(await px(bouton), "corps du bouton vs nom de la jambe").toBeGreaterThanOrEqual(await px(route));
+
+  // 3. Il n'est plus dans la couleur que le dépôt réserve au secondaire, AVANT le clic.
+  await expect(bouton).toHaveText(/chargé/i); // on est bien à l'état non chargé
+  const couleur = await bouton.evaluate((e) => getComputedStyle(e).color);
+  expect(couleur, "couleur au repos").not.toBe("rgb(138, 147, 168)"); // var(--muted)
+
+  // 4. L'en-tête reste sur UNE ligne, à la largeur nominale de la carte comme à sa largeur repliée.
+  //
+  // La mesure porte sur le CHEVAUCHEMENT VERTICAL du nom et du bouton, pas sur la hauteur de
+  // l'en-tête. Celle-ci grandit légitimement quand le bouton grandit — une première version de ce
+  // test comparait à « deux fois la hauteur du nom » et échouait sur un en-tête parfaitement sur une
+  // ligne. Deux éléments qui se chevauchent en Y sont sur la même rangée ; c'est ça, « une ligne ».
+  for (const largeur of [1440, 900]) {
+    await page.setViewportSize({ width: largeur, height: 900 });
+    const r = await route.boundingBox();
+    const l = await bouton.boundingBox();
+    const chevauche = Math.min(r.y + r.height, l.y + l.height) - Math.max(r.y, l.y);
+    expect(chevauche, `nom et bouton sur la même rangée à ${largeur} px`).toBeGreaterThan(0);
+  }
+});

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -3133,5 +3133,18 @@ test("Voyage : « ✓ chargé » se lit comme l'action de la jambe (#53)", async
     const l = await bouton.boundingBox();
     const chevauche = Math.min(r.y + r.height, l.y + l.height) - Math.max(r.y, l.y);
     expect(chevauche, `nom et bouton sur la même rangée à ${largeur} px`).toBeGreaterThan(0);
+
+    // 5. LE CENTRE DE L'EN-TÊTE N'EST PAS SUR LE BOUTON, et c'est la contrainte que grossir le
+    //    bouton a failli emporter — elle n'était tenue par AUCUN test. `.jleg-head` est cliquable
+    //    pour déplier l'éditeur et CONTIENT ce bouton : quand le centre tombe dessus, cliquer le
+    //    milieu de la rangée charge la jambe au lieu de la déplier. Le geste le plus engageant de
+    //    l'application, déclenché par erreur. Playwright vise le centre, donc la CI l'a vu — mais
+    //    seulement par ricochet, sur six autres tests, et sans dire pourquoi.
+    const auCentre = await page.locator("#journeyCard .jleg-head").first().evaluate((h) => {
+      const b = h.getBoundingClientRect();
+      const el = document.elementFromPoint(b.x + b.width / 2, b.y + b.height / 2);
+      return el ? el.className : "";
+    });
+    expect(auCentre, `ce qu'on touche au centre de l'en-tête à ${largeur} px`).not.toContain("jleg-load");
   }
 });

--- a/style.css
+++ b/style.css
@@ -577,8 +577,12 @@ input::placeholder { color: var(--muted); }
 .jleg.current { border-left-color: var(--acc); background: rgb(var(--acc-rgb) / 0.06); }
 .jleg-head { display: flex; align-items: center; gap: 8px; font-size: 11.5px; }
 .jleg-n { display: inline-grid; place-items: center; flex-shrink: 0; width: 16px; height: 16px; font-family: var(--mono); font-size: 9px; color: var(--acc-2); border: 1px solid var(--acc-2); border-radius: 50%; }
-.jleg-route { font-weight: 600; color: var(--text-fort); }
-.jleg-profit { margin-left: auto; font-family: var(--mono); }
+/* `flex: 1` : le nom ABSORBE l'espace libre de la rangée, ce qui garde le centre géométrique de
+   l'en-tête DANS le nom quelle que soit la largeur. C'est ce qui rend la non-collision structurelle
+   au lieu d'être une coïncidence de largeurs — voir `.jleg-load` pour ce qu'elle protège.
+   `min-width: 0` sinon un nom long refuse de se compresser et repousse le bouton hors de la carte. */
+.jleg-route { flex: 1; min-width: 0; font-weight: 600; color: var(--text-fort); }
+.jleg-profit { margin-left: 8px; font-family: var(--mono); }
 .jleg-cargo { margin-top: 5px; display: flex; flex-wrap: wrap; gap: 4px 12px; font-size: 10.5px; color: var(--muted); }
 .jcargo-item { display: inline-flex; align-items: center; gap: 5px; }
 .jcargo-item .cicon { width: 18px; height: 18px; font-size: 10px; }
@@ -765,7 +769,22 @@ input.jman-qty { width: 56px; min-width: 0; padding: 3px 5px; text-align: right;
   font-family: var(--mono); font-size: 11.5px; letter-spacing: 0.5px; text-transform: uppercase;
   white-space: nowrap; color: var(--good); background: rgb(var(--good-rgb) / 0.08);
   border: 1px solid var(--good); border-radius: 2px;
-  padding: 5px 9px; margin-left: 6px; cursor: pointer;
+  padding: 5px 9px; cursor: pointer;
+  /* POUSSÉ À DROITE, et c'est une conséquence de l'agrandissement, pas une coquetterie.
+     `.jleg-head` est cliquable pour déplier l'éditeur ET contient ce bouton. Tant qu'il faisait
+     65 × 19 px au milieu de la rangée, le centre géométrique de l'en-tête tombait à côté ; à
+     30 px de haut et 11,5 px de corps, il tombe DESSUS — `elementFromPoint` au centre rendait
+     `jleg-load`. Cliquer le milieu de l'en-tête pour le déplier chargeait donc la jambe : le geste
+     le plus engageant de l'application, déclenché par erreur. C'est le défaut que style.css
+     signalait déjà à 460 px, ramené à toutes les largeurs.
+     Il passe donc EN BOUT DE RANGÉE (`order: 1`), après le chevron. Le milieu de l'en-tête — la
+     zone qu'on vise pour déplier — cesse d'être à lui, et il se groupe avec le chiffre qu'il engage.
+     `.jleg-route { flex: 1 }` complète la garantie : le nom absorbe l'espace libre, donc le centre
+     tombe dans le nom quand la carte est large, et sur le profit quand elle est étroite. Jamais sur
+     le bouton. Mesuré à 1440 et à 900 px, et tenu par `e2e/smoke.pw.mjs`.
+     Le simple décalage à droite ne suffisait PAS : à 900 px la carte fait 311 px et un bouton de
+     81 px y enjambe le centre quelle que soit sa marge. */
+  order: 1; margin-left: 8px;
 }
 .jleg-load:hover { background: rgb(var(--good-rgb) / 0.2); }
 /* La convention de focus du dépôt. Aucune règle ne visait ce bouton, alors qu'Entrée l'active. */

--- a/style.css
+++ b/style.css
@@ -747,14 +747,35 @@ input.jman-qty { width: 56px; min-width: 0; padding: 3px 5px; text-align: right;
 .depot-take:hover { background: rgb(var(--acc-2-rgb) / 0.2); }
 .depot-take:focus-visible { outline: 2px solid var(--acc-2); outline-offset: 1px; }
 
-/* « ✓ chargé » sur la jambe : le moment où l'intention devient un fait. Vert quand c'est à bord. */
+/* « ✓ chargé » sur la jambe : le moment où l'intention devient un fait.
+   C'est le geste le PLUS engageant de l'application — il crée les lots de la soute au prix affiché,
+   retranche le stock du terminal d'achat et fige les autres jambes qui achètent au même point. Il
+   était pourtant l'élément le plus effacé de sa rangée : 9,5 px en `var(--muted)`, la couleur que ce
+   dépôt réserve au secondaire, sur 19 px de haut, entre deux libellés de 11,5 px (#53).
+
+   L'emphase allait à l'ÉTAT DÉJÀ ACQUIS et pas à l'action : le bouton ne s'allumait qu'une fois le
+   geste fait. Les deux états gardent donc le vert, mais dans l'autre sens de lecture — l'action
+   PROPOSÉE prend le contour vif, l'état ACQUIS se calme en fond léger. Il reste parfaitement
+   distinct (fond plein contre fond transparent), sans crier plus fort que ce qu'il reste à faire.
+
+   24 px de haut : la cible tactile de WCAG 2.2 SC 2.5.8, la même règle que ▶ tient déjà. Le padding
+   passe donc de 2 à 5 px verticaux, et la taille de 9,5 à 11,5 px — celle de l'en-tête, pour que ce
+   ne soit plus le plus petit texte de sa propre rangée. */
 .jleg-load {
-  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.5px; text-transform: uppercase;
-  white-space: nowrap; color: var(--muted); background: none;
-  border: 1px solid var(--line); border-radius: 2px; padding: 2px 6px; margin-left: 6px; cursor: pointer;
+  font-family: var(--mono); font-size: 11.5px; letter-spacing: 0.5px; text-transform: uppercase;
+  white-space: nowrap; color: var(--good); background: rgb(var(--good-rgb) / 0.08);
+  border: 1px solid var(--good); border-radius: 2px;
+  padding: 5px 9px; margin-left: 6px; cursor: pointer;
 }
-.jleg-load:hover { color: var(--good); border-color: var(--good); }
-.jleg-load.charge { color: var(--good-fg); background: var(--good); border-color: var(--good); font-weight: 700; }
+.jleg-load:hover { background: rgb(var(--good-rgb) / 0.2); }
+/* La convention de focus du dépôt. Aucune règle ne visait ce bouton, alors qu'Entrée l'active. */
+.jleg-load:focus-visible { outline: 2px solid var(--acc-2); outline-offset: 1px; }
+/* « ⬢ à bord » : un ÉTAT, pas une action. Il se distingue sans réclamer le regard. */
+.jleg-load.charge {
+  color: var(--good); background: rgb(var(--good-rgb) / 0.16);
+  border-color: rgb(var(--good-rgb) / 0.45); font-weight: 700;
+}
+.jleg-load.charge:hover { background: rgb(var(--good-rgb) / 0.26); }
 
 /* ---------- Carte 2D du parcours (ADR-001) ---------- */
 /* Bandeau pleine largeur sous le compagnon. Tout est dessiné par app.js : aucun asset, aucune


### PR DESCRIPTION
C'est le geste le PLUS engageant de l'application : il crée les lots de la soute au prix affiché,
retranche le stock du terminal d'achat et fige les autres jambes qui achètent au même point. C'était
aussi l'élément le plus effacé de sa rangée.

## Cause racine

`style.css` — `.jleg-load { font-size: 9.5px; color: var(--muted); background: none }`, mesuré à
19 px de haut, entre deux libellés de 11,5 px. `var(--muted)` est la couleur que ce dépôt réserve à
ce qui est SECONDAIRE, sur la seule action de la rangée. Et 19 px passe sous les 24 px de cible
tactile que le dépôt s'est fixés pour ▶ (WCAG 2.2 SC 2.5.8).

La seule variante forte était `.jleg-load.charge` — c'est-à-dire APRÈS le clic. L'emphase allait à
l'état déjà acquis, pas à l'action à faire.

## Le correctif

Les deux états gardent le vert, mais dans l'AUTRE sens de lecture, et c'est le choix à trancher que
l'issue laissait ouvert : l'action PROPOSÉE prend le contour vif, l'état ACQUIS se calme en fond
léger. « ⬢ à bord » reste parfaitement distinct — fond plein contre fond transparent — sans crier
plus fort que ce qu'il reste à faire.

Corps à 11,5 px (celui de l'en-tête) et padding vertical de 2 à 5 px : 24 px de haut.
`:focus-visible` prend la convention du dépôt — aucune règle ne visait ce bouton, alors qu'Entrée
l'active.

## Vérification

Quatre mesures, dans l'ordre de l'issue. ROUGE avant sur la première : hauteur **19** pour 24 exigés.

1. cible tactile ≥ 24 × 24 ;
2. corps ≥ celui de `.jleg-route` — il ne peut plus être le plus petit texte de sa rangée ;
3. couleur au repos ≠ `rgb(138, 147, 168)` (`var(--muted)`) ;
4. le nom et le bouton restent sur la MÊME rangée, à 1440 comme à 900 px.

La 4e mesure porte sur le chevauchement vertical, pas sur la hauteur de l'en-tête : celle-ci grandit
légitimement quand le bouton grandit. Une première version comparait à « deux fois la hauteur du
nom » et échouait sur un en-tête parfaitement sur une ligne — le test était faux, pas le style.

Les tests de soute existants passent SANS modification : ils cliquent `.jleg-load` et attendent
`/à bord/i`, et ni le libellé ni la bascule ne changent.

```
node --test          → tests 490 | pass 490 | fail 0
npx playwright test  → 247 tests (246 avant) | 245 passed | 2 skipped | 0 failed (1,9 min)
```

## Ce qui n'est pas couvert

Le comportement de `chargerJambe()` n'est pas touché — cette issue est de présentation. Aucune
confirmation ni annulation n'est ajoutée : le second clic reste le seul retour arrière. Les autres
boutons de la carte Voyage gardent leur style ; ce n'est pas une passe générale de hiérarchie.

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)