### PR TITLE
feat(accueil): une aide s'ouvre à la première visite, et se rejoue quand on veut

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -28,6 +28,7 @@ import { VueTrajetsArbitrage } from "./vues/trajets-vue.tsx";
 import { CarteParcours } from "./vues/carte-vue.tsx";
 import { VueEnRoute } from "./vues/enroute-vue.tsx";
 import { Bandeau } from "./vues/bandeau-vue.tsx";
+import { Aide } from "./vues/aide.tsx";
 import { indexStationExacte } from "./marche.ts";
 
 /**
@@ -95,6 +96,12 @@ export function App() {
       {/* LE BANDEAU. Sa garde est NÉGATIVE — il est visible dans six vues sur huit, seul le Plan de
           vol le masque. C'est l'inverse du patron des vues d'onglet, et le seul de son espèce. */}
       <Bandeau />
+      {/* L'AIDE DE DÉMARRAGE (#62), et la SEULE chose de cet arbre qui ne passe par aucun portail :
+          elle n'a pas de conteneur dans `index.html`, parce qu'elle est neuve. Elle rend donc dans
+          `#racine` lui-même — dernier enfant de <body> — ce qui la pose au-dessus du rail sans un
+          z-index à négocier. En DERNIER, pour que l'ordre du document suive l'ordre visuel.
+          Sa garde est en tête du composant, comme celle de `VueCommodites`. */}
+      <Aide />
     </>
   );
 }

--- a/README.md
+++ b/README.md
@@ -70,7 +70,15 @@ signe et **en rouge**, jamais dans le vert des gains.
 - **Permaliens & persistance** : l'état (filtres, tri, vue, vaisseau) est mémorisé (localStorage) et encodé dans l'URL → bouton **Partager**.
 - **Copier le manifeste**, **raccourcis clavier** (`/` recherche, `1`–`8` vues) ; tout ce qui s'active
   au clic s'active aussi à **Entrée/Espace** (en-têtes de tri, escales de la carte, valeurs
-  corrigeables, en-tête d'une jambe), et les raccourcis se taisent tant que le focus est sur l'un d'eux.
+  corrigeables, en-tête d'une jambe), et les raccourcis se taisent tant que le focus est sur l'un d'eux
+  — comme ils se taisent **sous une modale** : rien n'agit derrière le voile de l'aide.
+- **Première visite** : au tout premier chargement, une **aide modale** dit ce qu'est cet écran et à
+  quoi répond chacune des huit vues. Sa liste n'est pas écrite à la main — elle est **lue sur le
+  rail** (numéro, libellé, description), pour qu'une vue ajoutée ou renumérotée ne puisse pas la
+  rendre menteuse. Elle se referme à **Échap**, au clic hors du panneau ou par son bouton, et ne
+  revient plus : le drapeau vit dans `localStorage` sous **sa propre clé** (`best-hauling-aide-vue`)
+  et **ne part jamais dans le permalien** — un lien partagé ne doit pas décider à la place de son
+  destinataire s'il a déjà vu l'aide. Le **?** posé à côté du logo la rejoue à tout moment.
 - Systèmes couverts : **Stanton**, **Pyro**, **Nyx**.
 
 ### Portée des filtres par vue

--- a/aide-gestes.ts
+++ b/aide-gestes.ts
@@ -1,0 +1,23 @@
+// LE GESTE DE REJEU (#62).
+//
+// Une DÉLÉGATION, pas un `onClick` : `#aideRejouer` est du markup d'`index.html`, posé dans
+// `.brand`, que la racine React ne possède pas (ADR-012 §2). Elle est posée sur `.brand` et non sur
+// le bouton lui-même, comme `navigation.ts` le fait sur `.rail-nav` — le jour où la marque gagne un
+// troisième bouton, il n'y a rien à rebrancher.
+//
+// Le bouton est FRÈRE de `#brandHome`, jamais son enfant : deux éléments interactifs imbriqués sont
+// invalides en ARIA — la règle appliquée en sortant `.scomm-undo` du `.editv` (#38). `index.html`
+// réservait la place depuis l'ADR-004, et `e2e/plan.pw.mjs` la garde déjà.
+import { ouvrirAide } from "./aide.ts";
+
+import type { Noeud } from "./types.ts";
+// La CIBLE d'un événement, typée. Le cast est posé UNE fois par module, comme `$` — pas dans un
+// module partagé (même choix que `$`, pris huit fois dans ce dépôt).
+const cible = (e: Event) => e.target as Noeud;
+
+export function brancherAide(): void {
+  const marque = document.querySelector(".brand");
+  if (marque) marque.addEventListener("click", (e) => {
+    if (cible(e).closest("#aideRejouer")) ouvrirAide();
+  });
+}

