### PR TITLE
chore(carte): #43 est absorbée par l'ADR-004 — on retire ce qui décrit encore une colonne disparue

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,14 +276,14 @@ n'as pas touché n'est **pas** persisté — la jambe reste branchée sur le mar
 
 ### La carte du parcours
 
-À côté du compagnon, une **troisième colonne** pose les arrêts **dans l'espace** : un disque par
+**Dans le Plan de vol**, la carte pose les arrêts **dans l'espace** : un disque par
 système traversé, le vaisseau sur l'escale courante, et un corridor violet `⚡` quand le parcours
 change de système. Les systèmes se lisent **toujours de gauche à droite dans le même ordre — Nyx,
 Pyro, Stanton** — quel que soit le sens du voyage : une carte qu'on doit relire à chaque trajet ne
 se lit pas d'un coup d'œil. Seuls les systèmes **traversés** ont un disque, sans case vide pour les
-autres ; un système qu'UEX publierait en plus se range après les trois connus. Elle ne reste à côté que si elle y garde une largeur lisible (≈ 460 px) —
-en dessous, elle repasse en **bandeau pleine largeur** sur sa propre ligne, ce qui vaut mieux qu'une
-colonne où les libellés d'escale tomberaient sous 5 px.
+autres ; un système qu'UEX publierait en plus se range après les trois connus. Elle vit **dans la vue de conclusion et nulle part ailleurs** (ADR-004) : elle
+répondait à « où suis-je », qui est une question de plan, depuis une colonne posée à côté des vues
+de recherche — où elle se redessinait à chaque frappe pour un écran que personne ne regardait.
 Un saut est **routé par les deux passerelles** — on ne change pas de système n'importe où : le
 trajet part de l'escale, rejoint la passerelle d'ici, traverse, puis repart de celle de là-bas.
 Chaque bout se décide **séparément** : partir d'une passerelle ne dispense pas de **ressortir par

--- a/style.css
+++ b/style.css
@@ -835,7 +835,9 @@ input.jman-qty { width: 56px; min-width: 0; padding: 3px 5px; text-align: right;
   flex: 1 1 460px; min-width: 380px;
   background: var(--panel); border: 1px solid var(--line); border-left: 2px solid var(--acc-2);
 }
-.ship-journey-row.stacked .journey-map { width: 100%; max-width: none; }
+/* (La règle `.ship-journey-row.stacked .journey-map` a disparu : elle était INATTEIGNABLE depuis
+   que la carte du parcours est passée enfant de `<section id="plan">` (ADR-004). Elle décrivait la
+   troisième colonne du bandeau compagnon, qui n'existe plus — #43.) */
 .jm-label {
   display: block; margin-bottom: 8px;
   font-family: var(--mono); font-size: 10px; letter-spacing: 2px; text-transform: uppercase; color: var(--muted);


### PR DESCRIPTION
L'issue #43 demandait de réunir le vaisseau, le voyage et sa carte, éclatés sur trois colonnes.
Elle n'est pas à implémenter : l'ADR-004 l'a ABSORBÉE, et le code le montre déjà.

## Ce qui est vérifié

- `App.tsx` porte `<Portail id="journeyMap" si="plan">` : la carte ne vit QUE dans le Plan de vol ;
- `#shipJourneyRow` (index.html) n'a plus que deux colonnes, `#voyageLeft` et `#journeyCard` ;
- `#journeyMap` est passé enfant de `<section id="plan">` ;
- deux tests e2e le tiennent, et sont verts : « la carte du parcours ne vit QUE dans cette vue
  (#61) » et « le bandeau et les filtres restent, seule la vue change (#57) ».

L'ADR-004 le dit en toutes lettres, section « Sur les autres issues » : « **#43** […] Cet ADR
l'**absorbe** : à fermer. »

## Ce qui restait, et qui partait avec

Deux résidus qui décrivaient encore la colonne disparue, et qui mentaient donc à qui les lisait :

- `style.css` — `.ship-journey-row.stacked .journey-map` était **inatteignable** : `#journeyMap`
  n'est plus descendant de cette rangée. Le sélecteur ne pouvait plus matcher quoi que ce soit ;
- `README.md` — « À côté du compagnon, une **troisième colonne** » et « elle repasse en **bandeau
  pleine largeur** » décrivaient une disposition que l'ADR-004 a supprimée. Le paragraphe dit
  maintenant où la carte vit, et POURQUOI : elle répondait à « où suis-je », qui est une question de
  plan, depuis une colonne posée à côté des vues de recherche — où elle se redessinait à chaque
  frappe pour un écran que personne ne regardait.

## Vérification

```
node --test          → tests 492 | pass 492 | fail 0
npx playwright test  → 256 tests | 254 passed | 2 skipped | 0 failed
npm run build:site   → ✓ built | précache 20 entrées
```

Aucun test n'est ajouté : les deux qui tiennent l'invariant existaient déjà, et c'est précisément ce
qui permet de fermer l'issue sans écrire de code.

## Ce qui n'est pas couvert

Le reliquat réel de #43 n'est pas la carte mais les **516 px vides à droite de la rangée compagnon
sur écran large**. Décider qui prend cette largeur est une autre question, qui mérite sa propre
issue — hors v2.

Closes #43
🤖 Generated with [Claude Code](https://claude.com/claude-code)