### PR TITLE
fix(ci): la version passe à 2.0.0 — le site en ligne annonçait encore la v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "best-hauling",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Site statique des meilleures routes d'arbitrage de commodités Star Citizen (données UEX Corp).",
   "license": "MIT",
   "author": "0xKestrelNova",

--- a/scripts/version.test.mjs
+++ b/scripts/version.test.mjs
@@ -28,6 +28,22 @@ test("le nom du cache de sw.js suit la version — le bump manuel n'est plus oub
     "bump de version sans bump du cache : les visiteurs installés garderaient l'ancien index.html");
 });
 
+test("l'amorce de data/ ne porte jamais une version PÉRIMÉE", () => {
+  // L'instantané versionné dans `data/` est régénéré par `chore(data)`, à la main, quand ça arrange.
+  // S'il porte une estampille, elle doit être CELLE DE MAINTENANT — sinon le rail annonce en
+  // développement une version qui n'est plus, et un rapport de bug parti de là désigne le mauvais
+  // code. C'est exactement ce qui vient d'arriver en production : `package.json` était resté à
+  // 1.1.0 pendant que le déployé était la v2, et le rail affichait « v1.1.0 · b555614 » — un
+  // numéro de v1 sur un commit de v2.
+  //
+  // Sans estampille, RIEN à vérifier : une amorce n'est pas un déploiement, et le rail préfère
+  // alors se taire (`.rail-version:empty { display: none }`) plutôt qu'annoncer un « v— ».
+  const meta = JSON.parse(lire("data", "meta.json"));
+  if (meta.app_version == null) return;
+  assert.equal(meta.app_version, VERSION,
+    "l'amorce de data/meta.json annonce une version que package.json ne porte plus");
+});
+
 test("le build estampille meta.json avec la version et le commit", () => {
   // Lecture de source : `build-data.mjs` fait des appels réseau, on ne le rejoue pas ici. Ce qu'on
   // vérifie est qu'il tire sa version de la source unique au lieu d'en écrire une seconde.

--- a/sw.js
+++ b/sw.js
@@ -5,7 +5,7 @@
 // recevrait encore l'ANCIEN index.html — sans CSP et avec son <script> inline — pendant toute une
 // visite, tandis que rail.js, lui, serait déjà là. `activate` purge tout cache au nom différent :
 // le bump garantit que la nouvelle page et son script arrivent ENSEMBLE.
-const CACHE = "best-hauling-v1.1.0";
+const CACHE = "best-hauling-v2.0.0";
 // Coquille précachée. Cette liste est un DÉFAUT DE REPLI : en production, le build la remplace par
 // ce qu'il a réellement émis, noms hachés compris (vite.config.mjs, plugin best-hauling:precache).
 // `logic.mjs` n'y figure plus depuis qu'il est devenu `logic.ts` (ADR-008 §5) — un fichier


### PR DESCRIPTION
Le site déployé porte la v2 depuis la bascule (#172), et son rail annonçait **`v1.1.0 · b555614`** :
un numéro de v1 sur un commit de v2. Un rapport de bug rattaché à « v1.1.0 » désignait la mauvaise
application.

## Ce que j'avais écrit de faux, et la mesure qui l'a corrigé

L'issue #177 disait « le rail n'affiche **rien** ». C'est faux, et la correction est dans l'issue.

```
GET https://0xkestrelnova.github.io/best-hauling/data/meta.json
→ { "app_version": "1.1.0", "commit": "b555614", "generated_at": 1786651393 }
```

La chaîne fonctionnait de bout en bout — `build-data.mjs` estampille, le déploiement l'a fait à
18:03, `amorce.ts` l'affiche. Le défaut était plus étroit : **le numéro**, pas son absence.

## Le correctif

`package.json` → `2.0.0`, et le `CACHE` de `sw.js` suit. Le test existant a fait exactement ce pour
quoi il a été écrit :

```
✖ le nom du cache de sw.js suit la version — le bump manuel n'est plus oubliable
```

Le changement de nom de cache **purge les caches v1** des visiteurs déjà installés, et c'est un effet
souhaitable ici : `sw.js` sert la coquille en « stale-while-revalidate », donc sans lui un visiteur
de la v1 continuerait de recevoir l'ancien `index.html` pendant toute une visite, avec des scripts v2
à côté.

## Le garde qui manquait

Rien ne reliait `package.json` à l'amorce versionnée dans `data/`. Un `chore(data)` régénéré à une
version, puis committé après un bump, aurait annoncé en développement une version qui n'est plus.

`version.test.mjs` gagne donc : **si** `data/meta.json` porte une estampille, elle doit être celle de
`package.json`. Sans estampille, rien à vérifier — une amorce n'est pas un déploiement, et le rail
préfère se taire plutôt qu'annoncer un « v— ».

Vu ROUGE en posant `app_version: "1.1.0"` dans l'amorce, puis restauré à l'identique
(`git diff --numstat` vide).

## Vérification

```
node --test          → tests 498 (497 avant) | pass 498 | fail 0
npx playwright test  → 267 tests | 265 passed | 2 skipped | 0 failed (1,7 min)
npx tsc --noEmit     → aucune sortie
npm run build:site   → ✓ built | précache 20 entrées
```

## Ce qui n'est pas couvert

- **L'affichage réel ne sera vérifiable qu'après le prochain déploiement.** C'est la CI qui pose
  l'estampille ; en local le rail reste muet, faute d'amorce estampillée.
- **L'amorce de `data/` reste sans estampille**, et c'est le choix retenu : une amorce n'est pas un
  déploiement, elle n'a pas de version à annoncer. Le nouveau garde n'impose rien — il vérifie
  seulement qu'elle ne MENT pas si elle en porte une.
- `e2e/smoke.pw.mjs` **injecte** toujours son `meta.json` : il vérifie l'affichage, jamais qu'une
  estampille arrive vraiment. Aucun test ne traverse le build réel.

Closes #177
🤖 Generated with [Claude Code](https://claude.com/claude-code)