--- a/aide.ts
+++ b/aide.ts
@@ -1,0 +1,50 @@
+// L'AIDE DE DÉMARRAGE (#62) : le drapeau, et les deux gestes qui l'ouvrent et la referment.
+//
+// ── POURQUOI SA PROPRE CLÉ, ET SURTOUT PAS L'ÉTAT ENCODÉ ──────────────────────────────────────
+// `persistance.ts` encode l'état DANS LE HASH, et ce hash est le lien qu'on partage. Un drapeau
+// « j'ai déjà vu l'aide » posé là déciderait à la place du destinataire : recevoir le lien d'un
+// pilote expérimenté supprimerait l'aide d'une VRAIE première visite — c'est-à-dire exactement le
+// cas pour lequel elle existe — et un premier visiteur qui partage l'imposerait à tout le monde.
+//
+// La séparation n'est pas qu'une intention, elle est MÉCANIQUE : `collectState()` ne lit que
+// `STATE_FIELDS`, `STATE_CHECKS` et six clés nommées. Une clé à part ne PEUT pas y entrer par
+// accident. Le nom suit les neuf magasins déjà en place (`best-hauling-hold`, `-overrides`…).
+//
+// ── POURQUOI UN BOOLÉEN DANS `etat` ──────────────────────────────────────────────────────────
+// `navigation.ts` doit répondre « l'aide est ouverte » SANS interroger le DOM : après un clic dans
+// le voile le focus retombe sur `<body>`, et `closest('[role="dialog"]')` rendrait alors `null` —
+// les touches 1…8 traverseraient. Même choix que `declarationOuverte` et `ecoulerOuvert`.
+import { etat, notifier } from "./etat.ts";
+
+const CLE = "best-hauling-aide-vue";
+
+/** Le drapeau de visite. `false` en cas de stockage refusé : l'aide se remontre, elle ne plante pas. */
+export function aideDejaVue(): boolean {
+  try { return localStorage.getItem(CLE) === "1"; } catch { return false; }
+}
+
+/** Ouvre l'aide. La restitution du focus, elle, est portée par le composant (voir `vues/aide.tsx`). */
+export function ouvrirAide(): void {
+  if (etat.aideOuverte) return;
+  etat.aideOuverte = true;
+  notifier();
+}
+
+export function fermerAide(): void {
+  if (!etat.aideOuverte) return;
+  etat.aideOuverte = false;
+  // LE DRAPEAU SE POSE ICI, ET PAS À L'OUVERTURE : un onglet fermé pendant que l'aide s'affiche est
+  // une aide NON LUE. Elle doit revenir à la visite suivante.
+  try { localStorage.setItem(CLE, "1"); } catch {}
+  notifier();
+}
+
+/**
+ * L'ouverture de PREMIÈRE VISITE. Appelée une fois par l'amorce.
+ *
+ * `notifier()` et non `rafraichir()` : rien de partagé ne change ici — ni les générations de saisie,
+ * ni le permalien. Un cycle complet réécrirait le hash pour un état identique, et pour rien.
+ */
+export function ouvrirAideSiPremiereVisite(): void {
+  if (!aideDejaVue()) ouvrirAide();
+}

--- a/amorce.ts
+++ b/amorce.ts
@@ -54,6 +54,8 @@ import { loadManifestEdit } from "./manifeste-etat.ts";
 import { brancherGestesManifeste } from "./manifeste-gestes.ts";
 import { brancherPressePapiers } from "./presse-papiers.ts";
 import { brancherGestesVoyage } from "./voyage-gestes.ts";
+import { brancherAide } from "./aide-gestes.ts";
+import { ouvrirAideSiPremiereVisite } from "./aide.ts";
 
 
 import { chargerVaisseaux, montrerCarteVaisseau } from "./selecteur.ts";
@@ -97,6 +99,7 @@ async function init() {
   brancherGestesManifeste();
   brancherGestesSoute();
   brancherGestesVoyage();
+  brancherAide();
 
   loadOverrides();
   loadAutoloadK();
@@ -181,6 +184,16 @@ async function init() {
     $("empty").textContent = "Impossible de charger data/routes.json — lance le script de mise à jour.";
     console.error(e);
   }
+
+  // L'AIDE DE PREMIÈRE VISITE (#62). APRÈS le try/catch, et DEHORS : un premier visiteur dont le
+  // marché n'a pas chargé est le plus démuni de tous, et c'est précisément à lui qu'il faut dire ce
+  // qu'il regarde. Le rail est du markup statique — l'aide sait le lire même quand les données
+  // manquent.
+  //
+  // En DERNIER de l'amorce, et c'est un ordre qui compte : `basculerVue()` ci-dessus appelle
+  // `rafraichir()`, donc `saveState()`. Ouvrir l'aide avant ferait écrire le hash avec une modale
+  // déjà à l'écran — sans conséquence aujourd'hui, mais l'ordre inverse n'a aucun avantage.
+  ouvrirAideSiPremiereVisite();
 }
 
 init();

