### PR TITLE
fix(trajets): le bouton du manifeste cesse d'être le plus petit objet de sa cellule, et d'être un sosie

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,7 +594,7 @@ Les relevés bruts et le raisonnement complet sont dans
   strictement inchangés). Runner intégré `node --test`, **zéro dépendance**.
 - **E2E de fumée** ([`e2e/smoke.pw.mjs`](e2e/smoke.pw.mjs), Playwright) : non-régression des bugs vécus
   (carte vaisseau au reload, demande corrigée à 0, contrôles qui ne fuient plus, persistance des corrections,
-  navigation, cible tactile du ▶, dépliant de chargement) et **cohérence des filtres par vue** (« légales » agit sur Trajets/Boucles/Commodités,
+  navigation, cible tactile du ▶ et du 🧾 qui ouvre le chargement) et **cohérence des filtres par vue** (« légales » agit sur Trajets/Boucles/Commodités,
   « même système » contraint la Chaîne). Playwright est une dépendance **de dev uniquement** — le site livré reste sans dépendance.
 - **Socle de build** ([`e2e/socle.pw.mjs`](e2e/socle.pw.mjs)) : depuis la v2, la suite E2E sert
   `dist/` — **ce que le build produit réellement**, et non les fichiers du dépôt. Servir les sources

--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -3125,3 +3125,44 @@ test("Corrections : les commodités d'une station sortent par ordre alphabétiqu
     expect(propres, `section ${section} (${propres.length} tuiles)`).toEqual(attendu);
   }
 });
+
+// #52 : en multi-commodité, la première colonne alignait trois objets dont les tailles disaient le
+// CONTRAIRE de leur importance — ▶ à 30 px (action principale), le bouton du manifeste à 24, et les
+// pastilles de catégorie à 30. Le seul autre bouton de la cellule était donc plus petit que des
+// pastilles qui ne sont même pas cliquables.
+//
+// Pire : sa boîte 📦 n'était pas à lui. `KIND_ICON.other` vaut « 📦 » et sert de repli à toute
+// catégorie sans icône dédiée — six commodités de l'amorce l'affichent en pastille, à 6 px du bouton
+// et en plus grand que lui. Sur ces lignes-là, on ne savait plus lequel des deux 📦 était cliquable.
+test("Trajets multi : le bouton du manifeste n'est ni le plus petit ni un sosie (#52)", async ({ page }) => {
+  await page.check("#useCargo");
+  await page.check("#multiCommodity");
+  await expect(page.locator("#rows .route-toggle").first()).toBeVisible({ timeout: 8000 });
+
+  const cellule = page.locator("#rows tr .commodity-cell").first();
+  const manifeste = cellule.locator(".route-toggle");
+  const jouer = cellule.locator(".journey-pick");
+  const pastille = cellule.locator(".multi-icons .cicon").first();
+
+  // 1. Même taille que ▶, et au moins la cible tactile de WCAG 2.2 SC 2.5.8. Sa subordination se dit
+  //    par la COULEUR — contour contre fond plein — jamais par la taille.
+  const bm = await manifeste.boundingBox();
+  const bj = await jouer.boundingBox();
+  expect(bm.width, "largeur du bouton manifeste").toBe(bj.width);
+  expect(bm.height, "hauteur du bouton manifeste").toBe(bj.height);
+  expect(bm.height).toBeGreaterThanOrEqual(24);
+
+  // 2. Les pastilles cessent d'être les plus gros objets de la ligne.
+  const bp = await pastille.boundingBox();
+  expect(bp.width, "pastille vs bouton").toBeLessThanOrEqual(bm.width);
+
+  // 3. Elles passent SOUS les deux boutons, alignées sur le bord gauche du bouton manifeste : le
+  //    décrochement dit ce qu'aucun texte ne dit — ces commodités sont le contenu de ce manifeste.
+  expect(Math.abs(bp.x - bm.x), "indentation des pastilles").toBeLessThanOrEqual(1);
+  expect(bp.y, "les pastilles sont sous les boutons").toBeGreaterThan(bm.y + bm.height - 1);
+
+  // 4. Plus aucun glyphe partagé entre le bouton et les pastilles de la MÊME cellule.
+  const glyphes = await cellule.locator(".multi-icons .cicon").allInnerTexts();
+  const sien = (await manifeste.innerText()).trim();
+  expect(glyphes.map((g) => g.trim()), "le bouton ne porte pas un glyphe de pastille").not.toContain(sien);
+});

