### PR TITLE
fix(voyage): les suggestions d'arrêt disent ce que l'arrêt RAPPORTE, et se classent dessus

### DIFF
--- a/e2e/smoke.pw.mjs
+++ b/e2e/smoke.pw.mjs
@@ -3330,3 +3330,44 @@ test("Trajets multi : le bouton du manifeste n'est ni le plus petit ni un sosie 
   const sien = (await manifeste.innerText()).trim();
   expect(glyphes.map((g) => g.trim()), "le bouton ne porte pas un glyphe de pastille").not.toContain(sien);
 });
+
+// #50 : le bouton de suggestion annonçait une marge AU SCU sur un stock qu'on n'a pas. Mesuré sur
+// l'instantané : 37 origines sur 93 mettaient la mauvaise destination en tête, et depuis PSS Alpha
+// le bouton de gauche valait 56 832 aUEC quand celui rangé derrière en valait 311 010 — 254 178
+// laissés au sol par un classement qui regardait le prix au lieu du total.
+//
+// Le vrai contrat n'est pas « un montant s'affiche » mais « CE montant est celui de la jambe ». Une
+// suggestion qui promet un chiffre que la jambe créée contredit est pire que pas de chiffre du tout.
+test("Voyage : le montant d'une suggestion est celui que la jambe rapporte vraiment (#50)", async ({ page }) => {
+  await page.check("#useCargo");
+  await voyageAvecSuggestion(page);
+
+  const bouton = page.locator("#journeyCard .jstop-suggest").first();
+  const annonce = (await bouton.innerText()).trim();
+  // Un montant compact et SIGNÉ, pas une marge au SCU : « +311K », jamais « +9 472/SCU ».
+  expect(annonce, "le bouton annonce un montant compact").toMatch(/\+\s*[\d,.]+[KM]?\s*$/);
+  expect(annonce, "le bouton n'annonce plus une marge au SCU").not.toContain("/SCU");
+
+  // L'infobulle porte le montant en clair ET la marge au SCU, dans cet ordre.
+  const bulle = await bouton.getAttribute("title");
+  expect(bulle, "l'infobulle dit ce que l'arrêt rapporte").toMatch(/aUEC pour un chargement complet/);
+  expect(bulle, "l'infobulle garde la marge au SCU").toMatch(/\/SCU/);
+
+  // LE CONTRAT : on ajoute l'arrêt, et le profit de la jambe créée doit valoir ce qui était promis.
+  // Les deux passent par le même formateur compact, donc la comparaison est exacte.
+  const promis = annonce.match(/\+\s*([\d,.]+[KM]?)\s*$/)[1];
+  await bouton.click();
+  await expect(page.locator("#journeyCard .jleg")).toHaveCount(2, { timeout: 8000 });
+  const profitJambe = await page.locator("#journeyCard .jleg").last().locator(".jleg-profit").innerText();
+  const compact = await page.evaluate(
+    ([texte]) => {
+      const n = Number(texte.replace(/[^\d-]/g, ""));
+      const a = Math.abs(n);
+      if (a >= 1e6) return Math.round(n / 1e5) / 10 + "M";
+      if (a >= 1e3) { const k = Math.round(n / 100) / 10; return Math.abs(k) >= 1000 ? Math.round(n / 1e5) / 10 + "M" : k + "K"; }
+      return String(Math.round(n));
+    },
+    [profitJambe],
+  );
+  expect(compact, `la jambe rapporte ${profitJambe}, le bouton promettait +${promis}`).toBe(promis);
+});

--- a/logic.test.mjs
+++ b/logic.test.mjs
@@ -1271,6 +1271,12 @@ test("compactValue : notation compacte K/M", () => {
   assert.equal(compactValue(540), "540");
   assert.equal(compactValue(0), "0");
   assert.equal(compactValue(null), "—");
+  // Le cas de bord de #50, et il était FAUX en production : 999 999 rendait « 1000K », soit quatre
+  // chiffres devant un préfixe qui existe pour n'en laisser que trois. Un montant qui atteint le
+  // million doit le DIRE — c'est la seule frontière que ce formateur trace.
+  assert.equal(compactValue(999999), "1M");
+  assert.equal(compactValue(999499), "999.5K");
+  assert.equal(compactValue(-999999), "-1M");
 });
 
 // ---------- Heatmap relative (mode Marché) ----------