--- a/e2e/accueil.pw.mjs
+++ b/e2e/accueil.pw.mjs
@@ -1,0 +1,151 @@
+import { test, expect } from "@playwright/test";
+
+// LA PREMIÈRE VISITE (#62). Aucun de ces tests ne peut passer sans l'aide : le dépôt ne portait
+// jusqu'ici AUCUN `role="dialog"`, AUCUN `aria-modal`, AUCUN `<dialog>` — il n'y avait rien à
+// copier, et donc rien qui puisse rendre l'un d'eux vert par accident.
+//
+// ── POURQUOI CE FICHIER SE DÉSAMORCE ──────────────────────────────────────────────────────────
+// `playwright.config.mjs` pose `best-hauling-aide-vue = "1"` dans le `storageState` de TOUTE la
+// suite : sans ça l'aide s'ouvrirait dans les 257 tests, et une quarantaine d'entre eux
+// cliqueraient dans le voile. Ce fichier-ci est le SEUL qui doive voir une première visite, il rend
+// donc son contexte vierge — `origins: []` et non une clé effacée : c'est l'ABSENCE qu'on teste, et
+// c'est elle que voit un vrai premier visiteur.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+const NBSP = / /g;
+const texte = (s) => (s || "").replace(NBSP, " ").trim();
+
+test("Accueil : à la PREMIÈRE visite l'aide s'ouvre seule, et modale (#62)", async ({ page }) => {
+  await page.goto("/index.html");
+  const aide = page.locator("#aide");
+  await expect(aide).toBeVisible();
+  await expect(aide).toHaveAttribute("role", "dialog");
+  await expect(aide).toHaveAttribute("aria-modal", "true");
+  // Le nom accessible vient du TITRE, pas d'un aria-label recopié à côté qui divergerait de lui.
+  await expect(aide).toHaveAccessibleName(/bienvenue/i);
+  // `inert` sur #app : c'est le navigateur qui interdit alors d'atteindre quoi que ce soit derrière
+  // le voile. #racine est un FRÈRE de #app, jamais son enfant — le dialogue reste vivant.
+  await expect(page.locator("#app")).toHaveAttribute("inert", "");
+});
+
+test("Accueil : refermée, elle ne revient plus — et le drapeau est LOCAL (#62)", async ({ page }) => {
+  await page.goto("/index.html");
+  await expect(page.locator("#aide")).toBeVisible();
+  await page.click("#aideFermer");
+  await expect(page.locator("#aide")).toBeHidden();
+  await expect(page.locator("#app")).not.toHaveAttribute("inert", "");
+
+  expect(await page.evaluate(() => localStorage.getItem("best-hauling-aide-vue"))).toBe("1");
+
+  await page.reload();
+  await expect(page.locator("#aide")).toBeHidden();
+});
+
+test("Accueil : le drapeau ne part PAS dans le permalien (#62)", async ({ page }) => {
+  // Un lien partagé ne doit pas décider à la place de son destinataire s'il a « déjà vu » l'aide :
+  // recevoir le lien d'un habitué supprimerait l'aide d'une vraie première visite. Le drapeau vit
+  // donc dans SA clé, jamais dans l'état encodé (persistance.ts).
+  await page.goto("/index.html");
+  await page.click("#aideFermer");
+  await page.click("#viewLoops");
+  await expect(page.locator("#loops")).toBeVisible();
+  expect(await page.evaluate(() => location.hash), "l'état encodé porte le drapeau d'aide")
+    .not.toContain("aide");
+  expect(await page.evaluate(() => localStorage.getItem("best-hauling-state")))
+    .not.toContain("aide");
+});
+
+test("Accueil : l'aide DÉCRIT LE RAIL RÉEL, dérivé de lui (#62)", async ({ page }) => {
+  // « Une aide qui décrit une interface fausse est pire que pas d'aide » : la liste n'est pas écrite
+  // à la main, elle est LUE sur le rail. Deux listes jumelles divergeraient à la neuvième vue, et
+  // rien ne le verrait — c'est très exactement l'argument déjà retenu pour les raccourcis
+  // (navigation.ts : « on le dérive du rail lui-même »).
+  await page.goto("/index.html");
+  const entrees = page.locator("#aide .aide-vues li");
+  await expect(entrees).toHaveCount(8);
+
+  const rail = await page.evaluate(() =>
+    [...document.querySelectorAll(".rail-nav .vbtn")].map((b) => ({
+      rn: b.querySelector(".rn").textContent,
+      rl: b.querySelector(".rl").textContent,
+    })));
+
+  for (let i = 0; i < 8; i++) {
+    const ligne = entrees.nth(i);
+    await expect(ligne.locator(".aide-num"), `entrée ${i + 1} : mauvais numéro`).toHaveText(rail[i].rn);
+    expect(texte(await ligne.locator(".aide-vue").textContent()),
+      `entrée ${i + 1} : le nom ne suit pas le rail`).toBe(texte(rail[i].rl));
+  }
+});
+
+test("Accueil : les raccourcis NE TRAVERSENT PAS le voile (#62)", async ({ page }) => {
+  // LA fuite mesurée : la garde de `navigation.ts` ne couvre que INPUT/SELECT/TEXTAREA/
+  // role="button"/.editv. Le bouton de fermeture de l'aide est un <button> NATIF — comme
+  // #brandHome, mesuré : focus dessus, touche « 3 », la vue bascule sur Boucles. Sans garde de
+  // modalité, refermer l'aide découvrait un autre écran que celui qu'on venait de quitter.
+  await page.goto("/index.html");
+  await expect(page.locator("#aide")).toBeVisible();
+  await expect(page.locator("#viewRoutes")).toHaveClass(/active/);
+
+  await page.keyboard.press("3");
+  await expect(page.locator("#viewRoutes"), "« 3 » a traversé le voile").toHaveClass(/active/);
+  await expect(page.locator("#loops")).toBeHidden();
+
+  await page.keyboard.press("/");
+  expect(await page.evaluate(() => document.activeElement.id),
+    "« / » a donné le focus au champ de recherche DERRIÈRE l'aide").not.toBe("search");
+
+  // Et la garde LÈVE : refermée, les huit raccourcis reprennent leur service.
+  await page.click("#aideFermer");
+  await page.keyboard.press("3");
+  await expect(page.locator("#loops")).toBeVisible();
+});
+
+test("Accueil : le focus est PIÉGÉ dans l'aide, et rendu à la fermeture (#62)", async ({ page }) => {
+  await page.goto("/index.html");
+  await expect(page.locator("#aide")).toBeVisible();
+
+  // À l'ouverture, le focus ENTRE dans le dialogue — sinon un lecteur d'écran reste sur le <body> et
+  // n'annonce rien de ce qui vient de s'afficher.
+  expect(await page.evaluate(() => document.getElementById("aide").contains(document.activeElement)),
+    "le focus n'est pas entré dans l'aide").toBe(true);
+
+  // Le piège : douze tabulations ne sortent jamais du dialogue.
+  for (let i = 0; i < 12; i++) {
+    await page.keyboard.press("Tab");
+    expect(await page.evaluate(() => document.getElementById("aide").contains(document.activeElement)),
+      `le focus a fui du dialogue à la tabulation ${i + 1}`).toBe(true);
+  }
+  await page.keyboard.press("Shift+Tab");
+  expect(await page.evaluate(() => document.getElementById("aide").contains(document.activeElement)),
+    "le focus a fui du dialogue en arrière").toBe(true);
+
+  await page.keyboard.press("Escape");
+  await expect(page.locator("#aide")).toBeHidden();
+});
+
+test("Accueil : le bouton de rejeu rouvre l'aide, et rend le focus À LUI (#62)", async ({ page }) => {
+  await page.goto("/index.html");
+  await page.click("#aideFermer");
+  await expect(page.locator("#aide")).toBeHidden();
+
+  const rejeu = page.locator("#aideRejouer");
+  await expect(rejeu).toBeVisible();
+  await expect(rejeu).toHaveAccessibleName(/aide/i);
+
+  await rejeu.click();
+  await expect(page.locator("#aide")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.locator("#aide")).toBeHidden();
+  expect(await page.evaluate(() => document.activeElement.id),
+    "le focus n'est pas revenu au bouton qui a ouvert l'aide").toBe("aideRejouer");
+});
+
+test("Accueil : le rejeu est FRÈRE de la marque, jamais son enfant (#62)", async ({ page }) => {
+  // Deux éléments interactifs imbriqués sont invalides en ARIA — la règle que le dépôt a appliquée
+  // en sortant .scomm-undo du .editv (#38), et que `plan.pw.mjs` garde déjà sur #brandHome.
+  await page.goto("/index.html");
+  await page.click("#aideFermer");
+  expect(await page.locator("#brandHome button, #brandHome a, #brandHome [role='button']").count()).toBe(0);
+  expect(await page.locator(".brand > #aideRejouer").count(), "le rejeu n'est pas dans .brand").toBe(1);
+});