--- a/style.css
+++ b/style.css
@@ -916,6 +916,13 @@ tbody tr:hover td { border-bottom-color: var(--line2); }
 
 /* Icône de catégorie (emoji) */
 .commodity-cell { display: flex; align-items: center; gap: 10px; }
+/* Les pastilles et le libellé « n commodités » passent SOUS les deux boutons, indentés de 36 px —
+   30 px de ▶ plus les 6 px d'écart réel de `.loc > div:first-child`, dont la spécificité l'emporte
+   sur celle d'ici. L'indentation les aligne donc exactement sur le bord gauche du bouton manifeste,
+   et ce décrochement dit ce qu'aucun texte ne disait : ces commodités sont le CONTENU de ce
+   manifeste. Le retour à la ligne existait déjà à 1440 px, mais à ras du bord — il ne disait rien.
+   `flex-basis: 100%` force le passage à la ligne sans toucher au reste de la cellule. */
+.commodity-cell .multi-icons, .commodity-cell .cname { flex-basis: 100%; margin-left: 36px; }
 .commodity-cell > span { font-family: var(--font); }
 
 /* Badges alignés SOUS le titre (système, avant-poste, illégal, à vérifier, saut inter-système). */
@@ -934,7 +941,7 @@ tbody tr:hover td { border-bottom-color: var(--line2); }
 .loop-end { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; }
 .loop-mid { display: flex; align-items: center; gap: 8px; }
 .cicon {
-  flex-shrink: 0; width: 30px; height: 30px; display: grid; place-items: center; font-size: 15px;
+  flex-shrink: 0; width: 26px; height: 26px; display: grid; place-items: center; font-size: 14px;
   border-radius: 4px; border: 1px solid var(--k-line, var(--line2)); background: var(--k-bg, rgb(var(--text-fort-rgb) / .04));
 }
 
@@ -984,13 +991,23 @@ tbody tr:hover td { border-bottom-color: var(--line2); }
 .ovmark { font-size: 9px; margin-left: 2px; vertical-align: super; }
 input.editv-input { width: 80px; min-width: 0; padding: 2px 5px; font-size: 12px; font-family: var(--mono); text-align: right; background: rgb(var(--fond-carte-rgb) / 0.95); border: 1px solid var(--acc); color: var(--text); border-radius: 3px; }
 
-/* Bouton « voir le chargement » — lignes multi-commodité uniquement (#30). */
+/* Bouton « voir le chargement » — lignes multi-commodité uniquement (#30).
+   MÊME TAILLE que le ▶ voisin (#52) : c'est le seul autre bouton de la cellule, et il était le plus
+   petit des trois objets alignés — plus petit que des pastilles de catégorie qui, elles, ne sont même
+   pas cliquables. Sa subordination continue de se dire par la COULEUR (contour contre fond plein),
+   jamais par la taille. 30 px tient au passage la cible tactile de WCAG 2.2 SC 2.5.8, comme ▶.
+   Son glyphe est passé de 📦 à 🧾 : `KIND_ICON.other` vaut « 📦 » et sert de repli à toute catégorie
+   sans icône dédiée — six commodités de l'amorce l'affichent en pastille, à 6 px du bouton et en plus
+   grand que lui. On ne savait plus lequel des deux était cliquable. Une caisse, c'est du fret ; un
+   manifeste, c'est un papier. */
 .route-toggle {
-  flex-shrink: 0; width: 24px; height: 24px; padding: 0; display: grid; place-items: center; font-size: 12px; line-height: 1;
+  flex-shrink: 0; width: 30px; height: 30px; padding: 0; display: grid; place-items: center; font-size: 14px; line-height: 1;
   background: rgb(var(--text-fort-rgb) / 0.04); border: 1px solid var(--line2); border-radius: 4px; cursor: pointer; color: var(--muted);
   transition: color 0.12s, border-color 0.12s, background 0.12s;
 }
 .route-toggle:hover { color: var(--acc); border-color: var(--acc); }