@@ -3314,6 +3320,45 @@ test("stopSuggestions : ne propose JAMAIS un trajet que la vue refuse d'afficher
   assert.deepEqual(terminaux(stopSuggestions(MARCHE_ARRETS, 0, filtres({ noOutpost: true }))), ["Relais"]);
   assert.deepEqual(terminaux(stopSuggestions(MARCHE_ARRETS, 0, filtres({ sameOnly: true }))), ["Poste"]);
   assert.deepEqual(terminaux(stopSuggestions(MARCHE_ARRETS, 0, filtres({ q: "ferraille" }))), ["Relais"]);
+});
+
+// #50 : LE MARCHÉ DE L'ARBITRAGE. Deux destinations, et celle qui a la plus forte marge au SCU est
+// celle qui rapporte le MOINS — parce qu'elle n'a que 3 SCU en rayon. C'est exactement le défaut
+// mesuré sur les vraies données : 37 origines sur 93 mettent la mauvaise destination en tête, et à
+// PSS Alpha le bouton de gauche vaut 56 832 aUEC quand celui rangé derrière en vaut 311 010.
+const MARCHE_NET = {
+  terminals: [
+    { name: "Dépôt", system: "Stanton", planet: "P", outpost: false },
+    { name: "Rare", system: "Stanton", planet: "P", outpost: false },   // marge énorme, stock famélique
+    { name: "Volume", system: "Stanton", planet: "P", outpost: false }, // marge modeste, stock plein
+  ],
+  commodities: [
+    { name: "Gemme", code: "GEM", kind: "metal", illegal: false, buys: [[0, 1000, 3, 9e9, 3]], sells: [[1, 6000, 9e9, 9e9, 3]] },
+    { name: "Sable", code: "SAB", kind: "metal", illegal: false, buys: [[0, 100, 9e9, 9e9, 3]], sells: [[2, 500, 9e9, 9e9, 3]] },
+  ],
+};
+
+test("stopSuggestions : le classement suit ce que l'arrêt RAPPORTE, pas la marge au SCU (#50)", () => {
+  // « Rare » : 5 000 de marge au SCU, mais 3 SCU en rayon -> 15 000 net.
+  // « Volume » :  400 de marge au SCU, sur les 96 SCU de la soute -> 38 400 net.
+  // L'ancien classement mettait « Rare » en tête : 15 000 annoncés comme meilleurs que 38 400.
+  const s = stopSuggestions(MARCHE_NET, 0, filtres(), 4, idResolve);
+  assert.deepEqual(terminaux(s), ["Volume", "Rare"]);
+  assert.equal(s[0].net, 38400);
+  assert.equal(s[1].net, 15000);
+  // La marge au SCU RESTE portée : elle départage à net égal, et l'infobulle la cite encore.
+  assert.equal(s[0].margin, 400);
+  assert.equal(s[1].margin, 5000);
+});
+
+test("stopSuggestions : sans soute bornée, le net est `null` et le classement retombe sur la marge (#50)", () => {
+  // `manifestsFrom` rend [] dès que `useCargo` est faux : sans capacité, aucun net n'est calculable.
+  // 107 origines réelles sont dans ce cas. Le champ doit valoir `null` — jamais un 0 silencieux, qui
+  // se lirait « cet arrêt ne rapporte rien » alors qu'on n'en sait rien.
+  const s = stopSuggestions(MARCHE_NET, 0, filtres({ useCargo: false }), 4, idResolve);
+  assert.deepEqual(terminaux(s), ["Rare", "Volume"]); // 5 000/SCU devant 400/SCU
+  assert.equal(s[0].net, null);
+  assert.equal(s[1].net, null);
 });
 
 test("stopSuggestions : le menu « système d'achat » ne bride PAS les suggestions", () => {

--- a/logic.ts
+++ b/logic.ts
@@ -1331,7 +1331,13 @@ export function compactValue(n: number | null): string {
   if (n == null || !isFinite(n)) return "—";
   const a = Math.abs(n);
   if (a >= 1e6) return Math.round(n / 1e5) / 10 + "M";
-  if (a >= 1e3) return Math.round(n / 100) / 10 + "K";
+  // Le seuil se lit sur la valeur ARRONDIE, pas sur la brute. 999 999 s'arrondissait à 1 000,0 et
+  // rendait « 1000K » : quatre chiffres devant un préfixe qui existe justement pour n'en laisser que
+  // trois. Un montant qui atteint le million doit le dire (#50).
+  if (a >= 1e3) {
+    const k = Math.round(n / 100) / 10;
+    return Math.abs(k) >= 1000 ? Math.round(n / 1e5) / 10 + "M" : k + "K";
+  }
   return String(Math.round(n));
 }
 
@@ -1446,17 +1452,41 @@ const legPasses = (r: Route, f: Filtres): boolean => routePasses(r, { ...f, sysF
 // « légales uniquement » est coché, avant-poste exclu, relevé périmé — et la jambe ajoutée
 // s'affichait « aucun fret rentable », son manifeste étant filtré, lui, par pairEligible.
 // Même divergence de règles que celle qui a donné pairEligible : une seule source, partagée.
-export function stopSuggestions(market: Marche, origin: number, f: Filtres, limit: number = 4): SuggestionArret[] {
+export function stopSuggestions(market: Marche, origin: number, f: Filtres, limit: number = 4, resolve: Resolveur | null = null, autoloadFor: ResolveurFrais | null = null): SuggestionArret[] {
+  // DEUX SOURCES, ET C'EST VOULU (#50).
+  //
+  // `enRouteDeals` + `legPasses` décident QUI est éligible : eux seuls appliquent `sameOnly`, `q` et
+  // l'avant-poste d'ORIGINE, que `pairEligible` — le filtre de `manifestsFrom` — ignore. Changer de
+  // source ferait reparaître des suggestions que la vue refuse d'afficher, et c'est précisément ce
+  // que le test « ne propose JAMAIS un trajet que la vue refuse d'afficher » garde.
+  //
+  // `manifestsFrom` ne fait qu'ESTAMPILLER le montant sur ce qui a survécu au filtre. C'est le
+  // patron déjà prouvé par `estampillerManifestes` pour la chaîne.
   const byDest = new Map();
   for (const d of enRouteDeals(market, origin, "", null, f)) {
     if (!legPasses(d, f)) continue;
     const label = stationLabel(d.sell.terminal, d.sell.system);
     const cur = byDest.get(label);
     if (!cur || d.margin > cur.margin) {
-      byDest.set(label, { label, terminal: d.sell.terminal, system: d.sell.system, commodity: d.commodity, margin: d.margin });
+      byDest.set(label, { label, terminal: d.sell.terminal, system: d.sell.system, commodity: d.commodity, margin: d.margin, net: null });
     }
   }
-  return [...byDest.values()].sort((a, b) => b.margin - a.margin).slice(0, limit);
+
+  // Le montant NET, par destination. `manifestsFrom` rend `[]` sans soute bornée : `net` reste alors
+  // `null` partout et le classement retombe sur la marge au SCU — 107 origines réelles sont dans ce
+  // cas, et un 0 s'y lirait « cet arrêt ne rapporte rien » alors qu'on ne l'a pas mesuré.
+  if (resolve) {
+    for (const trip of manifestsFrom(market, origin, "", f, resolve, null, autoloadFor)) {
+      const s = byDest.get(stationLabel(trip.dest.name, trip.dest.system));
+      if (s) s.net = trip.profit;
+    }
+  }
+
+  // Le NET classe, la marge au SCU départage. Une suggestion sans montant passe derrière celles qui
+  // en ont un : on ne met pas devant ce qu'on n'a pas su chiffrer.
+  return [...byDest.values()]
+    .sort((a, b) => (b.net ?? -Infinity) - (a.net ?? -Infinity) || b.margin - a.margin)
+    .slice(0, limit);
 }
 // Meilleure jambe entre deux terminaux (commodité de marge max), filtres appliqués comme
 // ci-dessus, ou null si aucun fret éligible : l'appelant pose alors une jambe « à vide ».

--- a/types.ts
+++ b/types.ts
@@ -867,7 +867,15 @@ export type Parcours = { legs: Jambe[]; current: number; start?: Station };
 
 export type RetraitArret = Parcours & { removedFrom: number; removedCount: number; insertedCount: number };
 
-export type SuggestionArret = { label: string; terminal: string; system: string; commodity: string; margin: number };
+/** Une destination proposée depuis l'étape courante du parcours.
+ *
+ *  `net` est ce que l'arrêt RAPPORTE — le profit du manifeste qu'on y emporterait, frais déduits —
+ *  et c'est LUI qui classe (#50). `margin` reste la marge au SCU de la meilleure commodité : elle
+ *  départage à net égal, et l'infobulle la cite encore.
+ *
+ *  `net` vaut `null` quand aucun manifeste n'est calculable — soute non bornée, ou rayon vide. C'est
+ *  une ABSENCE de mesure, pas un zéro : 0 se lirait « cet arrêt ne rapporte rien ». */
+export type SuggestionArret = { label: string; terminal: string; system: string; commodity: string; margin: number; net: number | null };
 
 export type IntentionLigne = { name: string; units: number };
 

--- a/voyage-donnees.ts
+++ b/voyage-donnees.ts
@@ -181,7 +181,13 @@ export function journeyEndIndex(): number | null {
 /** Les arrêts qu'on pourrait ajouter depuis la fin du parcours, filtres appliqués. */
 export function journeyStopSuggestions() {
   const fromIdx = journeyEndIndex();
-  return fromIdx == null ? [] : stopSuggestions(etat.MARKET!, fromIdx, readFilters());
+  if (fromIdx == null) return [];
+  const f = readFilters();
+  // `effVals` et `feeResolver` DESCENDENT, et c'est le sens du montant : sans le premier la
+  // suggestion chiffrerait sur des prix que l'utilisateur a corrigés, sans le second elle
+  // annoncerait un brut là où la jambe qu'elle crée affichera un net. Elle contredirait sa propre
+  // jambe, qui, elle, les passe déjà (`legManifest`).
+  return stopSuggestions(etat.MARKET!, fromIdx, f, 4, effVals, feeResolver(f));
 }
 
 // ── LA GÉNÉRATION DU COMPAGNON ────────────────────────────────────────────────────────────────

--- a/vues/voyage.tsx
+++ b/vues/voyage.tsx
@@ -15,6 +15,7 @@
 //     et le détruisait à chaque rendu. La carte étant passée à React, ce détour n'a plus de raison
 //     d'être — et un conteneur peint à part DANS une carte possédée par React est précisément le
 //     piège de #120.
+import { compactValue } from "../logic.ts";
 import { fmt, fmtFee, signe } from "../format.ts";
 import { Fragment } from "react";
 import { PointFraicheur, IconeCommodite, TagIllegal } from "./communs.tsx";
@@ -61,7 +62,10 @@ export type Jambe = {
   suggestions: ProprietesSuggestions | null;
 };
 
-export type SuggestionArret = { label: string; terminal: string; commodity: string; margin: number };
+/** Ce que la vue lit d'une suggestion. `net` est ce que l'arrêt RAPPORTE — le profit du manifeste
+ *  qu'on y emporterait, frais déduits — et c'est lui qui classe (#50). `null` = non chiffrable
+ *  (soute non bornée) : une ABSENCE de mesure, pas un zéro. */
+export type SuggestionArret = { label: string; terminal: string; commodity: string; margin: number; net: number | null };
 
 export type ProprietesVoyage = {
   stations: { name: string; system: string }[];
@@ -265,11 +269,20 @@ export function CarteVoyage(p: ProprietesVoyage) {
             <button
               className="jstop-suggest"
               data-label={s.label}
-              title={`Ajouter ${s.terminal} — via ${s.commodity}, +${fmt(s.margin)} marge/SCU`}
+              // L'infobulle porte les DEUX chiffres, et dans cet ordre : ce que l'arrêt rapporte
+              // d'abord — c'est lui qui classe — puis la marge au SCU, qui dit à quel prix. La
+              // commodité citée est celle de plus forte marge ; le manifeste réellement chargé peut
+              // en contenir d'autres (c'est le second symptôme de #50, laissé ouvert).
+              title={s.net != null
+                ? `Ajouter ${s.terminal} — ${fmt(s.net)} aUEC pour un chargement complet, via ${s.commodity} à +${fmt(s.margin)}/SCU`
+                : `Ajouter ${s.terminal} — via ${s.commodity}, +${fmt(s.margin)} marge/SCU (borne la soute pour chiffrer l'arrêt)`}
               key={s.label}
             >
               {`+ ${s.terminal} `}
-              <span className="muted">{`+${fmt(s.margin)}`}</span>
+              {/* Le montant COMPACT : ces boutons tiennent sur une rangée, et « +311 010 » y prend
+                  la place de deux. Sans soute bornée il n'y a pas de montant — on retombe alors sur
+                  la marge au SCU, avec son unité, pour qu'on ne confonde pas les deux chiffres. */}
+              <span className="muted">{s.net != null ? `+${compactValue(s.net)}` : `+${fmt(s.margin)}/SCU`}</span>
             </button>
           ))}
         </div>


### PR DESCRIPTION
Le bouton « + Arrêt » annonçait une marge AU SCU — un prix — sur un stock qu'on n'a pas forcément.
Mesuré sur l'instantané : **37 origines sur 93 mettaient la mauvaise destination en tête**. Depuis
PSS Alpha, le bouton de gauche valait 56 832 aUEC quand celui rangé derrière en valait 311 010 :
254 178 aUEC laissés au sol par un classement qui regardait le prix au lieu du total.

## Cause racine

`logic.ts` — `stopSuggestions` retenait ET triait sur `d.margin`, la marge au SCU de la meilleure
commodité. `SuggestionArret` (types.ts) ne portait aucun montant. Et `journeyStopSuggestions`
(voyage-donnees.ts) appelait à trois arguments : ni `effVals` ni `feeResolver` ne descendaient, donc
même un montant calculé là aurait été un brut déguisé, contredisant sa propre jambe.

## Le correctif

DEUX SOURCES, et c'est le point à ne pas simplifier. `enRouteDeals` + `legPasses` décident QUI est
éligible : eux seuls appliquent `sameOnly`, `q` et l'avant-poste d'ORIGINE, que `pairEligible` — le
filtre de `manifestsFrom` — ignore. Changer de source ferait reparaître des suggestions que la vue
refuse d'afficher, ce que garde le test « ne propose JAMAIS un trajet que la vue refuse d'afficher ».
`manifestsFrom` ne fait donc qu'ESTAMPILLER le net sur ce qui a survécu au filtre — le patron déjà
prouvé par `estampillerManifestes` pour la chaîne.

Le NET classe, la marge au SCU départage. `effVals` et `feeResolver(f)` descendent enfin.

## Les décisions que l'issue laissait ouvertes

- **`net: null`, jamais 0**, quand aucun manifeste n'est calculable (soute non bornée : 107 origines
  réelles). Un 0 se lirait « cet arrêt ne rapporte rien » alors qu'on ne l'a pas mesuré. Le
  classement retombe alors sur la marge au SCU, et le bouton l'affiche AVEC son unité (`+9 472/SCU`)
  pour qu'on ne confonde pas les deux chiffres.
- **`compactValue` est RÉEMPLOYÉE, pas remplacée.** L'issue la croyait absente ; elle existe, est
  testée, et sert la vue Commodités. Poser un second formateur aux règles fr-FR laisserait deux
  conventions compactes contradictoires dans la même application.
- **L'infobulle porte les deux chiffres**, le net d'abord — c'est lui qui classe — puis la marge.

## Un bug déjà en production, corrigé au passage

`compactValue(999999)` rendait **`"1000K"`** : quatre chiffres devant un préfixe qui existe pour n'en
laisser que trois. Le seuil se lit maintenant sur la valeur ARRONDIE. Ce défaut était affiché dans la
vue Commodités, pas seulement dans le Voyage.

## Vérification

Trois rouges avant, dans cet ordre :
- `compactValue(999999)` → `"1000K"` au lieu de `"1M"` — rouge sans écrire une ligne de fonctionnalité ;
- `stopSuggestions` sur un marché synthétique (« Rare » 5 000/SCU sur 3 SCU = 15 000 net ;
  « Volume » 400/SCU sur 96 SCU = 38 400 net) rendait `["Rare", "Volume"]` et `s[0].net === undefined`.
  Après : `["Volume", "Rare"]`, `net` 38 400 puis 15 000 ;
- Playwright : le montant promis par le bouton doit être CELUI de la jambe créée. C'est le vrai
  contrat — une suggestion qui promet un chiffre que sa jambe contredit est pire que pas de chiffre.

```
node --test          → tests 492 (490 avant) | pass 492 | fail 0
npx playwright test  → 256 tests (255 avant) | 254 passed | 2 skipped | 0 failed (1,6 min)
npx tsc --noEmit     → aucune sortie
```

## Ce qui n'est pas couvert

- **L'infobulle nomme encore la commodité de plus forte MARGE**, alors que la jambe chargera un
  manifeste multi-commodité. C'est le second symptôme listé par l'issue, et il ne disparaît pas en
  ajoutant le montant.
- **Trois suggestions réelles pointent un terminal d'achat à stock 0** (Levski→Port Tressler via
  Construction Materials, CRU-L5→HUR-L4 via Nitrogen, Chawla's Beach→Ashland via Elespo) : elles
  n'ont aucun manifeste, tombent donc en `net: null`, et passent désormais DERRIÈRE celles qui sont
  chiffrées. Elles restent affichées — les retirer masquerait un débouché réel.
- **La ligne « marge cumulée … aUEC/SCU » juste sous les boutons garde son unité.** L'issue la met
  hors périmètre, mais deux unités voisines se lisent mal : à traiter à part.

Closes #50
🤖 Generated with [Claude Code](https://claude.com/claude-code)