--- a/etat.ts
+++ b/etat.ts
@@ -82,6 +82,13 @@ export interface Etat {
   venteEnCours: string | null;      // commodité dont le champ « vendu » est ouvert
   ecoulerOuvert: boolean;
   declarationOuverte: boolean;
+  /**
+   * L'aide de démarrage est ouverte (#62). Elle est MODALE, et c'est ce booléen — et non le DOM —
+   * qui le dit : `navigation.ts` doit pouvoir refuser les raccourcis 1…8 même quand le focus est
+   * retombé sur `<body>` (un clic dans le voile suffit), cas où `closest('[role="dialog"]')` rendrait
+   * `null` et laisserait les touches traverser. Même patron que les deux booléens ci-dessus.
+   */
+  aideOuverte: boolean;
 }
 
 // `sortDir` et ses jumeaux sont typés `number` et non `1 | -1` : trois écritures composées
@@ -115,6 +122,7 @@ export const etat: Etat = {
   venteEnCours: null,
   ecoulerOuvert: false,
   declarationOuverte: false,
+  aideOuverte: false,
 };
 
 let version = 0;

--- a/index.html
+++ b/index.html
@@ -55,6 +55,12 @@
             <span class="brand-sub">Flight&nbsp;Ops</span>
           </span>
         </button>
+        <!-- Le rejeu de l'aide (#62), à la place que le commentaire ci-dessus lui réservait : FRÈRE
+             de #brandHome, jamais son enfant. Son écouteur est une délégation posée sur .brand
+             (aide-gestes.ts) — ce markup n'appartient pas à l'arbre React.
+             Masqué quand le rail est rétracté : il n'y reste que 68 px, dont 40 pour le losange. -->
+        <button id="aideRejouer" class="brand-aide" type="button"
+                aria-label="Revoir l'aide de démarrage" title="Revoir l'aide de démarrage">?</button>
       </div>
 
       <button class="rail-toggle" id="railToggle" title="Rétracter / déplier le menu" aria-label="Rétracter le menu" aria-expanded="true">«</button>

--- a/navigation.ts
+++ b/navigation.ts
@@ -103,9 +103,27 @@ export function brancherNavigation() {
   });
   $("brandHome")?.addEventListener("click", () => basculerVue("routes"));
 