+/* La convention de focus du dépôt. Aucune règle ne visait ce bouton, alors qu'il est activable. */
+.route-toggle:focus-visible { outline: 2px solid var(--acc-2); outline-offset: 1px; }
 /* Ouvert, ce bouton prenait le remplissage ambre plein. Il ne le peut plus : le ▶ voisin l'a pris
    (#29), et deux carrés pleins côte à côte annulent la hiérarchie. L'état actif se dit donc ici en
    CONTOUR — d'autant que le glyphe est un emoji, que `color` ne repeint pas : sur fond ambre plein,

--- a/vues/trajets.tsx
+++ b/vues/trajets.tsx
@@ -274,7 +274,7 @@ function LigneComposee({ t, celluleFrais, libelleCaisses, releveLePlusAncien, te
             title="Voir le chargement"
             aria-label="Voir le chargement"
             aria-expanded={deplie}
-          >📦</button>
+          >🧾</button>
           <span className="multi-icons" title={noms}>
             {t.lines.slice(0, MAX_ICONES).map((l, k) => <IconeCommodite key={k} kind={l.kind} />)}
             {n > MAX_ICONES ? <span className="muted">+{n - MAX_ICONES}</span> : null}


### PR DESCRIPTION
En multi-commodité, la première colonne alignait trois objets dont les tailles disaient le CONTRAIRE
de leur importance : ▶ à 30 px (l'action principale), le bouton du manifeste à 24, et les pastilles
de catégorie à 30. Le seul autre bouton de la cellule était donc plus petit que des pastilles qui ne
sont même pas cliquables.

## Cause racine

`style.css` — `.route-toggle { width: 24px; height: 24px; font-size: 12px }` contre
`.journey-pick { width: 30px; height: 30px; font-size: 14px }`, et `.cicon { width: 30px }`. Le
commentaire de `.journey-pick` raconte son passage de 20 à 30 px pour tenir WCAG 2.2 SC 2.5.8 ; le
dépliant, lui, est resté à 24.

Et son glyphe n'était pas à lui : `KIND_ICON.other` vaut « 📦 » et sert de repli à toute catégorie
sans icône dédiée. Six commodités de l'amorce l'affichent en pastille, à 6 px du bouton et EN PLUS
GRAND que lui — sur ces lignes-là, on ne savait plus lequel des deux était cliquable.

## Le correctif

Quatre points, ceux de l'issue :

1. **🧾 au lieu de 📦.** Une caisse, c'est du fret ; un manifeste, c'est un papier. Plus aucun glyphe
   partagé avec les pastilles de la même cellule ;
2. **30 × 30 px, glyphe 14** — la taille de ▶. Sa subordination continue de se dire par la COULEUR
   (contour contre fond plein), jamais par la taille ;
3. **Les pastilles descendent à 26 px** : elles cessent d'être les plus gros objets de la ligne ;
4. **Elles passent SOUS les deux boutons, indentées de 36 px** — 30 px de ▶ plus les 6 px d'écart
   réel de `.loc > div:first-child`, dont la spécificité l'emporte. Elles s'alignent donc exactement
   sur le bord gauche du bouton manifeste, et ce décrochement dit ce qu'aucun texte ne disait : ces
   commodités sont le CONTENU de ce manifeste. Le retour à la ligne existait déjà à 1440 px, mais à
   ras du bord — il ne disait rien.

`.route-toggle:focus-visible` prend la convention du dépôt : aucune règle ne le visait.

## Vérification

ROUGE avant : largeur du bouton **24** pour 30 attendus. Les quatre critères de l'issue sont testés,
dont le garde-fou contre le retour d'un glyphe partagé — le `textContent` du bouton ne doit être
celui d'aucune `.cicon` de sa cellule.

Le test « ▶ reste le seul bouton plein, dépliant ouvert » passe SANS modification.

```
npx tsc --noEmit     → aucune sortie
node --test          → tests 490 | pass 490 | fail 0
npx playwright test  → 247 tests (246 avant) | 245 passed | 2 skipped | 0 failed (1,7 min)
```

`README.md` mentionne le nouveau glyphe, comme l'issue le demandait.

## Ce qui n'est pas couvert

#25 vise les deux mêmes boutons pour un AUTRE défaut — pendant le chargement du marché, ils
agissaient sur les lignes d'un autre mode. Cette issue-ci ne touche pas à cette logique.

Closes #52
🤖 Generated with [Claude Code](https://claude.com/claude-code)