-  // Raccourcis clavier : / (recherche), 1 à 8 (vues). Ignorés pendant la saisie.
+  // Raccourcis clavier : / (recherche), 1 à 8 (vues). Ignorés pendant la saisie, et MUETS sous une
+  // modale.
   document.addEventListener("keydown", (e) => {
     if (e.ctrlKey || e.metaKey || e.altKey) return;
+    // ── LA GARDE DE MODALITÉ (#62) ─────────────────────────────────────────────────────────────
+    // L'aide de démarrage est un dialogue modal : rien ne doit agir DERRIÈRE son voile. Sans cette
+    // ligne, taper « 3 » depuis son bouton de fermeture basculait la vue du dessous, et refermer
+    // l'aide découvrait un autre écran que celui qu'on venait de quitter — de même « / » donnait le
+    // focus à un champ invisible et inatteignable à la souris.
+    //
+    // POURQUOI PAS `el.tagName === "BUTTON"`, qui semble être la vraie réparation : c'est MESURÉ, et
+    // ça casse deux tests. `e2e/plan.pw.mjs:47` et `e2e/tournee.pw.mjs:45` cliquent un bouton du rail
+    // PUIS tapent un chiffre — relevé : après `click("#viewRoutes")`, `activeElement` vaut
+    // `BUTTON#viewRoutes` (sans `role`), et « 7 » ouvre bien le Plan de vol. Les boutons du rail SONT
+    // le sélecteur de vue ; un chiffre tapé pendant qu'ils ont le focus est le geste voulu, affirmé
+    // deux fois. Ce qui fuyait n'était donc pas « les <button> natifs » en général, c'était l'absence
+    // de toute notion de modalité — ce dépôt n'en avait jamais eu.
+    //
+    // Et c'est un BOOLÉEN d'état, pas une question posée au DOM : après un clic dans le voile le
+    // focus retombe sur `<body>`, où `closest('[role="dialog"]')` rendrait `null`.
+    if (etat.aideOuverte) return;
     const el = document.activeElement;
     // `role="button"` couvre d'un coup tout ce que l'app rend activable sans être un <button> :
     // l'en-tête d'une jambe, une escale de la carte, une valeur corrigeable. Sans lui, tabuler

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -27,6 +27,26 @@ export default defineConfig({
   use: {
     baseURL: ORIGINE,
     trace: "on-first-retry",
+    // ── L'AIDE DE PREMIÈRE VISITE EST AMORCÉE POUR TOUTE LA SUITE (#62) ───────────────────────
+    // Une modale qui s'ouvre à la première visite s'ouvre dans les 257 tests, pas seulement dans
+    // les siens : Playwright isole le contexte par test, donc chaque test EST une première visite.
+    // Une quarantaine d'entre eux cliqueraient alors dans le voile, et le diagnostic serait
+    // illisible — « element intercepts pointer events » répété partout.
+    //
+    // Ici et pas dans un helper importé par les quinze fichiers : c'est UN endroit contre 44 points
+    // d'appel à `goto()` (16 dans autoload.pw.mjs, 7 dans socle, 6 dans smoke), dont un seul oublié
+    // suffirait à ramener la panne. Et `ORIGINE` est déjà DÉRIVÉ de la copie de travail — la règle
+    // de #70 tient, aucun port n'est réécrit ici.
+    //
+    // `e2e/accueil.pw.mjs` s'en désamorce par `test.use({ storageState: { cookies: [], origins: [] } })` :
+    // c'est le seul fichier qui doive voir une vraie première visite.
+    //
+    // MESURÉ avec cet amorçage : 257 tests, 255 passés, 2 ignorés, 0 échec — le coût sur la suite
+    // existante est nul.
+    storageState: {
+      cookies: [],
+      origins: [{ origin: ORIGINE, localStorage: [{ name: "best-hauling-aide-vue", value: "1" }] }],
+    },
   },
   projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
   // La suite tourne sur `dist/`, c'est-à-dire sur CE QUI EST RÉELLEMENT PRODUIT (ADR-008 §4).

--- a/style.css
+++ b/style.css
@@ -279,6 +279,18 @@ a:hover { color: #ffcf6b; text-decoration: underline; }
 .brand-home:hover .brand-name { color: var(--acc); }
 .rail-collapsed .brand-home { justify-content: center; }
 
+/* Le rejeu de l'aide (#62), frère de la marque. `flex-shrink: 0` n'est pas décoratif : .brand-home
+   porte `width: 100%` et, sans ça, le comprimerait jusqu'à le faire disparaître. */
+.brand-aide {
+  flex-shrink: 0; width: 22px; height: 22px; display: grid; place-items: center;
+  font-family: var(--display); font-size: 12px; line-height: 1; cursor: pointer;
+  color: var(--muted); background: none; border: 1px solid var(--line); border-radius: 50%;
+}
+.brand-aide:hover { color: var(--acc); border-color: var(--line2); }
+/* Rail rétracté : 68 px de large, dont 40 pour le losange. Le « ? » n'y tient pas — il ferait
+   passer la marque à la ligne. Un clic sur « » le ramène avec le reste des libellés. */
+.rail-collapsed .brand-aide { display: none; }
+
 .rail-toggle {
   align-self: flex-end; width: 28px; height: 28px; margin: -6px 0 8px;
   display: grid; place-items: center; cursor: pointer;
@@ -1385,6 +1397,58 @@ input.mqty-input.over-stock { color: var(--warn); border-color: var(--warn); box
 .corr-item.autoload { border-left-color: var(--acc-2); background: rgb(var(--acc-2-rgb) / 0.04); }
 
 /* ---------- Toast ---------- */
+/* ---------- L'aide de démarrage (#62) ---------- */
+/* Le PREMIER dialogue modal du dépôt : il n'y avait ni voile, ni piège de focus, ni palier de
+   z-index de modale à reprendre. `#racine` étant le dernier enfant de <body>, le voile passe
+   au-dessus du rail sans avoir à négocier avec lui — d'où un seul z-index, posé au-dessus du toast
+   (200) pour qu'un message éphémère ne vienne pas se glisser par-dessus l'aide. */
+.aide-voile {
+  position: fixed; inset: 0; z-index: 300;
+  display: grid; place-items: center; padding: 24px;
+  background: rgb(var(--fond-carte-rgb) / 0.82);
+  overflow-y: auto;
+}
+.aide {
+  width: min(680px, 100%); max-height: 100%; overflow-y: auto;
+  padding: 22px 26px 24px;
+  background: var(--panel-solid); border: 1px solid var(--line2); border-left: 3px solid var(--acc);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.7);
+}
+.aide-titre {
+  margin: 0 0 12px; font-family: var(--display); font-size: 14px; letter-spacing: 2px;
+  text-transform: uppercase; color: var(--acc); font-weight: 700;
+}
+.aide-intro, .aide-clavier, .aide-local, .aide-rejeu {
+  margin: 0 0 14px; font-size: 13px; line-height: 1.55; color: var(--text);
+}
+.aide-intro b, .aide-clavier b, .aide-local b, .aide-rejeu b { color: var(--text-fort); }
+.aide-rejeu { color: var(--muted); font-size: 12px; }
+.aide-vues { list-style: none; margin: 0 0 16px; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.aide-vues li {
+  display: grid; grid-template-columns: 24px minmax(92px, auto) 1fr; align-items: baseline;
+  gap: 4px 10px; padding: 6px 9px; font-size: 12.5px;
+  background: rgb(var(--acc-rgb) / 0.04); border-left: 1px solid var(--line);
+}
+.aide-num { font-family: var(--mono); font-size: 11px; color: var(--acc); font-variant-numeric: tabular-nums; }
+.aide-vue { color: var(--text-fort); }
+.aide-quoi { color: var(--muted); }
+.aide kbd {
+  font-family: var(--mono); font-size: 11px; padding: 1px 5px;
+  color: var(--acc); background: rgb(var(--acc-rgb) / 0.10); border: 1px solid var(--line2);
+}
+.aide-ok {
+  font-family: var(--display); font-size: 11px; letter-spacing: 1.5px; text-transform: uppercase;
+  padding: 10px 18px; cursor: pointer; color: var(--acc-fg); background: var(--acc); border: 0;
+}
+.aide-ok:hover { background: var(--warn); }
+/* Le voile masque tout : sur un écran étroit, la carte prend la largeur et se lit d'un pouce. */
+@media (max-width: 620px) {
+  .aide-voile { padding: 0; place-items: stretch; }
+  .aide { width: 100%; max-height: 100%; border-left-width: 0; border-top: 3px solid var(--acc); }
+  .aide-vues li { grid-template-columns: 24px 1fr; }
+  .aide-quoi { grid-column: 2; }
+}
+
 .toast {
   position: fixed; right: 20px; bottom: 20px; z-index: 200; max-width: 320px; padding: 12px 16px;
   font-family: var(--font); font-size: 13px; color: var(--text);

--- a/vues/aide.tsx
+++ b/vues/aide.tsx
@@ -1,0 +1,176 @@
+// L'AIDE DE DÉMARRAGE (#62), et le PREMIER dialogue modal du dépôt.
+//
+// Il n'y avait RIEN à copier, et c'est vérifié : `role="dialog"`, `aria-modal` et `<dialog>` ont zéro
+// occurrence dans tout le dépôt. `#holdDeclare` est un `<aside hidden>` avec un simple Échap
+// (`soute-gestes.ts`) — sans voile, sans piège de focus, sans restitution. Tout ce qui suit est
+// écrit, pas transposé.
+//
+// ── POURQUOI PAS DE PORTAIL ───────────────────────────────────────────────────────────────────
+// Les onze autres vues rendent DANS un conteneur d'`index.html` par `createPortal`, parce que leur
+// markup existait avant elles. Celle-ci est neuve et n'a pas de conteneur : elle se pose en voile
+// sur toute la page. Elle rend donc dans `#racine` lui-même — le nœud vide de la racine unique,
+// DERNIER enfant de <body> — ce qui la place au-dessus du rail sans un z-index à négocier.
+//
+// ── POURQUOI `onClick` EST LÉGITIME ICI, ET SEULEMENT ICI ─────────────────────────────────────
+// L'ADR-012 §2 interdit de convertir en `onClick` une délégation posée sur un conteneur
+// d'`index.html` : le portail rend dedans sans le posséder, l'écouteur traverse déjà, et le
+// convertir doublerait les gestes non idempotents. Ce markup-ci n'existe QUE dans l'arbre, React le
+// possède entièrement, et personne n'a posé de délégation dessus. Le bouton de REJEU, lui, vit dans
+// `.brand` (index.html) : il reste une délégation, dans `aide-gestes.ts`.
+//
+// ── L'AIDE EST DÉRIVÉE DU RAIL, JAMAIS RECOPIÉE ───────────────────────────────────────────────
+// « Une aide qui décrit une interface fausse est pire que pas d'aide. » Une liste écrite à la main
+// serait une SECONDE table jumelle du rail, à tenir d'accord avec lui — exactement ce que
+// `navigation.ts` a refusé pour les raccourcis (« on le dérive du rail lui-même, pour qu'aucune des
+// deux listes ne puisse se désynchroniser de l'autre »). Les huit entrées sont donc LUES sur
+// `.rail-nav .vbtn` : une neuvième vue apparaît ici sans que personne n'y pense, et aucune
+// renumérotation ne peut rendre cette page menteuse.
+import { useEffect, useRef } from "react";
+
+import { etat } from "../etat.ts";
+import { fermerAide } from "../aide.ts";
+
+/** Ce qui peut recevoir le focus dans le dialogue. */
+const FOCUSABLES = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+/** Le « (raccourci : 3) » que porte chaque `title` du rail : la colonne du numéro le redit déjà. */
+const SANS_RACCOURCI = /\s*\(raccourci\s*:[^)]*\)\s*$/;
+
+type EntreeRail = { vue: string; num: string; nom: string; quoi: string };
+
+/**
+ * Les huit vues, LUES sur le rail.
+ *
+ * L'ORDRE DES DEUX COUPES EST UN CONTRAT : on retire d'abord « (raccourci : N) », on coupe ensuite
+ * sur le premier « : ». L'inverse laisserait « 8) » comme description de Corrections, dont le titre
+ * ne porte pas d'autre deux-points. La coupe sert les quatre libellés qui s'expliquent eux-mêmes
+ * (« Commodités : tous les points d'achat/vente ») ; les autres passent entiers.
+ *
+ * `#viewCorrections` voit son libellé réécrit par `updateOvBadge` (« Corrections (3) ») : c'est bien
+ * ce qu'on veut afficher — l'aide dit ce que l'écran dit, compteur compris.
+ */
+function lireLeRail(): EntreeRail[] {
+  return [...document.querySelectorAll<HTMLElement>(".rail-nav .vbtn")].map((b) => {
+    const titre = (b.getAttribute("title") || "").replace(SANS_RACCOURCI, "").trim();
+    const coupe = titre.indexOf(" : ");
+    return {
+      vue: b.dataset.view || "",
+      num: b.querySelector(".rn")?.textContent || "",
+      nom: b.querySelector(".rl")?.textContent || "",
+      quoi: coupe > 0 ? titre.slice(coupe + 3) : titre,
+    };
+  });
+}
+
+function Dialogue() {
+  const boite = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // QUI a ouvert l'aide : c'est à lui que le focus reviendra. Lu au MONTAGE, donc après le clic.
+    const rendreA = document.activeElement as HTMLElement | null;
+    const dlg = boite.current;
+
+    // Le focus ENTRE dans le dialogue : sans ça un lecteur d'écran reste sur le <body> et n'annonce
+    // rien de ce qui vient de s'afficher.
+    dlg?.querySelector<HTMLElement>(FOCUSABLES)?.focus();
+
+    // LE PIÈGE, MOITIÉ 1 — `inert` sur `#app`. C'est le navigateur lui-même qui refuse alors de
+    // focaliser quoi que ce soit derrière le voile, et l'AT cesse de le lire. `#racine` est un FRÈRE
+    // de `#app` dans index.html, jamais son enfant : le dialogue n'est donc pas atteint.
+    const app = document.getElementById("app");
+    app?.setAttribute("inert", "");
+
+    // LE PIÈGE, MOITIÉ 2 — le bouclage manuel, pour les moteurs sans `inert`. Sans lui, la
+    // tabulation part visiter le rail et les filtres SOUS le voile, qu'aucun clic ne peut atteindre :
+    // le clavier et la souris ne verraient plus la même page.
+    const surTouche = (e: KeyboardEvent) => {
+      if (e.key === "Escape") { e.preventDefault(); fermerAide(); return; }
+      if (e.key !== "Tab" || !dlg) return;
+      const cibles = [...dlg.querySelectorAll<HTMLElement>(FOCUSABLES)];
+      if (!cibles.length) return;
+      const premier = cibles[0], dernier = cibles[cibles.length - 1];
+      // On ne boucle QU'AUX DEUX BOUTS : entre les deux, laisser faire le navigateur garde l'ordre
+      // naturel. Le troisième cas rattrape un focus déjà sorti (clic dans le voile).
+      if (!dlg.contains(document.activeElement)) { e.preventDefault(); premier.focus(); }
+      else if (!e.shiftKey && document.activeElement === dernier) { e.preventDefault(); premier.focus(); }
+      else if (e.shiftKey && document.activeElement === premier) { e.preventDefault(); dernier.focus(); }
+    };
+    // En CAPTURE : on passe avant les deux `document` keydown déjà posés (navigation, voyage), sans
+    // dépendre de leur ordre de branchement dans l'amorce.
+    document.addEventListener("keydown", surTouche, true);
+
+    return () => {
+      document.removeEventListener("keydown", surTouche, true);
+      app?.removeAttribute("inert");
+      // LA RESTITUTION vit ICI et pas dans `fermerAide()` : React démonte le dialogue APRÈS avoir
+      // rendu, et poser le focus avant le démontage le rendrait au <body> en disparaissant.
+      // Ouverte seule (première visite), personne n'avait le focus — il part alors sur le bouton de
+      // rejeu, ce qui montre au passage où retrouver l'aide.
+      const cible = (rendreA && rendreA !== document.body ? rendreA : null)
+        || document.getElementById("aideRejouer");
+      cible?.focus();
+    };
+  }, []);
+
+  const vues = lireLeRail();
+
+  return (
+    <div
+      className="aide-voile"
+      // `mousedown` et non `click` : une sélection de texte commencée DANS le dialogue et relâchée
+      // sur le voile émettrait un `click` dont la cible est le voile, et refermerait l'aide sous les
+      // doigts. La garde `target === currentTarget` évite en plus de fermer sur le dialogue lui-même.
+      onMouseDown={(e) => { if (e.target === e.currentTarget) fermerAide(); }}
+    >
+      <div className="aide" id="aide" role="dialog" aria-modal="true" aria-labelledby="aideTitre" ref={boite}>
+        <h2 className="aide-titre" id="aideTitre">Bienvenue à bord</h2>
+
+        <p className="aide-intro">
+          Cet écran classe les routes de fret de <b>Star&nbsp;Citizen</b> à partir des relevés
+          publiés par <b>UEX</b>, rafraîchis toutes les heures. Dis ce que tu pilotes et ce que tu
+          peux avancer — <b>vaisseau</b>, <b>soute</b>, <b>budget</b>, en haut de l'écran — puis
+          choisis la question que tu te poses&nbsp;:
+        </p>
+
+        <ol className="aide-vues">
+          {vues.map((v) => (
+            <li key={v.vue}>
+              <b className="aide-num">{v.num}</b>
+              <b className="aide-vue">{v.nom}</b>
+              <span className="aide-quoi">{v.quoi}</span>
+            </li>
+          ))}
+        </ol>
+
+        <p className="aide-clavier">
+          <b>Au clavier</b> — les touches <kbd>1</kbd> à <kbd>8</kbd> ouvrent ces huit vues dans
+          l'ordre ci-dessus, et <kbd>/</kbd> saute au champ <b>Commodité</b>. Tout ce qui s'active au
+          clic s'active aussi à <kbd>Entrée</kbd>.
+        </p>
+
+        <p className="aide-local">
+          <b>Tout reste chez toi</b> — soute, corrections de prix et réglages vivent dans ce
+          navigateur, jamais sur un serveur. Le bouton <b>⟐ Partager</b> fabrique un lien qui porte
+          tes filtres, et rien d'autre. Une correction que tu saisis est locale et périme d'elle-même
+          dès qu'UEX publie un relevé plus récent.
+        </p>
+
+        <p className="aide-rejeu">Ce panneau se rouvre par le <b>?</b> posé à côté du logo.</p>
+
+        <button id="aideFermer" className="aide-ok" type="button" onClick={fermerAide}>
+          Compris — au travail
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * La garde est EN TÊTE, au-dessus de toute lecture du DOM : fermée, l'aide ne parcourt même pas le
+ * rail. Et le dialogue est un composant SÉPARÉ pour que son montage soit exactement l'ouverture —
+ * c'est ce qui fait du nettoyage de son effet le bon endroit où rendre le focus.
+ */
+export function Aide() {
+  if (!etat.aideOuverte) return null;
+  return <Dialogue />;
+}


### PR DESCRIPTION
À la première visite, l'application s'ouvrait sur huit vues, un rail numéroté et une barre de
filtres, sans une ligne pour dire ce qu'on regarde ni comment s'en servir. Et rien ne permettait de
rejouer l'explication ensuite.

## Cause racine

Ce n'est pas un oubli d'écriture, c'est une absence d'INFRASTRUCTURE. Vérifié par grep sur tout le
dépôt : zéro `role="dialog"`, zéro `aria-modal`, zéro `<dialog>`. `#holdDeclare` n'est qu'un
`<aside hidden>` avec un `Escape` — sans voile, sans piège de focus, sans restitution. Il n'y avait
rien à copier.

Second défaut, trouvé en chemin : **le raccourci clavier fuyait déjà**. `navigation.ts` ne gardait
que INPUT/SELECT/TEXTAREA/`role="button"`/`.editv` — or taper 1 à 8 par-dessus n'importe quel
`<button>` natif changeait de vue. Une modale par-dessus laquelle les raccourcis passent n'est pas
une modale.

## L'ordre d'application, et pourquoi il compte

1. **la garde de modalité d'abord.** Posée après la modale, son test serait vert par accident ;
2. **l'amorçage `storageState` ENSUITE, avant toute ligne de vue.** C'est le point que le plan
   initial sous-estimait d'un ordre de grandeur : une aide qui s'ouvre à la première visite s'ouvre
   dans **les 257 tests**, pas dans les siens. `playwright.config.mjs` amorce donc le drapeau pour
   toute la suite, et `e2e/accueil.pw.mjs` s'en désamorce explicitement ;
3. **le fichier de tests, ROUGE**, avant le code : 8 échecs lus, pas un « 0 passed » silencieux —
   Playwright 1.61 sort d'ailleurs en code 1 sur un chemin qui ne matche rien, vérifié ;
4. puis le drapeau, la modale, le bouton, le câblage.

## Ce que l'aide dit, et comment elle évite de mentir

La liste des vues est **DÉRIVÉE du rail réel**, pas recopiée : une aide qui décrit une interface
fausse est pire que pas d'aide, et c'est le risque qu'un texte figé prend à chaque nouvelle vue.

Le drapeau vit dans `localStorage` et **ne part pas dans le permalien** — un lien partagé ne doit pas
décider si son destinataire a déjà vu l'aide. Un test l'épingle.

Le focus est **piégé** dans la modale et **rendu** à sa cible d'ouverture : au bouton `?` quand c'est
lui qui a ouvert, au document à la première visite.

## Vérification

```
node --test          → tests 497 (496 avant) | pass 497 | fail 0
npx playwright test  → 267 tests (258 avant) | 265 passed | 2 skipped | 0 failed (1,6 min)
npx tsc --noEmit     → aucune sortie
npm run build:site   → ✓ built | précache 20 entrées
```

Les 8 tests d'accueil sont passés du rouge au vert, et **les 257 autres n'ont pas bougé** — c'est ce
que l'amorçage `storageState` achète, et c'était la vraie difficulté de ce lot.

## Ce qui n'est pas couvert

- **L'aide ne se rouvre pas après une mise à jour** : le drapeau est booléen, pas versionné. Un
  utilisateur de longue date ne verra jamais l'aide d'une vue ajoutée après lui.
- **Aucune visite guidée pas à pas**, aucun surlignage : c'est un panneau qu'on lit et qu'on referme.
- **Le lien entre l'aide et les données n'est pas testé** : rien ne vérifie que « rafraîchis toutes
  les heures » corresponde encore à la cadence de `update-data.yml`. Seule la liste des VUES est
  dérivée, donc seule elle ne peut pas mentir.
- `#viewEnroute` a pour `title` « En route (raccourci : 2) » : privé de son suffixe il répète son
  propre libellé, et l'aide affiche donc un nom et une description identiques sur cette seule ligne.

Closes #62
🤖 Generated with [Claude Code](https://claude.com/claude-code)